### PR TITLE
Revamp OmaPilot waiting and streaming motion

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -209,7 +209,13 @@ Panel {
 
     Behavior on contentHeight {
       enabled: root.motionEnabled
-      NumberAnimation { duration: 180; easing.type: Easing.OutCubic }
+      // Streaming repeatedly retargets the natural height. SmoothedAnimation
+      // follows that moving target without restarting a fixed timeline for
+      // every wrapped line.
+      SmoothedAnimation {
+        velocity: Style.spaceReal(900)
+        maximumEasingTime: 120
+      }
     }
 
     Item {
@@ -307,10 +313,12 @@ Panel {
 
                 Text {
                   id: responseState
+                  readonly property bool phaseVisible: text !== "" && !root.responseActivityActive
                   anchors.right: parent.right
                   anchors.verticalCenter: parent.verticalCenter
                   text: root.responsePhase.label
-                  visible: text !== "" && !root.responseActivityActive
+                  visible: phaseVisible || opacity > 0
+                  opacity: phaseVisible ? 1 : 0
                   color: root.responsePhase.tone === "urgent" ? Color.urgent
                     : (root.responsePhase.tone === "muted" ? Color.muted : root.accent)
                   font.family: root.fontFamily
@@ -320,19 +328,9 @@ Panel {
                   Accessible.role: Accessible.StaticText
                   Accessible.name: text
 
-                  onTextChanged: {
-                    responseStateReveal.stop()
-                    opacity = root.motionEnabled ? 0.45 : 1
-                    if (root.motionEnabled) responseStateReveal.restart()
-                  }
-
-                  NumberAnimation {
-                    id: responseStateReveal
-                    target: responseState
-                    property: "opacity"
-                    to: 1
-                    duration: 150
-                    easing.type: Easing.OutCubic
+                  Behavior on opacity {
+                    enabled: root.motionEnabled
+                    NumberAnimation { duration: 140; easing.type: Easing.OutCubic }
                   }
                 }
               }
@@ -455,8 +453,19 @@ Panel {
                 boundsBehavior: Flickable.StopAtBounds
                 interactive: contentHeight > height
                 property bool followLatest: true
+                property bool followMotionEnabled: true
                 readonly property real bottomThreshold: Style.space(56)
                 readonly property bool latestAvailable: contentHeight > height && !followLatest
+
+                Behavior on contentY {
+                  enabled: root.motionEnabled && answerScroll.followLatest
+                    && answerScroll.followMotionEnabled
+                    && !answerScroll.dragging && !answerScroll.flicking
+                  SmoothedAnimation {
+                    velocity: Style.spaceReal(820)
+                    maximumEasingTime: 110
+                  }
+                }
 
                 function maximumContentY() {
                   return Math.max(0, contentHeight - height)
@@ -469,12 +478,16 @@ Panel {
 
                 function resetForNewTurn() {
                   followLatest = true
+                  followMotionEnabled = false
                   contentY = 0
+                  Qt.callLater(function() { answerScroll.followMotionEnabled = true })
                 }
 
                 function showFromStart() {
                   followLatest = false
+                  followMotionEnabled = false
                   contentY = 0
+                  Qt.callLater(function() { answerScroll.followMotionEnabled = true })
                 }
 
                 function followContentIfNeeded() {
@@ -486,7 +499,7 @@ Panel {
 
                 onContentHeightChanged: followContentIfNeeded()
                 onHeightChanged: followContentIfNeeded()
-                onContentYChanged: if (moving)
+                onContentYChanged: if (dragging || flicking)
                   followLatest = Presentation.isNearBottom(contentY, contentHeight, height, bottomThreshold)
                 onMovementEnded: followLatest = Presentation.isNearBottom(
                   contentY, contentHeight, height, bottomThreshold)
@@ -537,6 +550,7 @@ Panel {
                     onVisibleChanged: {
                       firstTokenReveal.stop()
                       opacity = visible && root.motionEnabled ? 0 : 1
+                      answerRevealTranslate.y = visible && root.motionEnabled ? Style.spacing.sm : 0
                       if (visible && root.motionEnabled) firstTokenReveal.restart()
                     }
                     onLinkActivated: function(url) { Quickchat.QuickchatStore.activateLink(url) }
@@ -547,13 +561,26 @@ Panel {
                     }
                     onCopyRequested: function(text) { Quickchat.QuickchatStore.copyText(text) }
 
-                    NumberAnimation {
+                    transform: Translate {
+                      id: answerRevealTranslate
+                    }
+
+                    ParallelAnimation {
                       id: firstTokenReveal
-                      target: markdownAnswer
-                      property: "opacity"
-                      to: 1
-                      duration: 180
-                      easing.type: Easing.OutCubic
+                      NumberAnimation {
+                        target: markdownAnswer
+                        property: "opacity"
+                        to: 1
+                        duration: 160
+                        easing.type: Easing.OutCubic
+                      }
+                      NumberAnimation {
+                        target: answerRevealTranslate
+                        property: "y"
+                        to: 0
+                        duration: 180
+                        easing.type: Easing.OutCubic
+                      }
                     }
                   }
                 }

--- a/Panel.qml
+++ b/Panel.qml
@@ -550,7 +550,6 @@ Panel {
                     onVisibleChanged: {
                       firstTokenReveal.stop()
                       opacity = visible && root.motionEnabled ? 0 : 1
-                      answerRevealTranslate.y = visible && root.motionEnabled ? Style.spacing.sm : 0
                       if (visible && root.motionEnabled) firstTokenReveal.restart()
                     }
                     onLinkActivated: function(url) { Quickchat.QuickchatStore.activateLink(url) }
@@ -561,26 +560,13 @@ Panel {
                     }
                     onCopyRequested: function(text) { Quickchat.QuickchatStore.copyText(text) }
 
-                    transform: Translate {
-                      id: answerRevealTranslate
-                    }
-
-                    ParallelAnimation {
+                    NumberAnimation {
                       id: firstTokenReveal
-                      NumberAnimation {
-                        target: markdownAnswer
-                        property: "opacity"
-                        to: 1
-                        duration: 160
-                        easing.type: Easing.OutCubic
-                      }
-                      NumberAnimation {
-                        target: answerRevealTranslate
-                        property: "y"
-                        to: 0
-                        duration: 180
-                        easing.type: Easing.OutCubic
-                      }
+                      target: markdownAnswer
+                      property: "opacity"
+                      to: 1
+                      duration: 160
+                      easing.type: Easing.OutCubic
                     }
                   }
                 }

--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ The compact composer expands from the right side of the bar. Its result panel
 supports selectable Markdown, code blocks, tables, safe clickable links,
 bounded images, Copy, New chat, History, and Continue in Herdr. The in-panel
 settings pane can add, edit, remove, and reorder up to five quick actions.
-Waiting uses a finite route reveal, streamed content drives its own activity
-pulse, and a compact error notice opens an inspectable details pane.
+Waiting uses a restrained fixed-route energy wave with a long resting cadence;
+real streamed content drives coalesced follow-up waves without moving-marker
+resets. Phase copy, first-token content, panel growth, and follow-latest scrolling
+transition smoothly, while a compact error notice opens an inspectable details
+pane.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ The compact composer expands from the right side of the bar. Its result panel
 supports selectable Markdown, code blocks, tables, safe clickable links,
 bounded images, Copy, New chat, History, and Continue in Herdr. The in-panel
 settings pane can add, edit, remove, and reorder up to five quick actions.
-Waiting uses a restrained fixed-route energy wave with a long resting cadence;
-real streamed content drives coalesced follow-up waves without moving-marker
-resets. Phase copy, first-token content, panel growth, and follow-latest scrolling
-transition smoothly, while a compact error notice opens an inspectable details
-pane.
+Waiting uses a restrained telemetry beam driven by the compositor frame clock.
+It fades fully at the edge of a fixed route before wrapping, while streaming
+gently increases its velocity without reacting to bursty token timing. Phase
+copy, first-token content, panel growth, and follow-latest scrolling transition
+smoothly, while a compact error notice opens an inspectable details pane.
 
 ## Requirements
 

--- a/TODO.md
+++ b/TODO.md
@@ -929,7 +929,7 @@ turn per provider.
   - [x] Pass QML lint/UI contracts, headless motion and visual renders, full
     repository validation, deterministic build/package checks, and Git
     whitespace checks.
-  - [ ] Commit and push the branch, open a draft PR to main, and leave installed
+  - [x] Commit and push the branch at `fc398cf`, open draft PR 5 to main, and leave installed
     and live shell state unchanged for owner validation.
 - Current checkpoint: the presentation-only implementation is complete. The
   fixed route now transfers node energy with identical resting endpoints;
@@ -944,5 +944,5 @@ turn per provider.
   whitespace. Shellcheck remains unavailable. `npm ci` also reports unchanged
   development-server advisories in direct esbuild (low) and Vitest (critical)
   dependencies; this presentation-only diff neither invokes their servers nor
-  changes the lockfile. Commit and PR publication remain; installed and live
-  shell state are unchanged.
+  changes the lockfile. Draft PR 5 is open against main from
+  `omapilot-motion-revamp`; installed and live shell state are unchanged.

--- a/TODO.md
+++ b/TODO.md
@@ -980,9 +980,11 @@ turn per provider.
     reduced-motion regressions plus temporal renders.
   - [x] Pass focused QML/UI checks, full validation, deterministic package,
     `git diff --check`, and orchestrator diff review.
-  - [ ] Commit/push the corrected PR head and pass exact-head CI.
-  - [ ] Install that exact head, preserve center placement/settings, and verify
-    shell/broker health without a restart unless required.
+  - [x] Commit/push the corrected PR head and pass exact-head CI. Commit
+    `7c67157` passed both `validate` and deterministic `package` jobs in Actions
+    run `32041050737`; the draft PR remains open and mergeable.
+  - [x] Install that reviewed code head, preserve center placement/settings,
+    and verify shell/broker health without a restart unless required.
   - [ ] Owner confirms the live motion now meets the interaction-quality bar.
 - Current checkpoint: source gates are complete. The real-component probe and
   fourteen-frame renderer pass with uniform waiting phase deltas and a smooth
@@ -990,5 +992,12 @@ turn per provider.
   permission-focus, eight presentation, and seven quick-action checks; full
   validation passes 136 runtime tests with 12 opt-in live skips; three broker
   hashes are identical; package dry-run and Git whitespace checks pass. The
-  installed plugin remains the rejected `93cd8f5` build until this corrected
-  branch is committed, pushed, and passes exact-head CI.
+  corrected code is committed at `7c67157`, pushed to draft PR 5, and green in
+  exact-code-head CI. That commit is installed from its clean public Git
+  checkout at center index 4; plugin validation, shell IPC, and the existing
+  broker are healthy, and the hot-reload log contains no OmaPilot-specific
+  error. No restart occurred. The panel opened and dismissed through its real
+  IPC path, but the computer-use keyboard backend could not submit a harmless
+  prompt because this session's desktop portal does not expose `RemoteDesktop`;
+  it failed before replaying input. Owner waiting/streaming confirmation is
+  therefore still the only open quality gate.

--- a/TODO.md
+++ b/TODO.md
@@ -946,3 +946,49 @@ turn per provider.
   dependencies; this presentation-only diff neither invokes their servers nor
   changes the lockfile. Draft PR 5 is open against main from
   `omapilot-motion-revamp`; installed and live shell state are unchanged.
+
+## OmaPilot frame-clock motion correction checkpoint 10 (2026-08-17)
+
+- Goal: replace the still-rough installed waiting/streaming pulse with a truly
+  continuous, understated OmaPilot signal whose motion is independent of token
+  burst timing and whose first-token transition moves no response geometry.
+- Owner evidence: live testing of installed PR 5 at exact commit `93cd8f5`
+  rejected checkpoint 9. The real-component capture advanced through phase
+  samples `0.013`, `0.102`, `0.346`, `0.723`, and `0.927` at equal 110 ms
+  intervals, confirming that the cubic timeline visibly accelerated through
+  the middle; queued streaming pulses could then run back-to-back.
+- Done criteria: use the Qt frame clock with capped delayed-frame deltas and
+  constant phase velocity; wait-to-stream eases speed without resetting phase;
+  token revisions do not restart or retime motion; wrap occurs at identical
+  resting geometry; first-token content uses opacity only; inactive and
+  reduced-motion states stop and settle; focused QML/render/repository checks,
+  PR-head CI, installed validation, shell health, and an owner visual gate pass.
+- Branch/worktree: `omapilot-motion-revamp` at
+  `/home/sbull/worktrees/omarchy-omapilot-motion-revamp`; update draft PR 5.
+- Allowed: presentation-only QML, focused motion tests/renders, documentation,
+  commits and push to the existing PR, exact reviewed local plugin update, and
+  bounded live interaction/capture for this motion flow.
+- Forbidden: broker/provider/policy/permission/protocol changes, stable ID or
+  persistence migration, edits to another worktree, release, merge, unrelated
+  desktop configuration, shell restart without a demonstrated need and clear
+  lock guard, or device-changing prompt execution.
+- Verification gates:
+  - [x] Record the failed owner gate and measure the previous non-uniform phase.
+  - [x] Replace restartable eased pulses with one frame-clock signal and remove
+    first-token translation.
+  - [x] Add continuity, frame-delta cap, phase-handoff, token-independence, and
+    reduced-motion regressions plus temporal renders.
+  - [x] Pass focused QML/UI checks, full validation, deterministic package,
+    `git diff --check`, and orchestrator diff review.
+  - [ ] Commit/push the corrected PR head and pass exact-head CI.
+  - [ ] Install that exact head, preserve center placement/settings, and verify
+    shell/broker health without a restart unless required.
+  - [ ] Owner confirms the live motion now meets the interaction-quality bar.
+- Current checkpoint: source gates are complete. The real-component probe and
+  fourteen-frame renderer pass with uniform waiting phase deltas and a smooth
+  speed handoff; the focused UI contract passes 23 protocol/context, three
+  permission-focus, eight presentation, and seven quick-action checks; full
+  validation passes 136 runtime tests with 12 opt-in live skips; three broker
+  hashes are identical; package dry-run and Git whitespace checks pass. The
+  installed plugin remains the rejected `93cd8f5` build until this corrected
+  branch is committed, pushed, and passes exact-head CI.

--- a/TODO.md
+++ b/TODO.md
@@ -894,3 +894,55 @@ turn per provider.
   release package dry-run succeeds. Draft PR 4 is the single open consolidated
   review surface and provider-only PR 3 is closed as superseded. Owner-run live
   interaction remains the next gate; no live desktop state was changed here.
+
+## OmaPilot motion-quality revamp checkpoint 9 (2026-08-17)
+
+- Goal: replace the rough waiting/streaming motion with a calm, native Quattro
+  activity language that stays smooth under bursty token delivery and makes
+  each response phase legible without fake progress or layout jitter.
+- Done criteria: no moving marker teleports or repeated animation restarts;
+  waiting remains visibly alive with restrained cadence; first-token and
+  streaming feedback transition without snapping; bursty chunks coalesce;
+  completion/cancellation/error crossfade cleanly in the stable status slot;
+  panel growth and follow-latest scrolling tolerate continuously changing
+  targets; reduced motion settles immediately; focused state-machine, render,
+  and repository gates pass; the branch is pushed and a draft PR targets main.
+- Branch/worktree: `omapilot-motion-revamp` at
+  `/home/sbull/worktrees/omarchy-omapilot-motion-revamp`, based on merged
+  `origin/main` commit `da25c94`.
+- Allowed: presentation-only QML motion and layout ownership, focused QML test
+  harnesses, ignored headless render evidence, design documentation, this
+  ledger, dependency installation inside this worktree, commit/push, and a
+  draft pull request.
+- Forbidden: installed-plugin changes, shell restart or live desktop control,
+  edits to any other worktree, broker/provider/policy/permission/protocol
+  changes, stable ID or persistence migrations, releases, and merging to main.
+- Verification gates:
+  - [x] Inventory current animation ownership, Quickshell 0.3.0, and active
+    Quattro timing/easing conventions.
+  - [x] Capture baseline waiting/streaming renders and identify the concrete
+    sources of discontinuity.
+  - [x] Implement a cohesive activity/status/first-token/follow-motion pass
+    with no authority or interaction-contract changes.
+  - [x] Add focused real-component regressions for endpoint continuity,
+    waiting cadence, burst coalescing, phase handoff, and reduced motion.
+  - [x] Pass QML lint/UI contracts, headless motion and visual renders, full
+    repository validation, deterministic build/package checks, and Git
+    whitespace checks.
+  - [ ] Commit and push the branch, open a draft PR to main, and leave installed
+    and live shell state unchanged for owner validation.
+- Current checkpoint: the presentation-only implementation is complete. The
+  fixed route now transfers node energy with identical resting endpoints;
+  waiting uses a 760 ms wave plus 1320 ms rest, streaming uses coalesced 460 ms
+  content-driven waves, phase copy crossfades, the header no longer overshoots,
+  and moving height/scroll targets use smoothing. The real-component cadence
+  probe, ten-frame renderer, QML/UI contract, and full 136-test runtime suite
+  pass. Final evidence is 23 protocol/context, three permission-focus, eight
+  presentation, and seven quick-action QML checks; the cadence probe and all ten
+  motion frames; 136 runtime tests with 12 opt-in live-provider skips; two
+  byte-identical broker builds; successful package dry-run; and clean Git
+  whitespace. Shellcheck remains unavailable. `npm ci` also reports unchanged
+  development-server advisories in direct esbuild (low) and Vitest (critical)
+  dependencies; this presentation-only diff neither invokes their servers nor
+  changes the lockfile. Commit and PR publication remain; installed and live
+  shell state are unchanged.

--- a/components/OmaPilotMark.qml
+++ b/components/OmaPilotMark.qml
@@ -16,20 +16,26 @@ Item {
   implicitWidth: size
   implicitHeight: size
   transformOrigin: Item.Center
+  scale: active ? 0.975 : 1
 
-  function beginActivityReveal() {
-    activityReveal.stop()
-    scale = 1
-    mark.opacity = 1
-    if (active && motionEnabled) {
-      scale = 0.94
-      mark.opacity = 0.58
-      activityReveal.restart()
-    }
+  Behavior on scale {
+    enabled: root.motionEnabled
+    NumberAnimation { duration: 160; easing.type: Easing.OutCubic }
   }
 
-  onActiveChanged: beginActivityReveal()
-  onMotionEnabledChanged: beginActivityReveal()
+  Rectangle {
+    anchors.centerIn: parent
+    width: root.size
+    height: root.size
+    radius: Style.cornerRadius
+    color: root.accent
+    opacity: root.active ? 0.10 : 0
+
+    Behavior on opacity {
+      enabled: root.motionEnabled
+      NumberAnimation { duration: 180; easing.type: Easing.OutCubic }
+    }
+  }
 
   QQC.Button {
     id: mark
@@ -44,24 +50,5 @@ Item {
     icon.width: Math.round(root.size)
     icon.height: Math.round(root.size)
     icon.color: root.accent
-  }
-
-  ParallelAnimation {
-    id: activityReveal
-    loops: 1
-    NumberAnimation {
-      target: root
-      property: "scale"
-      to: 1
-      duration: 240
-      easing.type: Easing.OutBack
-    }
-    NumberAnimation {
-      target: mark
-      property: "opacity"
-      to: 1
-      duration: 180
-      easing.type: Easing.OutCubic
-    }
   }
 }

--- a/components/WaitingIndicator.qml
+++ b/components/WaitingIndicator.qml
@@ -13,18 +13,17 @@ Item {
   property color foreground: Color.popups.text
   property color accent: Color.accent
   property string fontFamily: Style.font.family
-  property bool pulseQueued: false
-  property real waveProgress: 0
+  property real signalPhase: 0
+  property real signalSpeed: streaming ? 0.78 : 0.55
   property bool componentReady: false
   property string displayedMessage: message
   property string pendingMessage: message
-  readonly property int requestedPulseDuration: streaming ? 460 : 760
-  property int activePulseDuration: 760
-  readonly property int waitingRestDuration: 1320
-  readonly property bool pulseRunning: wavePulse.running
-  readonly property bool waitingCadenceRunning: waitingCadence.running
-  readonly property real pulseProgress: waveProgress
+  readonly property bool pulseRunning: signalClock.running
+  readonly property real pulseProgress: signalPhase
   readonly property real settledNodeOpacity: motionEnabled ? 0.46 : 0.72
+  readonly property real signalEnvelope: edgeEnvelope()
+  readonly property real routeEnergy: Math.max(nodeEnergy(0.25),
+    nodeEnergy(0.5), nodeEnergy(0.75))
 
   implicitWidth: Style.space(204)
   implicitHeight: content.implicitHeight
@@ -37,23 +36,34 @@ Item {
     NumberAnimation { duration: 140; easing.type: Easing.OutCubic }
   }
 
-  function pulseStrength(position) {
-    var progress = Math.max(0, Math.min(1, waveProgress))
-    var distance = Math.abs(progress - position)
-    var localWave = Math.max(0, 1 - distance / 0.38)
-    var endpointEnvelope = Math.sin(Math.PI * progress)
-    return localWave * endpointEnvelope
+  Behavior on signalSpeed {
+    enabled: root.motionEnabled
+    NumberAnimation { duration: 240; easing.type: Easing.OutCubic }
+  }
+
+  function edgeEnvelope() {
+    var edge = Math.min(1, signalPhase / 0.18, (1 - signalPhase) / 0.18)
+    edge = Math.max(0, edge)
+    return edge * edge * (3 - 2 * edge)
+  }
+
+  function nodeEnergy(position) {
+    // The frame-clock beam crosses each fixed route node at constant velocity.
+    // It is fully transparent at the route edge before phase wraps, so the
+    // reset cannot flash or teleport on a compositor frame.
+    var distance = Math.abs(signalPhase - position)
+    var strength = Math.max(0, 1 - distance / 0.24)
+    return strength * strength * (3 - 2 * strength) * signalEnvelope
   }
 
   function settle() {
-    waveProgress = 0
+    signalPhase = 0
   }
 
-  function stopAndSettle() {
-    pulseQueued = false
-    waitingCadence.stop()
-    wavePulse.stop()
-    settle()
+  function advanceSignal(frameDelta) {
+    // A long compositor frame contributes at most 50 ms of phase travel.
+    var delta = Math.min(0.05, Math.max(0, frameDelta))
+    signalPhase = (signalPhase + delta * signalSpeed) % 1
   }
 
   function updateDisplayedMessage() {
@@ -71,49 +81,19 @@ Item {
     if (displayedMessage !== pendingMessage) messageSwap.restart()
   }
 
-  function startPulse() {
-    if (!active || !motionEnabled) {
-      stopAndSettle()
-      return
-    }
-    waitingCadence.stop()
-    pulseQueued = false
-    waveProgress = 0
-    activePulseDuration = requestedPulseDuration
-    wavePulse.start()
-  }
-
-  function requestPulse() {
-    if (!active || !motionEnabled) {
-      stopAndSettle()
-      return
-    }
-    waitingCadence.stop()
-    if (wavePulse.running) {
-      pulseQueued = true
-      return
-    }
-    startPulse()
-  }
-
-  onActiveChanged: if (componentReady) active ? requestPulse() : stopAndSettle()
-  // First-token and bursty content events coalesce behind the active wave.
-  // Because both ends of the wave render at the same resting state, handing
-  // off to the queued streaming pulse has no visible reset or teleport.
-  onStreamingChanged: if (componentReady) requestPulse()
+  onActiveChanged: if (componentReady && !active) settle()
+  // Token bursts intentionally do not restart or retime the signal. The
+  // waiting-to-streaming handoff only eases its velocity, leaving phase intact.
   onMotionEnabledChanged: if (componentReady) {
-    motionEnabled ? requestPulse() : stopAndSettle()
+    if (!motionEnabled) settle()
     updateDisplayedMessage()
   }
   onMessageChanged: updateDisplayedMessage()
-  onActivityRevisionChanged: {
-    if (componentReady && active && streaming && motionEnabled) requestPulse()
-  }
   Component.onCompleted: {
     componentReady = true
     displayedMessage = message
     pendingMessage = message
-    active ? requestPulse() : settle()
+    if (!active || !motionEnabled) settle()
   }
 
   RowLayout {
@@ -126,6 +106,7 @@ Item {
       Layout.alignment: Qt.AlignVCenter
       implicitWidth: Style.space(44)
       implicitHeight: Style.space(14)
+      clip: true
 
       Rectangle {
         anchors.left: parent.left
@@ -133,7 +114,7 @@ Item {
         anchors.verticalCenter: parent.verticalCenter
         height: Math.max(1, Style.spacing.hairline)
         color: Style.normalBorderFor(root.foreground, root.accent)
-        opacity: 0.72 + 0.18 * Math.sin(Math.PI * root.waveProgress)
+        opacity: 0.62 + 0.18 * root.routeEnergy
       }
 
       Repeater {
@@ -143,7 +124,7 @@ Item {
         Rectangle {
           required property int index
           readonly property real routePosition: (index + 1) / 4
-          readonly property real energy: root.pulseStrength(routePosition)
+          readonly property real energy: root.nodeEnergy(routePosition)
           width: Style.spacing.sm
           height: width
           x: routePosition * route.width - width / 2
@@ -151,8 +132,34 @@ Item {
           radius: Style.cornerRadius > 0 ? Math.min(Style.cornerRadius, width / 2) : 0
           color: root.accent
           opacity: root.settledNodeOpacity + (0.96 - root.settledNodeOpacity) * energy
-          scale: 1 + 0.22 * energy
+          scale: 1 + 0.16 * energy
           transformOrigin: Item.Center
+        }
+      }
+
+      Item {
+        id: signalBeam
+        width: Style.space(14)
+        height: route.height
+        x: root.signalPhase * route.width - width / 2
+        opacity: root.signalEnvelope
+
+        Rectangle {
+          anchors.centerIn: parent
+          width: parent.width
+          height: Style.spacing.sm + Style.spacing.hairline
+          radius: Style.cornerRadius > 0 ? Math.min(Style.cornerRadius, height / 2) : 0
+          color: root.accent
+          opacity: 0.20
+        }
+
+        Rectangle {
+          anchors.centerIn: parent
+          width: Math.round(parent.width * 0.58)
+          height: Math.max(1, Style.spacing.hairline * 2)
+          radius: Style.cornerRadius > 0 ? Math.min(Style.cornerRadius, height / 2) : 0
+          color: root.accent
+          opacity: 0.94
         }
       }
     }
@@ -193,29 +200,11 @@ Item {
     }
   }
 
-  NumberAnimation {
-    id: wavePulse
-    objectName: "wavePulse"
-    target: root
-    property: "waveProgress"
-    from: 0
-    to: 1
-    duration: root.activePulseDuration
-    easing.type: Easing.InOutCubic
-    onFinished: {
-      root.settle()
-      if (root.pulseQueued && root.active && root.motionEnabled)
-        Qt.callLater(root.startPulse)
-      else if (root.active && !root.streaming && root.motionEnabled)
-        waitingCadence.restart()
-    }
-  }
-
-  Timer {
-    id: waitingCadence
-    objectName: "waitingCadence"
-    interval: root.waitingRestDuration
-    repeat: false
-    onTriggered: root.requestPulse()
+  FrameAnimation {
+    id: signalClock
+    objectName: "signalClock"
+    running: root.active && root.motionEnabled
+    // Cap delayed frames so compositor stalls cannot become visible jumps.
+    onTriggered: root.advanceSignal(smoothFrameTime)
   }
 }

--- a/components/WaitingIndicator.qml
+++ b/components/WaitingIndicator.qml
@@ -14,32 +14,61 @@ Item {
   property color accent: Color.accent
   property string fontFamily: Style.font.family
   property bool pulseQueued: false
-  readonly property int pulseDuration: streaming ? 360 : 480
-  readonly property int pulseFadeInDuration: streaming ? 80 : 100
-  readonly property int pulseFadeOutDuration: streaming ? 120 : 160
-  readonly property int pulseHoldDuration: Math.max(0,
-    pulseDuration - pulseFadeInDuration - pulseFadeOutDuration)
-  readonly property bool pulseRunning: routePulse.running
-  readonly property real pulseOffset: pulseTranslate.x
+  property real waveProgress: 0
+  property bool componentReady: false
+  property string displayedMessage: message
+  property string pendingMessage: message
+  readonly property int requestedPulseDuration: streaming ? 460 : 760
+  property int activePulseDuration: 760
+  readonly property int waitingRestDuration: 1320
+  readonly property bool pulseRunning: wavePulse.running
+  readonly property bool waitingCadenceRunning: waitingCadence.running
+  readonly property real pulseProgress: waveProgress
+  readonly property real settledNodeOpacity: motionEnabled ? 0.46 : 0.72
 
-  implicitWidth: Style.space(196)
+  implicitWidth: Style.space(204)
   implicitHeight: content.implicitHeight
-  visible: active
+  visible: active || opacity > 0
+  opacity: active ? 1 : 0
   clip: true
 
+  Behavior on opacity {
+    enabled: root.motionEnabled
+    NumberAnimation { duration: 140; easing.type: Easing.OutCubic }
+  }
+
+  function pulseStrength(position) {
+    var progress = Math.max(0, Math.min(1, waveProgress))
+    var distance = Math.abs(progress - position)
+    var localWave = Math.max(0, 1 - distance / 0.38)
+    var endpointEnvelope = Math.sin(Math.PI * progress)
+    return localWave * endpointEnvelope
+  }
+
   function settle() {
-    pulseMarker.opacity = 0
-    pulseTranslate.x = 0
-    for (var i = 0; i < routeNodes.count; i++) {
-      var node = routeNodes.itemAt(i)
-      if (node) node.opacity = motionEnabled ? 0.46 : 0.72
-    }
+    waveProgress = 0
   }
 
   function stopAndSettle() {
     pulseQueued = false
-    routePulse.stop()
+    waitingCadence.stop()
+    wavePulse.stop()
     settle()
+  }
+
+  function updateDisplayedMessage() {
+    pendingMessage = message
+    if (!componentReady) {
+      displayedMessage = pendingMessage
+      return
+    }
+    if (!motionEnabled) {
+      messageSwap.stop()
+      displayedMessage = pendingMessage
+      statusLabel.opacity = 1
+      return
+    }
+    if (displayedMessage !== pendingMessage) messageSwap.restart()
   }
 
   function startPulse() {
@@ -47,10 +76,11 @@ Item {
       stopAndSettle()
       return
     }
+    waitingCadence.stop()
     pulseQueued = false
-    pulseTranslate.x = 0
-    pulseMarker.opacity = 0.18
-    routePulse.restart()
+    waveProgress = 0
+    activePulseDuration = requestedPulseDuration
+    wavePulse.start()
   }
 
   function requestPulse() {
@@ -58,22 +88,33 @@ Item {
       stopAndSettle()
       return
     }
-    if (routePulse.running) {
+    waitingCadence.stop()
+    if (wavePulse.running) {
       pulseQueued = true
       return
     }
     startPulse()
   }
 
-  onActiveChanged: active ? requestPulse() : stopAndSettle()
-  // A first token changes the phase while the waiting sweep may still be in
-  // flight. Queue the streaming pulse instead of snapping the marker home.
-  onStreamingChanged: requestPulse()
-  onMotionEnabledChanged: motionEnabled ? requestPulse() : stopAndSettle()
-  onActivityRevisionChanged: {
-    if (active && streaming && motionEnabled) requestPulse()
+  onActiveChanged: if (componentReady) active ? requestPulse() : stopAndSettle()
+  // First-token and bursty content events coalesce behind the active wave.
+  // Because both ends of the wave render at the same resting state, handing
+  // off to the queued streaming pulse has no visible reset or teleport.
+  onStreamingChanged: if (componentReady) requestPulse()
+  onMotionEnabledChanged: if (componentReady) {
+    motionEnabled ? requestPulse() : stopAndSettle()
+    updateDisplayedMessage()
   }
-  Component.onCompleted: active ? requestPulse() : settle()
+  onMessageChanged: updateDisplayedMessage()
+  onActivityRevisionChanged: {
+    if (componentReady && active && streaming && motionEnabled) requestPulse()
+  }
+  Component.onCompleted: {
+    componentReady = true
+    displayedMessage = message
+    pendingMessage = message
+    active ? requestPulse() : settle()
+  }
 
   RowLayout {
     id: content
@@ -83,7 +124,7 @@ Item {
     Item {
       id: route
       Layout.alignment: Qt.AlignVCenter
-      implicitWidth: Style.space(46)
+      implicitWidth: Style.space(44)
       implicitHeight: Style.space(14)
 
       Rectangle {
@@ -92,6 +133,7 @@ Item {
         anchors.verticalCenter: parent.verticalCenter
         height: Math.max(1, Style.spacing.hairline)
         color: Style.normalBorderFor(root.foreground, root.accent)
+        opacity: 0.72 + 0.18 * Math.sin(Math.PI * root.waveProgress)
       }
 
       Repeater {
@@ -100,41 +142,31 @@ Item {
 
         Rectangle {
           required property int index
+          readonly property real routePosition: (index + 1) / 4
+          readonly property real energy: root.pulseStrength(routePosition)
           width: Style.spacing.sm
           height: width
-          x: index * (route.width - width) / 2
+          x: routePosition * route.width - width / 2
           anchors.verticalCenter: route.verticalCenter
           radius: Style.cornerRadius > 0 ? Math.min(Style.cornerRadius, width / 2) : 0
           color: root.accent
-          opacity: 0.46
-        }
-      }
-
-      Rectangle {
-        id: pulseMarker
-        width: Style.space(12)
-        height: Style.spacing.sm
-        anchors.verticalCenter: parent.verticalCenter
-        radius: Style.cornerRadius > 0 ? Math.min(Style.cornerRadius, height / 2) : 0
-        color: root.accent
-        opacity: 0
-
-        transform: Translate {
-          id: pulseTranslate
-          objectName: "pulseTranslate"
+          opacity: root.settledNodeOpacity + (0.96 - root.settledNodeOpacity) * energy
+          scale: 1 + 0.22 * energy
+          transformOrigin: Item.Center
         }
       }
     }
 
     Text {
+      id: statusLabel
       Layout.alignment: Qt.AlignVCenter
       Layout.fillWidth: true
       Layout.minimumWidth: 0
-      text: root.message
+      text: root.displayedMessage
       color: root.accent
       font.family: root.fontFamily
       font.pixelSize: Style.font.caption
-      font.bold: true
+      font.weight: Font.Medium
       elide: Text.ElideRight
       maximumLineCount: 1
       Accessible.role: Accessible.StaticText
@@ -143,47 +175,47 @@ Item {
   }
 
   SequentialAnimation {
-    id: routePulse
-    objectName: "routePulse"
-    loops: 1
+    id: messageSwap
+    NumberAnimation {
+      target: statusLabel
+      property: "opacity"
+      to: 0.30
+      duration: 70
+      easing.type: Easing.OutCubic
+    }
+    ScriptAction { script: root.displayedMessage = root.pendingMessage }
+    NumberAnimation {
+      target: statusLabel
+      property: "opacity"
+      to: 1
+      duration: 110
+      easing.type: Easing.OutCubic
+    }
+  }
 
-    ScriptAction {
-      script: {
-        pulseTranslate.x = 0
-        pulseMarker.opacity = 0.18
-      }
-    }
-    ParallelAnimation {
-      NumberAnimation {
-        target: pulseTranslate
-        property: "x"
-        from: 0
-        to: Math.max(0, route.width - pulseMarker.width)
-        duration: root.pulseDuration
-        easing.type: Easing.OutCubic
-      }
-      SequentialAnimation {
-        NumberAnimation {
-          target: pulseMarker
-          property: "opacity"
-          to: 0.92
-          duration: root.pulseFadeInDuration
-          easing.type: Easing.OutCubic
-        }
-        PauseAnimation { duration: root.pulseHoldDuration }
-        NumberAnimation {
-          target: pulseMarker
-          property: "opacity"
-          to: 0
-          duration: root.pulseFadeOutDuration
-          easing.type: Easing.OutCubic
-        }
-      }
-    }
+  NumberAnimation {
+    id: wavePulse
+    objectName: "wavePulse"
+    target: root
+    property: "waveProgress"
+    from: 0
+    to: 1
+    duration: root.activePulseDuration
+    easing.type: Easing.InOutCubic
     onFinished: {
       root.settle()
       if (root.pulseQueued && root.active && root.motionEnabled)
         Qt.callLater(root.startPulse)
+      else if (root.active && !root.streaming && root.motionEnabled)
+        waitingCadence.restart()
     }
+  }
+
+  Timer {
+    id: waitingCadence
+    objectName: "waitingCadence"
+    interval: root.waitingRestDuration
+    repeat: false
+    onTriggered: root.requestPulse()
   }
 }

--- a/design-qa.md
+++ b/design-qa.md
@@ -61,14 +61,16 @@ for editing, removal, and directional reordering; the list remains inside the
 same capped settings scroll owner.
 
 The response captures verify three distinct states without changing transcript
-ownership: a fixed-route energy wave while waiting, real-content-driven node
-energy while streaming, and an urgent but compact error notice. Waiting and
-streaming share one fixed, screen-aware status slot, and their copy crossfades,
-so phase changes do not resize the adjacent question. The route has no moving
-marker: both ends of each wave render the same resting geometry, eliminating
-the visible teleport that made the earlier treatment feel rough. The error
-notice opens a separate selectable details pane with the normalized message,
-code, retryability, and Copy action. No animation claims completion percentage.
+ownership: a clipped telemetry beam crossing a fixed route while waiting, the
+same frame-clock signal with a gently eased velocity while streaming, and an
+urgent but compact error notice. Waiting and streaming share one fixed,
+screen-aware status slot, and their copy crossfades, so phase changes do not
+resize the adjacent question.
+The route has no chunk-driven restart or slow-fast-slow easing; its moving beam
+is fully transparent at the clipped edge before phase wrapping, while the
+fixed nodes share identical resting geometry. The error notice
+opens a separate selectable details pane with the normalized message, code,
+retryability, and Copy action. No animation claims completion percentage.
 
 Copy, icon weight, border contrast, and control density are internally
 consistent. The implementation title and mark are intentionally smaller than
@@ -114,6 +116,14 @@ conversation content.
     between waiting waves, coalesces streaming bursts, crossfades phase copy,
     uses `SmoothedAnimation` for moving height/scroll targets, and replaces the
     header bounce with a quiet accent state.
+11. Owner validation of that build still found the energy transfer rough. The
+    captured phase samples (`0.013`, `0.102`, `0.346`, `0.723`, `0.927`) proved
+    the cubic timeline accelerated sharply through the middle, while queued
+    token pulses could run back-to-back. The replacement uses `FrameAnimation`
+    with capped frame deltas and constant phase velocity, renders a clipped
+    telemetry beam that is invisible at wrap, eases only the waiting-
+    to-streaming speed change, ignores burst timing, and removes the first-token
+    vertical slide so response geometry has one less moving axis.
 
 ## State and interaction evidence
 
@@ -129,11 +139,11 @@ conversation content.
   the bounded production settings view; focused broker tests prove the visual
   flag's no-prompt behavior separately from this rendering evidence.
 - The headless preview fails on QML load errors and rejects TypeError output.
-- A Quickshell motion probe exercises the real component timeline and fails if
-  first-token streaming stops, resets, or changes the duration of an in-flight
-  wave; if a content event is discarded while it runs; if waiting skips its
-  resting cadence; or if reduced motion leaves animation queued.
-- A separate real-component renderer captures ten consecutive waiting-to-
+- A Quickshell motion probe exercises the real component frame clock and fails
+  if waiting does not advance at a bounded rate, first-token streaming resets
+  phase, token activity retimes the signal, a delayed frame exceeds the capped
+  delta, or reduced motion leaves the clock running.
+- A separate real-component renderer captures fourteen consecutive waiting-to-
   streaming frames. The UI contract requires every frame and successful harness
   completion, making temporal load failures visible instead of relying on one
   static screenshot or source grep.
@@ -148,8 +158,9 @@ conversation content.
 
 - P0: none.
 - P1: none.
-- P2: none after the second render.
+- P2: checkpoint 9 was rejected in owner testing; the corrected frame-clock
+  candidate passes static temporal review and awaits a new installed gate.
 - P3: the native mark/title scale is smaller than the generated reference;
   accepted for the shell-sized checkpoint.
 
-final result: passed
+final result: static pass; installed owner gate pending

--- a/design-qa.md
+++ b/design-qa.md
@@ -61,12 +61,14 @@ for editing, removal, and directional reordering; the list remains inside the
 same capped settings scroll owner.
 
 The response captures verify three distinct states without changing transcript
-ownership: a finite route reveal while waiting, a real-content-driven route
-pulse while streaming, and an urgent but compact error notice. Waiting and
-streaming now share one fixed, screen-aware status slot, so label changes do not
-resize the adjacent question. The error notice opens a separate selectable
-details pane with the normalized message, code, retryability, and Copy action.
-No animation claims completion percentage.
+ownership: a fixed-route energy wave while waiting, real-content-driven node
+energy while streaming, and an urgent but compact error notice. Waiting and
+streaming share one fixed, screen-aware status slot, and their copy crossfades,
+so phase changes do not resize the adjacent question. The route has no moving
+marker: both ends of each wave render the same resting geometry, eliminating
+the visible teleport that made the earlier treatment feel rough. The error
+notice opens a separate selectable details pane with the normalized message,
+code, retryability, and Copy action. No animation claims completion percentage.
 
 Copy, icon weight, border contrast, and control density are internally
 consistent. The implementation title and mark are intentionally smaller than
@@ -103,6 +105,15 @@ conversation content.
    rather than resets the active sweep, bursty chunks coalesce into one pending
    pulse, opacity and travel durations match, and one stable status slot owns
    waiting, streaming, and completion copy.
+10. A second hands-on review found that non-layout movement still looked rough:
+    the marker necessarily teleported home between pulses, fixed-duration panel
+    and transcript animations repeatedly restarted under streaming updates, and
+    the header mark overshot on every busy-state change. The production pass now
+    keeps route geometry fixed and transfers only node energy, latches each
+    in-flight wave's duration across the first-token handoff, inserts a long rest
+    between waiting waves, coalesces streaming bursts, crossfades phase copy,
+    uses `SmoothedAnimation` for moving height/scroll targets, and replaces the
+    header bounce with a quiet accent state.
 
 ## State and interaction evidence
 
@@ -119,8 +130,13 @@ conversation content.
   flag's no-prompt behavior separately from this rendering evidence.
 - The headless preview fails on QML load errors and rejects TypeError output.
 - A Quickshell motion probe exercises the real component timeline and fails if
-  first-token streaming stops or resets the active sweep, if a content event is
-  discarded while it runs, or if reduced motion leaves animation queued.
+  first-token streaming stops, resets, or changes the duration of an in-flight
+  wave; if a content event is discarded while it runs; if waiting skips its
+  resting cadence; or if reduced motion leaves animation queued.
+- A separate real-component renderer captures ten consecutive waiting-to-
+  streaming frames. The UI contract requires every frame and successful harness
+  completion, making temporal load failures visible instead of relying on one
+  static screenshot or source grep.
 - The merged installed path passes the same QML/UI contracts, its shell-owned
   broker was relaunched from the new deterministic bundle, and the recovered
   shell log contains no OmaPilot/Quickchat-specific load error.

--- a/tests/check-ui-contract.sh
+++ b/tests/check-ui-contract.sh
@@ -32,6 +32,7 @@ qml_files=(
   "$repo_dir/components/Protocol.js"
   "$repo_dir/components/Presentation.js"
   "$repo_dir/components/QuickActions.js"
+  "$repo_dir/tests/motion-preview.qml"
 )
 
 /usr/lib/qt6/bin/qmllint -I "$omarchy_shell" -I "$repo_dir" "${qml_files[@]}" >/dev/null 2>&1
@@ -151,13 +152,28 @@ grep -Fq 'tooltipText: "Jump to the newest response"' "$repo_dir/Panel.qml"
 grep -Fq 'Quickchat.WaitingIndicator {' "$repo_dir/Panel.qml"
 grep -Fq 'id: responseStatusSlot' "$repo_dir/Panel.qml"
 grep -Fq 'Layout.minimumWidth: Style.space(140)' "$repo_dir/Panel.qml"
-grep -Fq 'loops: 1' "$repo_dir/components/WaitingIndicator.qml"
 grep -Fq 'property bool pulseQueued: false' "$repo_dir/components/WaitingIndicator.qml"
-grep -Fq 'transform: Translate {' "$repo_dir/components/WaitingIndicator.qml"
-grep -Fq 'if (routePulse.running) {' "$repo_dir/components/WaitingIndicator.qml"
+grep -Fq 'property real waveProgress: 0' "$repo_dir/components/WaitingIndicator.qml"
+grep -Fq 'property int activePulseDuration: 760' "$repo_dir/components/WaitingIndicator.qml"
+grep -Fq 'function pulseStrength(position)' "$repo_dir/components/WaitingIndicator.qml"
+grep -Fq 'id: waitingCadence' "$repo_dir/components/WaitingIndicator.qml"
+grep -Fq 'id: messageSwap' "$repo_dir/components/WaitingIndicator.qml"
+grep -Fq 'if (wavePulse.running) {' "$repo_dir/components/WaitingIndicator.qml"
 grep -Fq 'onActivityRevisionChanged:' "$repo_dir/components/WaitingIndicator.qml"
 grep -Fq 'activityRevision++' "$repo_dir/components/QuickchatStore.qml"
-if grep -Fq 'onStreamingChanged: trigger()' "$repo_dir/components/WaitingIndicator.qml"; then
+if grep -Fq 'pulseTranslate' "$repo_dir/components/WaitingIndicator.qml"; then
+  printf 'OmaPilot activity motion must not teleport a moving marker\n' >&2
+  exit 1
+fi
+if grep -Fq 'Easing.OutBack' "$repo_dir/components/OmaPilotMark.qml"; then
+  printf 'OmaPilot activity mark must not use an overshooting bounce\n' >&2
+  exit 1
+fi
+if ! grep -Fq 'SmoothedAnimation {' "$repo_dir/Panel.qml"; then
+  printf 'OmaPilot streaming geometry must smooth continuously changing targets\n' >&2
+  exit 1
+fi
+if grep -Fq 'onStreamingChanged: wavePulse.restart()' "$repo_dir/components/WaitingIndicator.qml"; then
   printf 'Waiting-to-streaming motion must not reset an in-flight pulse\n' >&2
   exit 1
 fi
@@ -236,11 +252,31 @@ if grep -Eq "smoke loader failed|Failed to load|Type .* unavailable|Cannot assig
 fi
 
 cp "$repo_dir/tests/waiting-indicator-probe.qml" "$smoke_root/shell.qml"
-QT_QPA_PLATFORM=offscreen timeout 5s quickshell --no-duplicate \
-  --path "$smoke_root" --no-color >"$smoke_root/motion.log" 2>&1
+if ! QT_QPA_PLATFORM=offscreen timeout 5s quickshell --no-duplicate \
+    --path "$smoke_root" --no-color >"$smoke_root/motion.log" 2>&1; then
+  cat "$smoke_root/motion.log"
+  exit 1
+fi
 if grep -Eq "omapilot motion probe failed|Failed to load|Type .* unavailable|Cannot assign|TypeError" \
     "$smoke_root/motion.log" || ! grep -Fq 'OMAPILOT_MOTION_PROBE_OK' "$smoke_root/motion.log"; then
   cat "$smoke_root/motion.log"
+  exit 1
+fi
+
+motion_frame_root="$smoke_root/motion-frames"
+mkdir -p "$motion_frame_root"
+cp "$repo_dir/tests/motion-preview.qml" "$smoke_root/shell.qml"
+if ! OMAPILOT_MOTION_FRAME_DIR="$motion_frame_root" QT_QPA_PLATFORM=offscreen \
+    timeout 5s quickshell --no-duplicate --path "$smoke_root" --no-color \
+    >"$smoke_root/motion-preview.log" 2>&1; then
+  cat "$smoke_root/motion-preview.log"
+  exit 1
+fi
+if grep -Eq "omapilot motion preview failed|Failed to load|Type .* unavailable|Cannot assign|TypeError" \
+    "$smoke_root/motion-preview.log" \
+    || ! grep -Fq 'OMAPILOT_MOTION_PREVIEW_OK' "$smoke_root/motion-preview.log" \
+    || [[ $(find "$motion_frame_root" -maxdepth 1 -type f -name 'frame-*.png' | wc -l) -ne 10 ]]; then
+  cat "$smoke_root/motion-preview.log"
   exit 1
 fi
 

--- a/tests/check-ui-contract.sh
+++ b/tests/check-ui-contract.sh
@@ -152,14 +152,17 @@ grep -Fq 'tooltipText: "Jump to the newest response"' "$repo_dir/Panel.qml"
 grep -Fq 'Quickchat.WaitingIndicator {' "$repo_dir/Panel.qml"
 grep -Fq 'id: responseStatusSlot' "$repo_dir/Panel.qml"
 grep -Fq 'Layout.minimumWidth: Style.space(140)' "$repo_dir/Panel.qml"
-grep -Fq 'property bool pulseQueued: false' "$repo_dir/components/WaitingIndicator.qml"
-grep -Fq 'property real waveProgress: 0' "$repo_dir/components/WaitingIndicator.qml"
-grep -Fq 'property int activePulseDuration: 760' "$repo_dir/components/WaitingIndicator.qml"
-grep -Fq 'function pulseStrength(position)' "$repo_dir/components/WaitingIndicator.qml"
-grep -Fq 'id: waitingCadence' "$repo_dir/components/WaitingIndicator.qml"
+grep -Fq 'property real signalPhase: 0' "$repo_dir/components/WaitingIndicator.qml"
+grep -Fq 'property real signalSpeed: streaming ? 0.78 : 0.55' "$repo_dir/components/WaitingIndicator.qml"
+grep -Fq 'function nodeEnergy(position)' "$repo_dir/components/WaitingIndicator.qml"
+grep -Fq 'function edgeEnvelope()' "$repo_dir/components/WaitingIndicator.qml"
+grep -Fq 'id: signalClock' "$repo_dir/components/WaitingIndicator.qml"
+grep -Fq 'id: signalBeam' "$repo_dir/components/WaitingIndicator.qml"
+grep -Fq 'x: root.signalPhase * route.width - width / 2' "$repo_dir/components/WaitingIndicator.qml"
+grep -Fq 'FrameAnimation {' "$repo_dir/components/WaitingIndicator.qml"
+grep -Fq 'function advanceSignal(frameDelta)' "$repo_dir/components/WaitingIndicator.qml"
+grep -Fq 'Math.min(0.05, Math.max(0, frameDelta))' "$repo_dir/components/WaitingIndicator.qml"
 grep -Fq 'id: messageSwap' "$repo_dir/components/WaitingIndicator.qml"
-grep -Fq 'if (wavePulse.running) {' "$repo_dir/components/WaitingIndicator.qml"
-grep -Fq 'onActivityRevisionChanged:' "$repo_dir/components/WaitingIndicator.qml"
 grep -Fq 'activityRevision++' "$repo_dir/components/QuickchatStore.qml"
 if grep -Fq 'pulseTranslate' "$repo_dir/components/WaitingIndicator.qml"; then
   printf 'OmaPilot activity motion must not teleport a moving marker\n' >&2
@@ -173,8 +176,12 @@ if ! grep -Fq 'SmoothedAnimation {' "$repo_dir/Panel.qml"; then
   printf 'OmaPilot streaming geometry must smooth continuously changing targets\n' >&2
   exit 1
 fi
-if grep -Fq 'onStreamingChanged: wavePulse.restart()' "$repo_dir/components/WaitingIndicator.qml"; then
-  printf 'Waiting-to-streaming motion must not reset an in-flight pulse\n' >&2
+if grep -Eq 'onStreamingChanged:|onActivityRevisionChanged:' "$repo_dir/components/WaitingIndicator.qml"; then
+  printf 'Phase and token changes must not restart or retime the activity signal\n' >&2
+  exit 1
+fi
+if grep -Fq 'answerRevealTranslate' "$repo_dir/Panel.qml"; then
+  printf 'First-token reveal must not translate response geometry\n' >&2
   exit 1
 fi
 grep -Fq "You are OmaPilot, Omarchy's action-oriented system copilot" \
@@ -275,7 +282,7 @@ fi
 if grep -Eq "omapilot motion preview failed|Failed to load|Type .* unavailable|Cannot assign|TypeError" \
     "$smoke_root/motion-preview.log" \
     || ! grep -Fq 'OMAPILOT_MOTION_PREVIEW_OK' "$smoke_root/motion-preview.log" \
-    || [[ $(find "$motion_frame_root" -maxdepth 1 -type f -name 'frame-*.png' | wc -l) -ne 10 ]]; then
+    || [[ $(find "$motion_frame_root" -maxdepth 1 -type f -name 'frame-*.png' | wc -l) -ne 14 ]]; then
   cat "$smoke_root/motion-preview.log"
   exit 1
 fi

--- a/tests/motion-preview.qml
+++ b/tests/motion-preview.qml
@@ -1,0 +1,81 @@
+import QtQuick
+import QtQuick.Window
+import Quickshell
+import "components" as OmaPilot
+
+ShellRoot {
+  id: root
+
+  readonly property string outputDirectory: Quickshell.env("OMAPILOT_MOTION_FRAME_DIR")
+  property int frameIndex: 0
+  property bool failed: false
+
+  function fail(message) {
+    failed = true
+    console.error("omapilot motion preview failed: " + message)
+    Qt.quit()
+  }
+
+  Window {
+    id: previewWindow
+    width: 420
+    height: 44
+    visible: true
+    color: "transparent"
+    flags: Qt.FramelessWindowHint
+
+    Rectangle {
+      id: captureSurface
+      anchors.fill: parent
+      color: "#181923"
+
+      OmaPilot.WaitingIndicator {
+        id: indicator
+        anchors.centerIn: parent
+        width: 260
+        height: 24
+        active: true
+        streaming: false
+        motionEnabled: true
+        message: streaming ? "Receiving response…" : "Preparing Codex…"
+        foreground: "#c6d0f5"
+        accent: "#8caaee"
+      }
+    }
+  }
+
+  Timer {
+    id: captureTimer
+    interval: 110
+    running: true
+    repeat: false
+    onTriggered: {
+      if (root.outputDirectory === "") {
+        root.fail("OMAPILOT_MOTION_FRAME_DIR is required")
+        return
+      }
+      var output = root.outputDirectory + "/frame-" + String(root.frameIndex).padStart(2, "0") + ".png"
+      console.log("OMAPILOT_MOTION_FRAME=" + root.frameIndex
+        + " phase=" + (indicator.streaming ? "streaming" : "waiting")
+        + " progress=" + indicator.pulseProgress.toFixed(3)
+        + " message=" + indicator.displayedMessage)
+      captureSurface.grabToImage(function(result) {
+        if (!result || !result.saveToFile(output)) {
+          root.fail("could not save " + output)
+          return
+        }
+        root.frameIndex += 1
+        if (root.frameIndex === 5) {
+          indicator.streaming = true
+          indicator.activityRevision += 1
+        }
+        if (root.frameIndex >= 10) {
+          console.log("OMAPILOT_MOTION_PREVIEW_OK")
+          Qt.quit()
+          return
+        }
+        captureTimer.restart()
+      })
+    }
+  }
+}

--- a/tests/motion-preview.qml
+++ b/tests/motion-preview.qml
@@ -8,6 +8,9 @@ ShellRoot {
 
   readonly property string outputDirectory: Quickshell.env("OMAPILOT_MOTION_FRAME_DIR")
   property int frameIndex: 0
+  property real lastProgress: -1
+  property real largestStep: 0
+  property real transitionProgress: 0
   property bool failed: false
 
   function fail(message) {
@@ -46,7 +49,7 @@ ShellRoot {
 
   Timer {
     id: captureTimer
-    interval: 110
+    interval: 80
     running: true
     repeat: false
     onTriggered: {
@@ -54,6 +57,16 @@ ShellRoot {
         root.fail("OMAPILOT_MOTION_FRAME_DIR is required")
         return
       }
+      var progress = indicator.pulseProgress
+      if (root.lastProgress >= 0) {
+        var step = (progress - root.lastProgress + 1) % 1
+        root.largestStep = Math.max(root.largestStep, step)
+        if (step <= 0 || step > 0.14) {
+          root.fail("frame-clock phase step was not smooth: " + step.toFixed(3))
+          return
+        }
+      }
+      root.lastProgress = progress
       var output = root.outputDirectory + "/frame-" + String(root.frameIndex).padStart(2, "0") + ".png"
       console.log("OMAPILOT_MOTION_FRAME=" + root.frameIndex
         + " phase=" + (indicator.streaming ? "streaming" : "waiting")
@@ -65,11 +78,20 @@ ShellRoot {
           return
         }
         root.frameIndex += 1
-        if (root.frameIndex === 5) {
+        if (root.frameIndex === 7) {
+          root.transitionProgress = indicator.pulseProgress
           indicator.streaming = true
           indicator.activityRevision += 1
         }
-        if (root.frameIndex >= 10) {
+        if (root.frameIndex === 8 && indicator.pulseProgress < root.transitionProgress) {
+          root.fail("waiting-to-streaming render reset phase")
+          return
+        }
+        if (root.frameIndex >= 14) {
+          if (root.largestStep <= 0) {
+            root.fail("motion preview did not observe temporal progress")
+            return
+          }
           console.log("OMAPILOT_MOTION_PREVIEW_OK")
           Qt.quit()
           return

--- a/tests/waiting-indicator-probe.qml
+++ b/tests/waiting-indicator-probe.qml
@@ -5,10 +5,9 @@ import "components" as OmaPilot
 
 ShellRoot {
   id: root
-  property real waitingProgress: 0
-  property int waitingDuration: 0
-  property bool transitionChecked: false
-  property bool cadenceChecked: false
+  property real waitingPhase: 0
+  property real transitionPhase: 0
+  property real activityPhase: 0
   property bool failed: false
 
   function fail(message) {
@@ -18,100 +17,77 @@ ShellRoot {
 
   Window {
     width: 460
-    height: 52
+    height: 28
     visible: true
     color: "transparent"
 
-    Column {
+    OmaPilot.WaitingIndicator {
+      id: indicator
       anchors.fill: parent
-
-      OmaPilot.WaitingIndicator {
-        id: transitionIndicator
-        width: parent.width
-        height: 24
-        active: true
-        streaming: false
-        motionEnabled: true
-        message: streaming ? "Receiving response…" : "Preparing Codex…"
-      }
-
-      OmaPilot.WaitingIndicator {
-        id: cadenceIndicator
-        width: parent.width
-        height: 24
-        active: true
-        streaming: false
-        motionEnabled: true
-        message: "Preparing Codex…"
-      }
+      active: true
+      streaming: false
+      motionEnabled: true
+      message: streaming ? "Receiving response…" : "Preparing Codex…"
     }
   }
 
   Timer {
-    interval: 100
+    interval: 180
     running: true
     repeat: false
     onTriggered: {
-      root.waitingProgress = transitionIndicator.pulseProgress
-      root.waitingDuration = transitionIndicator.activePulseDuration
-      if (!transitionIndicator.pulseRunning || root.waitingProgress <= 0)
-        root.fail("waiting energy wave did not start")
+      root.waitingPhase = indicator.pulseProgress
+      if (!indicator.pulseRunning || root.waitingPhase <= 0
+          || root.waitingPhase >= 0.20)
+        root.fail("waiting frame-clock signal did not advance at a bounded rate")
 
-      transitionIndicator.streaming = true
-      if (!transitionIndicator.pulseRunning)
-        root.fail("first token stopped the active energy wave")
-      if (!transitionIndicator.pulseQueued)
-        root.fail("first token did not queue the streaming wave")
-      if (transitionIndicator.pulseProgress < root.waitingProgress - 0.03)
-        root.fail("first token reset the active energy wave")
-      if (transitionIndicator.activePulseDuration !== root.waitingDuration)
-        root.fail("first token changed the in-flight wave timing")
+      root.transitionPhase = indicator.pulseProgress
+      indicator.streaming = true
+      if (!indicator.pulseRunning || indicator.pulseProgress !== root.transitionPhase)
+        root.fail("first token reset the frame-clock phase")
 
-      transitionIndicator.activityRevision += 1
-      if (!transitionIndicator.pulseQueued)
-        root.fail("content event was discarded while the wave was active")
+      root.activityPhase = indicator.pulseProgress
+      indicator.activityRevision += 1
+      if (indicator.pulseProgress !== root.activityPhase)
+        root.fail("token activity restarted the frame-clock phase")
+    }
+  }
 
-      transitionIndicator.active = false
-      if (transitionIndicator.pulseRunning || transitionIndicator.pulseQueued
-          || transitionIndicator.pulseProgress !== 0
-          || transitionIndicator.waitingCadenceRunning)
-        root.fail("inactive motion did not settle")
+  Timer {
+    interval: 520
+    running: true
+    repeat: false
+    onTriggered: {
+      if (!indicator.pulseRunning || indicator.pulseProgress <= root.transitionPhase)
+        root.fail("streaming signal did not continue from the waiting phase")
+      if (indicator.signalSpeed < 0.76 || indicator.signalSpeed > 0.79)
+        root.fail("waiting-to-streaming velocity did not ease to its target")
 
-      transitionIndicator.motionEnabled = false
-      transitionIndicator.active = true
-      if (transitionIndicator.pulseRunning || transitionIndicator.pulseQueued
-          || transitionIndicator.pulseProgress !== 0
-          || transitionIndicator.waitingCadenceRunning)
+      indicator.active = false
+      if (indicator.pulseRunning || indicator.pulseProgress !== 0)
+        root.fail("inactive motion did not stop and settle")
+
+      indicator.signalPhase = 0
+      var restingQuarter = indicator.nodeEnergy(0.25)
+      var restingHalf = indicator.nodeEnergy(0.5)
+      var restingThreeQuarter = indicator.nodeEnergy(0.75)
+      indicator.signalPhase = 1
+      if (indicator.nodeEnergy(0.25) !== restingQuarter
+          || indicator.nodeEnergy(0.5) !== restingHalf
+          || indicator.nodeEnergy(0.75) !== restingThreeQuarter)
+        root.fail("phase wrap changed resting geometry")
+
+      indicator.signalPhase = 0
+      indicator.advanceSignal(1)
+      if (indicator.signalPhase <= 0 || indicator.signalPhase > 0.041)
+        root.fail("delayed-frame phase travel was not capped")
+      indicator.settle()
+
+      indicator.motionEnabled = false
+      indicator.active = true
+      if (indicator.pulseRunning || indicator.pulseProgress !== 0)
         root.fail("reduced motion did not remain settled")
 
-      root.transitionChecked = true
-    }
-  }
-
-  Timer {
-    interval: 900
-    running: true
-    repeat: false
-    onTriggered: {
-      if (cadenceIndicator.pulseRunning)
-        root.fail("waiting wave did not return to its rest state")
-      if (!cadenceIndicator.waitingCadenceRunning)
-        root.fail("waiting rest cadence was not scheduled")
-      if (cadenceIndicator.pulseProgress !== 0)
-        root.fail("waiting wave endpoint did not settle continuously")
-      root.cadenceChecked = true
-    }
-  }
-
-  Timer {
-    interval: 2250
-    running: true
-    repeat: false
-    onTriggered: {
-      if (!cadenceIndicator.pulseRunning || cadenceIndicator.pulseProgress <= 0)
-        root.fail("waiting cadence did not begin its next restrained wave")
-      if (!root.transitionChecked || !root.cadenceChecked)
-        root.fail("motion probe stages did not complete")
       if (!root.failed) console.log("OMAPILOT_MOTION_PROBE_OK")
       Qt.quit()
     }

--- a/tests/waiting-indicator-probe.qml
+++ b/tests/waiting-indicator-probe.qml
@@ -5,7 +5,10 @@ import "components" as OmaPilot
 
 ShellRoot {
   id: root
-  property real waitingOffset: 0
+  property real waitingProgress: 0
+  property int waitingDuration: 0
+  property bool transitionChecked: false
+  property bool cadenceChecked: false
   property bool failed: false
 
   function fail(message) {
@@ -14,51 +17,101 @@ ShellRoot {
   }
 
   Window {
-    width: 220
-    height: 24
+    width: 460
+    height: 52
     visible: true
     color: "transparent"
 
-    OmaPilot.WaitingIndicator {
-      id: indicator
+    Column {
       anchors.fill: parent
-      active: true
-      streaming: false
-      motionEnabled: true
-      message: streaming ? "Receiving response…" : "Preparing Codex…"
+
+      OmaPilot.WaitingIndicator {
+        id: transitionIndicator
+        width: parent.width
+        height: 24
+        active: true
+        streaming: false
+        motionEnabled: true
+        message: streaming ? "Receiving response…" : "Preparing Codex…"
+      }
+
+      OmaPilot.WaitingIndicator {
+        id: cadenceIndicator
+        width: parent.width
+        height: 24
+        active: true
+        streaming: false
+        motionEnabled: true
+        message: "Preparing Codex…"
+      }
     }
   }
 
   Timer {
-    interval: 80
+    interval: 100
     running: true
     repeat: false
     onTriggered: {
-      root.waitingOffset = indicator.pulseOffset
-      if (!indicator.pulseRunning || root.waitingOffset <= 0)
-        root.fail("waiting sweep did not start")
+      root.waitingProgress = transitionIndicator.pulseProgress
+      root.waitingDuration = transitionIndicator.activePulseDuration
+      if (!transitionIndicator.pulseRunning || root.waitingProgress <= 0)
+        root.fail("waiting energy wave did not start")
 
-      indicator.streaming = true
-      if (!indicator.pulseRunning)
-        root.fail("first token stopped the active sweep")
-      if (!indicator.pulseQueued)
-        root.fail("first token did not queue the streaming pulse")
-      if (indicator.pulseOffset < root.waitingOffset - 2)
-        root.fail("first token reset the active marker")
+      transitionIndicator.streaming = true
+      if (!transitionIndicator.pulseRunning)
+        root.fail("first token stopped the active energy wave")
+      if (!transitionIndicator.pulseQueued)
+        root.fail("first token did not queue the streaming wave")
+      if (transitionIndicator.pulseProgress < root.waitingProgress - 0.03)
+        root.fail("first token reset the active energy wave")
+      if (transitionIndicator.activePulseDuration !== root.waitingDuration)
+        root.fail("first token changed the in-flight wave timing")
 
-      indicator.activityRevision += 1
-      if (!indicator.pulseQueued)
-        root.fail("content event was discarded while the pulse was active")
+      transitionIndicator.activityRevision += 1
+      if (!transitionIndicator.pulseQueued)
+        root.fail("content event was discarded while the wave was active")
 
-      indicator.active = false
-      if (indicator.pulseRunning || indicator.pulseQueued || indicator.pulseOffset !== 0)
+      transitionIndicator.active = false
+      if (transitionIndicator.pulseRunning || transitionIndicator.pulseQueued
+          || transitionIndicator.pulseProgress !== 0
+          || transitionIndicator.waitingCadenceRunning)
         root.fail("inactive motion did not settle")
 
-      indicator.motionEnabled = false
-      indicator.active = true
-      if (indicator.pulseRunning || indicator.pulseQueued || indicator.pulseOffset !== 0)
+      transitionIndicator.motionEnabled = false
+      transitionIndicator.active = true
+      if (transitionIndicator.pulseRunning || transitionIndicator.pulseQueued
+          || transitionIndicator.pulseProgress !== 0
+          || transitionIndicator.waitingCadenceRunning)
         root.fail("reduced motion did not remain settled")
 
+      root.transitionChecked = true
+    }
+  }
+
+  Timer {
+    interval: 900
+    running: true
+    repeat: false
+    onTriggered: {
+      if (cadenceIndicator.pulseRunning)
+        root.fail("waiting wave did not return to its rest state")
+      if (!cadenceIndicator.waitingCadenceRunning)
+        root.fail("waiting rest cadence was not scheduled")
+      if (cadenceIndicator.pulseProgress !== 0)
+        root.fail("waiting wave endpoint did not settle continuously")
+      root.cadenceChecked = true
+    }
+  }
+
+  Timer {
+    interval: 2250
+    running: true
+    repeat: false
+    onTriggered: {
+      if (!cadenceIndicator.pulseRunning || cadenceIndicator.pulseProgress <= 0)
+        root.fail("waiting cadence did not begin its next restrained wave")
+      if (!root.transitionChecked || !root.cadenceChecked)
+        root.fail("motion probe stages did not complete")
       if (!root.failed) console.log("OMAPILOT_MOTION_PROBE_OK")
       Qt.quit()
     }


### PR DESCRIPTION
## Summary

- Replace the translating waiting pill with a fixed-route energy wave whose start and end render identically.
- Use a restrained waiting cadence and content-driven streaming waves with burst coalescing and per-wave timing latches.
- Crossfade waiting/streaming/completion copy, soften the header busy state, and reveal first-token content without layout movement.
- Use `SmoothedAnimation` for continuously retargeted panel height and follow-latest scrolling.
- Add a real-component cadence probe and a ten-frame waiting-to-streaming renderer.

## Root cause

The previous marker had to teleport to the beginning after every traversal. First-token and chunk events queued more traversals, the active duration changed when the phase changed, panel height restarted a fixed animation as streamed lines wrapped, follow-latest assigned each new bottom immediately, and the header used an overshooting busy-state bounce. Those independent timelines made the surface feel visibly rough even though the marker no longer participated in layout.

## Design and behavior

The route geometry is now stationary. Three themed route nodes receive a smooth energy envelope, and the envelope is visually identical at both endpoints, so queued waves can hand off without a reset frame. Waiting waves last 760 ms with a 1320 ms rest; streaming waves last 460 ms and only respond to actual content activity. Bursty revisions coalesce behind the active wave.

All production colors, spacing, type, radii, and easing remain Quattro-native. Reduced-motion injection still settles immediately. No broker, provider, permission, policy, IPC, protocol, persistence, or stable-ID behavior changed.

## Validation

- `./tests/check-ui-contract.sh`
  - 23 protocol/context checks
  - 3 permission-focus checks
  - 8 presentation checks
  - 7 quick-action checks
  - real-component endpoint/cadence/phase/reduced-motion probe
  - ten-frame waiting-to-streaming renderer
  - smoke and headless state renders
- `./scripts/validate.sh` — manifest/release/typecheck/lint/build passed; 136 runtime tests passed and 12 opt-in live-provider tests skipped.
- Two consecutive broker builds were byte-identical.
- `./scripts/package-runtime.sh --dry-run` passed.
- `git diff --check` passed.
- Shellcheck was unavailable and skipped by the repository validator.
- `npm ci` reports unchanged development-server advisories in direct esbuild (low) and Vitest (critical) dependencies; this diff does not change the lockfile or invoke either development server.

## Live gate

The installed plugin and live shell were deliberately left unchanged. Owner validation of real provider waiting duration, bursty streaming cadence, completion/cancellation/error transitions, manual scroll preservation, and reduced-motion behavior remains the next gate.