### PR TITLE
Add focused OmaPilot keyboard navigation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           sudo apt-get install --yes \
             qml6-module-qtquick \
             qml6-module-qtquick-controls \
+            qml6-module-qtqml-workerscript \
             qml6-module-qttest \
             qt6-declarative-dev-tools
       - name: Run keyboard QML tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,22 @@ jobs:
           git clone --filter=blob:none https://github.com/basecamp/omarchy.git /tmp/omarchy
           git -C /tmp/omarchy checkout "$OMARCHY_QUATTRO_COMMIT"
           /tmp/omarchy/bin/omarchy-plugin-validate .
+      - name: Install QML test runtime
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes \
+            qml6-module-qtquick \
+            qml6-module-qtquick-controls \
+            qml6-module-qttest \
+            qt6-declarative-dev-tools
+      - name: Run keyboard QML tests
+        run: |
+          QT_QPA_PLATFORM=offscreen /usr/lib/qt6/bin/qmltestrunner \
+            -input tests/tst_panel_keyboard_navigation.qml \
+            -import .
+          QT_QPA_PLATFORM=offscreen /usr/lib/qt6/bin/qmltestrunner \
+            -input tests/tst_history_keyboard.qml \
+            -import .
       - name: Run shell lint
         uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         with:
@@ -36,6 +52,8 @@ jobs:
         run: ./scripts/check-release-metadata.sh
       - name: Run broker checks
         run: npm run check
+      - name: Verify generated artifacts are current
+        run: git diff --exit-code -- runtime/dist browser-companion/dist
       - name: Broker protocol smoke test
         run: npm test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
             qml6-module-qtquick \
             qml6-module-qtquick-controls \
             qml6-module-qtquick-templates \
+            qml6-module-qtquick-window \
             qml6-module-qtqml-workerscript \
             qml6-module-qttest \
             qt6-declarative-dev-tools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           sudo apt-get install --yes \
             qml6-module-qtquick \
             qml6-module-qtquick-controls \
+            qml6-module-qtquick-templates \
             qml6-module-qtqml-workerscript \
             qml6-module-qttest \
             qt6-declarative-dev-tools

--- a/Panel.qml
+++ b/Panel.qml
@@ -54,6 +54,15 @@ Panel {
   readonly property bool responseActivityActive:
     Quickchat.QuickchatStore.state === "preparing"
     || Quickchat.QuickchatStore.state === "streaming"
+  readonly property bool panelWindowActive: panelFocus.Window.window
+    ? panelFocus.Window.window.active : false
+  readonly property bool modalInteractionActive: composer.popupOpen
+    || Quickchat.QuickchatStore.pendingPermission !== null
+    || root.previewSource !== ""
+    || (root.viewMode === "settings" && settingsView.modalInteractionActive)
+    || (root.viewMode === "history" && historyView.modalInteractionActive)
+  readonly property bool workInAppActionAvailable:
+    ActionCatalog.promptFor(root.quickActionItems, "work-in-app") !== ""
 
   function persistSettings(values) {
     var entry = { id: root.moduleName }
@@ -79,6 +88,12 @@ Panel {
 
   function setQuickActions(actions) {
     persistSettings({ quickActionsJson: ActionCatalog.serializedActions(actions) })
+  }
+
+  function prepareWorkInAppDraft() {
+    var prompt = ActionCatalog.promptFor(root.quickActionItems, "work-in-app")
+    if (prompt === "" || root.viewMode !== "chat" || Quickchat.QuickchatStore.busy) return
+    composer.setDraft(prompt)
   }
 
   function open() {
@@ -235,6 +250,20 @@ Panel {
       id: panelFocus
       anchors.fill: parent
       focus: true
+      Keys.onPressed: function(event) { panelKeyboardNavigation.handleKey(event) }
+
+      QuickchatInternal.PanelKeyboardNavigation {
+        id: panelKeyboardNavigation
+        focusRoot: panelFocus
+        activeFocusItem: panelFocus.Window.window
+          ? panelFocus.Window.window.activeFocusItem : null
+        panelActive: root.opened && root.panelWindowActive
+        modalInteractionActive: root.modalInteractionActive
+        workInAppShortcutEnabled: root.viewMode === "chat"
+          && root.workInAppActionAvailable
+          && !Quickchat.QuickchatStore.busy
+        onWorkInAppRequested: root.prepareWorkInAppDraft()
+      }
 
       ColumnLayout {
         id: chatView
@@ -686,6 +715,7 @@ Panel {
           background: root.surface
           accent: root.accent
           fontFamily: root.fontFamily
+          workInAppShortcutText: "Ctrl+Shift+A"
           onActionRequested: function(actionId, prompt) { composer.setDraft(prompt) }
         }
       }

--- a/components/HistoryView.qml
+++ b/components/HistoryView.qml
@@ -43,6 +43,7 @@ Item {
       }
 
       Button {
+        id: clearHistory
         text: root.confirmingClear ? "Confirm clear" : "Clear all"
         visible: root.history.length > 0
         foreground: root.confirmingClear ? Color.urgent : root.foreground
@@ -105,6 +106,10 @@ Item {
           onChatSelected: function(chat) { root.chatSelected(chat) }
           onDeleteRequested: function(chatId) { root.deleteRequested(chatId) }
           onCloseRequested: root.closeRequested()
+          onConfirmationCancelled: {
+            root.confirmingClear = false
+            clearHistory.forceActiveFocus()
+          }
         }
 
         delegate: BorderSurface {

--- a/components/HistoryView.qml
+++ b/components/HistoryView.qml
@@ -3,6 +3,7 @@ import QtQuick.Layouts
 import qs.Commons
 import qs.Ui
 import "Protocol.js" as Protocol
+import "internal" as QuickchatInternal
 
 Item {
   id: root
@@ -13,6 +14,7 @@ Item {
   property color accent: Color.accent
   property string fontFamily: Style.font.family
   property bool confirmingClear: false
+  readonly property bool modalInteractionActive: confirmingClear
 
   signal chatSelected(var chat)
   signal deleteRequested(string chatId)
@@ -93,19 +95,16 @@ Item {
         activeFocusOnTab: true
         currentIndex: count > 0 ? 0 : -1
 
-        Keys.onPressed: function(event) {
-          if (event.key === Qt.Key_Down) {
-            currentIndex = Math.min(count - 1, currentIndex + 1); event.accepted = true
-          } else if (event.key === Qt.Key_Up) {
-            currentIndex = Math.max(0, currentIndex - 1); event.accepted = true
-          } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
-            if (currentIndex >= 0) root.chatSelected(root.history[currentIndex])
-            event.accepted = true
-          } else if (event.key === Qt.Key_Delete && currentIndex >= 0) {
-            root.deleteRequested(String(root.history[currentIndex].id)); event.accepted = true
-          } else if (event.key === Qt.Key_Escape) {
-            root.closeRequested(); event.accepted = true
-          }
+        Keys.onPressed: function(event) { historyKeyboard.handleKey(event) }
+
+        QuickchatInternal.HistoryListKeyboardHandler {
+          id: historyKeyboard
+          list: list
+          history: root.history
+          confirmingClear: root.confirmingClear
+          onChatSelected: function(chat) { root.chatSelected(chat) }
+          onDeleteRequested: function(chatId) { root.deleteRequested(chatId) }
+          onCloseRequested: root.closeRequested()
         }
 
         delegate: BorderSurface {

--- a/components/QuickActionEditor.qml
+++ b/components/QuickActionEditor.qml
@@ -13,6 +13,7 @@ ColumnLayout {
   property color accent: Color.accent
   property string fontFamily: Style.font.family
   property bool adding: false
+  readonly property bool interactionActive: adding
   readonly property bool atLimit: actions.length >= ActionCatalog.maximumActions
   readonly property bool canSaveNew: String(newLabel.text || "").trim() !== ""
     && String(newPrompt.text || "").trim() !== ""

--- a/components/QuickActions.qml
+++ b/components/QuickActions.qml
@@ -11,6 +11,7 @@ Item {
   property color background: Color.popups.background
   property color accent: Color.accent
   property string fontFamily: Style.font.family
+  property string workInAppShortcutText: ""
   signal actionRequested(string actionId, string prompt)
 
   implicitHeight: actions.length > 0 ? actionFlow.implicitHeight : 0
@@ -30,7 +31,9 @@ Item {
         width: Math.min(implicitWidth, actionFlow.width)
         iconText: String(modelData.icon || "")
         text: String(modelData.label || "")
-        tooltipText: text
+        tooltipText: text + (String(modelData.id || "") === "work-in-app"
+          && root.workInAppShortcutText !== ""
+          ? " (" + root.workInAppShortcutText + ")" : "")
         foreground: root.foreground
         background: root.background
         accent: root.accent

--- a/components/SettingsView.qml
+++ b/components/SettingsView.qml
@@ -26,6 +26,10 @@ Item {
   property bool browserRemoveConfirmation: false
   property bool browserSetupExpanded: false
   readonly property bool popupOpen: providerPicker.popupOpen || modelPicker.popupOpen
+  readonly property bool modalInteractionActive: popupOpen
+    || browserRemoveConfirmation
+    || browserCompanionBusy
+    || quickActionEditor.interactionActive
 
   signal dangerousAutoApproveRequested(bool enabled)
   signal providerChanged(string provider)
@@ -561,6 +565,7 @@ Item {
           }
 
           QuickActionEditor {
+            id: quickActionEditor
             Layout.fillWidth: true
             actions: root.quickActions
             foreground: root.foreground

--- a/components/internal/HistoryListKeyboardHandler.qml
+++ b/components/internal/HistoryListKeyboardHandler.qml
@@ -12,6 +12,8 @@ Item {
   signal closeRequested()
 
   function handleKey(event) {
+    if (event.modifiers !== Qt.NoModifier
+        && event.modifiers !== Qt.KeypadModifier) return
     var directional = event.key === Qt.Key_Down || event.key === Qt.Key_J
       || event.key === Qt.Key_Up || event.key === Qt.Key_K
     if (root.confirmingClear && directional) {

--- a/components/internal/HistoryListKeyboardHandler.qml
+++ b/components/internal/HistoryListKeyboardHandler.qml
@@ -10,13 +10,18 @@ Item {
   signal chatSelected(var chat)
   signal deleteRequested(string chatId)
   signal closeRequested()
+  signal confirmationCancelled()
 
   function handleKey(event) {
     if (event.modifiers !== Qt.NoModifier
         && event.modifiers !== Qt.KeypadModifier) return
     var directional = event.key === Qt.Key_Down || event.key === Qt.Key_J
       || event.key === Qt.Key_Up || event.key === Qt.Key_K
-    if (root.confirmingClear && directional) {
+    var action = directional
+      || event.key === Qt.Key_Return || event.key === Qt.Key_Enter
+      || event.key === Qt.Key_Delete || event.key === Qt.Key_Escape
+    if (root.confirmingClear && action) {
+      if (event.key === Qt.Key_Escape) root.confirmationCancelled()
       event.accepted = true
     } else if (event.key === Qt.Key_Down || event.key === Qt.Key_J) {
       root.list.currentIndex = Math.min(

--- a/components/internal/HistoryListKeyboardHandler.qml
+++ b/components/internal/HistoryListKeyboardHandler.qml
@@ -1,0 +1,38 @@
+import QtQuick
+
+Item {
+  id: root
+
+  required property var list
+  property var history: []
+  property bool confirmingClear: false
+
+  signal chatSelected(var chat)
+  signal deleteRequested(string chatId)
+  signal closeRequested()
+
+  function handleKey(event) {
+    var directional = event.key === Qt.Key_Down || event.key === Qt.Key_J
+      || event.key === Qt.Key_Up || event.key === Qt.Key_K
+    if (root.confirmingClear && directional) {
+      event.accepted = true
+    } else if (event.key === Qt.Key_Down || event.key === Qt.Key_J) {
+      root.list.currentIndex = Math.min(
+        root.list.count - 1, root.list.currentIndex + 1)
+      event.accepted = true
+    } else if (event.key === Qt.Key_Up || event.key === Qt.Key_K) {
+      root.list.currentIndex = Math.max(0, root.list.currentIndex - 1)
+      event.accepted = true
+    } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+      if (root.list.currentIndex >= 0)
+        root.chatSelected(root.history[root.list.currentIndex])
+      event.accepted = true
+    } else if (event.key === Qt.Key_Delete && root.list.currentIndex >= 0) {
+      root.deleteRequested(String(root.history[root.list.currentIndex].id))
+      event.accepted = true
+    } else if (event.key === Qt.Key_Escape) {
+      root.closeRequested()
+      event.accepted = true
+    }
+  }
+}

--- a/components/internal/PanelKeyboardNavigation.qml
+++ b/components/internal/PanelKeyboardNavigation.qml
@@ -1,0 +1,135 @@
+import QtQuick
+
+Item {
+  id: root
+
+  required property Item focusRoot
+  property Item activeFocusItem: null
+  property bool panelActive: false
+  property bool modalInteractionActive: false
+  property bool workInAppShortcutEnabled: false
+
+  signal workInAppRequested()
+
+  function isEditableTextControl(item) {
+    if (!item || item.enabled === false) return false
+    return typeof item.text === "string"
+      && typeof item.cursorPosition === "number"
+      && typeof item.selectionStart === "number"
+      && typeof item.selectionEnd === "number"
+  }
+
+  function directionForKey(key, modifiers) {
+    var unmodified = modifiers === Qt.NoModifier
+      || modifiers === Qt.KeypadModifier
+    if (!unmodified) return ""
+    if (key === Qt.Key_Up || key === Qt.Key_K) return "up"
+    if (key === Qt.Key_Down || key === Qt.Key_J) return "down"
+    if (key === Qt.Key_Left || key === Qt.Key_H) return "left"
+    if (key === Qt.Key_Right || key === Qt.Key_L) return "right"
+    return ""
+  }
+
+  function shouldHandleNavigationKey(key, modifiers, item) {
+    return root.panelActive
+      && !root.modalInteractionActive
+      && !root.isEditableTextControl(item)
+      && root.directionForKey(key, modifiers) !== ""
+  }
+
+  function isFocusableCandidate(item) {
+    return item
+      && item !== root.focusRoot
+      && item.visible
+      && item.enabled
+      && item.activeFocusOnTab
+  }
+
+  function focusChainCandidates(current) {
+    var candidates = []
+    if (!current || typeof current.nextItemInFocusChain !== "function")
+      return candidates
+    var candidate = current.nextItemInFocusChain(true)
+    var remaining = 512
+    while (candidate && candidate !== current && remaining > 0) {
+      if (root.isFocusableCandidate(candidate)) candidates.push(candidate)
+      candidate = candidate.nextItemInFocusChain(true)
+      remaining -= 1
+    }
+    return candidates
+  }
+
+  function centerInFocusRoot(item) {
+    return item.mapToItem(root.focusRoot, item.width / 2, item.height / 2)
+  }
+
+  function spatialCandidate(current, direction) {
+    var origin = root.centerInFocusRoot(current)
+    var candidates = root.focusChainCandidates(current)
+    var best = null
+    var bestScore = Number.POSITIVE_INFINITY
+    for (var i = 0; i < candidates.length; i++) {
+      var point = root.centerInFocusRoot(candidates[i])
+      var dx = point.x - origin.x
+      var dy = point.y - origin.y
+      var primary = 0
+      var cross = 0
+      if (direction === "up" && dy < -1) {
+        primary = -dy; cross = Math.abs(dx)
+      } else if (direction === "down" && dy > 1) {
+        primary = dy; cross = Math.abs(dx)
+      } else if (direction === "left" && dx < -1) {
+        primary = -dx; cross = Math.abs(dy)
+      } else if (direction === "right" && dx > 1) {
+        primary = dx; cross = Math.abs(dy)
+      } else continue
+
+      // Prefer the closest control in the intended row/column, with distance
+      // in the requested direction breaking ties.
+      var score = cross * 4 + primary
+      if (score < bestScore) {
+        best = candidates[i]
+        bestScore = score
+      }
+    }
+    return best
+  }
+
+  function orderedCandidate(current, forward) {
+    if (!current || typeof current.nextItemInFocusChain !== "function") return null
+    var candidate = current.nextItemInFocusChain(forward)
+    var remaining = 512
+    while (candidate && candidate !== current && remaining > 0) {
+      if (root.isFocusableCandidate(candidate)) return candidate
+      candidate = candidate.nextItemInFocusChain(forward)
+      remaining -= 1
+    }
+    return null
+  }
+
+  function moveFocus(current, direction) {
+    if (!current) return false
+    var candidate = root.spatialCandidate(current, direction)
+    if (!candidate) candidate = root.orderedCandidate(
+      current, direction === "right" || direction === "down")
+    if (!candidate) return false
+    candidate.forceActiveFocus(Qt.TabFocusReason)
+    return candidate.activeFocus
+  }
+
+  function handleKey(event) {
+    var item = root.activeFocusItem
+    if (!root.shouldHandleNavigationKey(event.key, event.modifiers, item)) return
+    var direction = root.directionForKey(event.key, event.modifiers)
+    if (root.moveFocus(item, direction)) event.accepted = true
+  }
+
+  Shortcut {
+    sequence: "Ctrl+Shift+A"
+    context: Qt.WindowShortcut
+    enabled: root.panelActive
+      && root.workInAppShortcutEnabled
+      && !root.modalInteractionActive
+    onActivated: root.workInAppRequested()
+  }
+}

--- a/tests/check-ui-contract.sh
+++ b/tests/check-ui-contract.sh
@@ -29,6 +29,8 @@ qml_files=(
   "$repo_dir/components/SettingsView.qml"
   "$repo_dir/components/ResponseActivityBorder.qml"
   "$repo_dir/components/internal/PermissionFocusGuard.qml"
+  "$repo_dir/components/internal/PanelKeyboardNavigation.qml"
+  "$repo_dir/components/internal/HistoryListKeyboardHandler.qml"
   "$repo_dir/components/QuickchatStore.qml"
   "$repo_dir/components/DesktopContext.qml"
   "$repo_dir/components/Protocol.js"
@@ -126,6 +128,20 @@ if [[ -e "$repo_dir/components/ModeSwitch.qml" ]]; then
 fi
 grep -Fq 'visible: Quickchat.QuickchatStore.pendingPermission !== null' "$repo_dir/Panel.qml"
 grep -Fq 'Quickchat.QuickActions {' "$repo_dir/Panel.qml"
+grep -Fq 'workInAppShortcutText: "Ctrl+Shift+A"' "$repo_dir/Panel.qml"
+grep -Fq 'sequence: "Ctrl+Shift+A"' \
+  "$repo_dir/components/internal/PanelKeyboardNavigation.qml"
+if grep -RFq 'Ctrl+Alt+A' "$repo_dir/Panel.qml" "$repo_dir/components"; then
+  printf 'OmaPilot production QML must not retain the AltGr-aliased shortcut\n' >&2
+  exit 1
+fi
+grep -Fq 'var prompt = ActionCatalog.promptFor(root.quickActionItems, "work-in-app")' \
+  "$repo_dir/Panel.qml"
+grep -Fq 'composer.setDraft(prompt)' "$repo_dir/Panel.qml"
+test "$(grep -Fc '&& !Quickchat.QuickchatStore.busy' "$repo_dir/Panel.qml")" -ge 2
+grep -Fq 'modalInteractionActive: root.modalInteractionActive' \
+  "$repo_dir/Panel.qml"
+grep -Fq 'Accessible.name: tooltipText' "$repo_dir/components/QuickActions.qml"
 grep -Fq 'quickActionsJson' "$repo_dir/Panel.qml"
 grep -Fq 'onQuickActionsEdited:' "$repo_dir/Panel.qml"
 grep -Fq 'text: "OmaPilot settings"' "$repo_dir/components/SettingsView.qml"
@@ -256,6 +272,16 @@ QT_QPA_PLATFORM=offscreen /usr/lib/qt6/bin/qmltestrunner \
 
 QT_QPA_PLATFORM=offscreen /usr/lib/qt6/bin/qmltestrunner \
   -input "$repo_dir/tests/tst_permission_focus.qml" \
+  -import "$repo_dir" \
+  -import "$omarchy_shell"
+
+QT_QPA_PLATFORM=offscreen /usr/lib/qt6/bin/qmltestrunner \
+  -input "$repo_dir/tests/tst_panel_keyboard_navigation.qml" \
+  -import "$repo_dir" \
+  -import "$omarchy_shell"
+
+QT_QPA_PLATFORM=offscreen /usr/lib/qt6/bin/qmltestrunner \
+  -input "$repo_dir/tests/tst_history_keyboard.qml" \
   -import "$repo_dir" \
   -import "$omarchy_shell"
 

--- a/tests/tst_history_keyboard.qml
+++ b/tests/tst_history_keyboard.qml
@@ -1,0 +1,52 @@
+import QtQuick
+import QtTest
+import "../components/internal" as QuickchatInternal
+
+Item {
+  id: root
+  width: 640
+  height: 420
+
+  property bool confirmingClear: false
+
+  ListView {
+    id: historyList
+    anchors.fill: parent
+    model: 3
+    activeFocusOnTab: true
+    currentIndex: 0
+    Keys.onPressed: function(event) { historyKeyboard.handleKey(event) }
+    delegate: Rectangle { required property int index; width: 200; height: 40 }
+
+    QuickchatInternal.HistoryListKeyboardHandler {
+      id: historyKeyboard
+      list: historyList
+      confirmingClear: root.confirmingClear
+    }
+  }
+
+  TestCase {
+    name: "OmaPilotHistoryKeyboard"
+    when: windowShown
+
+    function test_confirmationKeepsListSelectionStable() {
+      root.confirmingClear = false
+      historyList.currentIndex = 0
+      historyList.forceActiveFocus()
+      wait(0)
+      verify(historyList.activeFocus)
+      compare(historyList.currentIndex, 0)
+
+      keyClick(Qt.Key_Down)
+      compare(historyList.currentIndex, 1)
+
+      root.confirmingClear = true
+      var guardedKeys = [Qt.Key_Up, Qt.Key_K, Qt.Key_Down, Qt.Key_J]
+      for (var i = 0; i < guardedKeys.length; i++) {
+        keyClick(guardedKeys[i])
+        compare(historyList.currentIndex, 1)
+        verify(historyList.activeFocus)
+      }
+    }
+  }
+}

--- a/tests/tst_history_keyboard.qml
+++ b/tests/tst_history_keyboard.qml
@@ -8,11 +8,21 @@ Item {
   height: 420
 
   property bool confirmingClear: false
+  property var historyItems: [
+    { id: "chat-1", title: "First" },
+    { id: "chat-2", title: "Second" },
+    { id: "chat-3", title: "Third" }
+  ]
+  property int selectedCount: 0
+  property string selectedChatId: ""
+  property int deletedCount: 0
+  property string deletedChatId: ""
+  property int closeCount: 0
 
   ListView {
     id: historyList
     anchors.fill: parent
-    model: 3
+    model: root.historyItems
     activeFocusOnTab: true
     currentIndex: 0
     Keys.onPressed: function(event) { historyKeyboard.handleKey(event) }
@@ -21,7 +31,17 @@ Item {
     QuickchatInternal.HistoryListKeyboardHandler {
       id: historyKeyboard
       list: historyList
+      history: root.historyItems
       confirmingClear: root.confirmingClear
+      onChatSelected: function(chat) {
+        root.selectedCount += 1
+        root.selectedChatId = String(chat.id || "")
+      }
+      onDeleteRequested: function(chatId) {
+        root.deletedCount += 1
+        root.deletedChatId = chatId
+      }
+      onCloseRequested: root.closeCount += 1
     }
   }
 
@@ -29,12 +49,20 @@ Item {
     name: "OmaPilotHistoryKeyboard"
     when: windowShown
 
-    function test_confirmationKeepsListSelectionStable() {
+    function init() {
       root.confirmingClear = false
+      root.selectedCount = 0
+      root.selectedChatId = ""
+      root.deletedCount = 0
+      root.deletedChatId = ""
+      root.closeCount = 0
       historyList.currentIndex = 0
       historyList.forceActiveFocus()
       wait(0)
       verify(historyList.activeFocus)
+    }
+
+    function test_confirmationKeepsListSelectionStable() {
       compare(historyList.currentIndex, 0)
 
       keyClick(Qt.Key_Down)
@@ -47,6 +75,64 @@ Item {
         compare(historyList.currentIndex, 1)
         verify(historyList.activeFocus)
       }
+    }
+
+    function test_keypadModifierRemainsSupported() {
+      var event = {
+        key: Qt.Key_Down,
+        modifiers: Qt.KeypadModifier,
+        accepted: false
+      }
+      historyKeyboard.handleKey(event)
+      verify(event.accepted)
+      compare(historyList.currentIndex, 1)
+    }
+
+    function test_modifiedKeysRemainUnacceptedAndInert() {
+      historyList.currentIndex = 1
+      var modifiedKeys = [
+        Qt.Key_Up, Qt.Key_Down, Qt.Key_J, Qt.Key_K,
+        Qt.Key_Return, Qt.Key_Enter, Qt.Key_Delete, Qt.Key_Escape
+      ]
+      var modifiedStates = [
+        Qt.ShiftModifier, Qt.ControlModifier, Qt.AltModifier,
+        Qt.ControlModifier | Qt.ShiftModifier
+      ]
+      for (var m = 0; m < modifiedStates.length; m++) {
+        for (var i = 0; i < modifiedKeys.length; i++) {
+          var event = {
+            key: modifiedKeys[i],
+            modifiers: modifiedStates[m],
+            accepted: false
+          }
+          historyKeyboard.handleKey(event)
+          verify(!event.accepted)
+          compare(historyList.currentIndex, 1)
+          compare(root.selectedCount, 0)
+          compare(root.deletedCount, 0)
+          compare(root.closeCount, 0)
+        }
+      }
+    }
+
+    function test_plainActionKeysEmitExactSignals() {
+      keyClick(Qt.Key_Down)
+      compare(historyList.currentIndex, 1)
+
+      keyClick(Qt.Key_Return)
+      compare(root.selectedCount, 1)
+      compare(root.selectedChatId, "chat-2")
+
+      keyClick(Qt.Key_Enter)
+      compare(root.selectedCount, 2)
+      compare(root.selectedChatId, "chat-2")
+
+      keyClick(Qt.Key_Delete)
+      compare(root.deletedCount, 1)
+      compare(root.deletedChatId, "chat-2")
+
+      keyClick(Qt.Key_Escape)
+      compare(root.closeCount, 1)
     }
   }
 }

--- a/tests/tst_history_keyboard.qml
+++ b/tests/tst_history_keyboard.qml
@@ -18,6 +18,7 @@ Item {
   property int deletedCount: 0
   property string deletedChatId: ""
   property int closeCount: 0
+  property int cancelledCount: 0
 
   ListView {
     id: historyList
@@ -42,6 +43,10 @@ Item {
         root.deletedChatId = chatId
       }
       onCloseRequested: root.closeCount += 1
+      onConfirmationCancelled: {
+        root.cancelledCount += 1
+        root.confirmingClear = false
+      }
     }
   }
 
@@ -56,6 +61,7 @@ Item {
       root.deletedCount = 0
       root.deletedChatId = ""
       root.closeCount = 0
+      root.cancelledCount = 0
       historyList.currentIndex = 0
       historyList.forceActiveFocus()
       wait(0)
@@ -69,12 +75,23 @@ Item {
       compare(historyList.currentIndex, 1)
 
       root.confirmingClear = true
-      var guardedKeys = [Qt.Key_Up, Qt.Key_K, Qt.Key_Down, Qt.Key_J]
+      var guardedKeys = [
+        Qt.Key_Up, Qt.Key_K, Qt.Key_Down, Qt.Key_J,
+        Qt.Key_Return, Qt.Key_Enter, Qt.Key_Delete
+      ]
       for (var i = 0; i < guardedKeys.length; i++) {
         keyClick(guardedKeys[i])
         compare(historyList.currentIndex, 1)
         verify(historyList.activeFocus)
+        compare(root.selectedCount, 0)
+        compare(root.deletedCount, 0)
+        compare(root.closeCount, 0)
       }
+
+      keyClick(Qt.Key_Escape)
+      compare(root.cancelledCount, 1)
+      verify(!root.confirmingClear)
+      compare(root.closeCount, 0)
     }
 
     function test_keypadModifierRemainsSupported() {

--- a/tests/tst_panel_keyboard_navigation.qml
+++ b/tests/tst_panel_keyboard_navigation.qml
@@ -1,0 +1,271 @@
+import QtQuick
+import QtQuick.Controls
+import QtTest
+import "../components/internal" as QuickchatInternal
+import "../components/QuickActions.js" as ActionCatalog
+
+Item {
+  id: root
+  width: 420
+  height: 400
+  focus: true
+
+  property bool popupOpen: false
+  property bool permissionPending: false
+  property bool confirmationOpen: false
+  property bool panelActive: true
+  property bool busy: false
+  readonly property bool modalInteractionActive: popupOpen
+    || permissionPending
+    || confirmationOpen
+  property int workInAppRequests: 0
+  property int submissions: 0
+  property string draft: ""
+  property var quickActionItems: [{
+    id: "work-in-app",
+    label: "Work in active app",
+    prompt: "In the active app, "
+  }]
+
+  Keys.onPressed: function(event) { navigation.handleKey(event) }
+
+  Button {
+    id: topButton
+    x: 20
+    y: 20
+    width: 120
+    text: "Top"
+  }
+
+  Button {
+    id: rightButton
+    x: 180
+    y: 20
+    width: 120
+    text: "Right"
+  }
+
+  Button {
+    id: downButton
+    x: 20
+    y: 80
+    width: 120
+    text: "Down"
+  }
+
+  TextField {
+    id: lineEditor
+    x: 20
+    y: 140
+    width: 280
+  }
+
+  TextArea {
+    id: multilineEditor
+    x: 20
+    y: 200
+    width: 280
+    height: 90
+  }
+
+  TextArea {
+    id: readOnlyEditor
+    x: 310
+    y: 140
+    width: 100
+    height: 150
+    readOnly: true
+    text: "read\nonly"
+  }
+
+  QuickchatInternal.PanelKeyboardNavigation {
+    id: navigation
+    focusRoot: root
+    activeFocusItem: root.Window.window
+      ? root.Window.window.activeFocusItem : null
+    panelActive: root.panelActive
+    modalInteractionActive: root.modalInteractionActive
+    workInAppShortcutEnabled:
+      ActionCatalog.promptFor(root.quickActionItems, "work-in-app") !== ""
+      && !root.busy
+    onWorkInAppRequested: {
+      var prompt = ActionCatalog.promptFor(root.quickActionItems, "work-in-app")
+      if (prompt === "") return
+      root.workInAppRequests += 1
+      root.draft = prompt
+      lineEditor.text = root.draft
+      lineEditor.forceActiveFocus()
+    }
+  }
+
+  TestCase {
+    name: "OmaPilotPanelKeyboardNavigation"
+    when: windowShown
+
+    function init() {
+      root.popupOpen = false
+      root.permissionPending = false
+      root.confirmationOpen = false
+      root.panelActive = true
+      root.busy = false
+      root.workInAppRequests = 0
+      root.submissions = 0
+      root.draft = ""
+      root.quickActionItems = [{
+        id: "work-in-app",
+        label: "Work in active app",
+        prompt: "In the active app, "
+      }]
+      lineEditor.clear()
+      multilineEditor.clear()
+      readOnlyEditor.text = "read\nonly"
+      readOnlyEditor.cursorPosition = readOnlyEditor.length
+      topButton.forceActiveFocus()
+      wait(0)
+    }
+
+    function test_arrowsAndVimKeysMoveSpatiallyOutsideEditors() {
+      keyClick(Qt.Key_L)
+      verify(rightButton.activeFocus)
+      keyClick(Qt.Key_H)
+      verify(topButton.activeFocus)
+      keyClick(Qt.Key_J)
+      verify(downButton.activeFocus)
+      keyClick(Qt.Key_K)
+      verify(topButton.activeFocus)
+      keyClick(Qt.Key_Right)
+      verify(rightButton.activeFocus)
+      keyClick(Qt.Key_Left)
+      verify(topButton.activeFocus)
+      keyClick(Qt.Key_Down)
+      verify(downButton.activeFocus)
+      keyClick(Qt.Key_Up)
+      verify(topButton.activeFocus)
+    }
+
+    function test_editorsKeepVimTextAndArrowEditing() {
+      lineEditor.forceActiveFocus()
+      keyClick(Qt.Key_H)
+      keyClick(Qt.Key_J)
+      keyClick(Qt.Key_K)
+      keyClick(Qt.Key_L)
+      compare(lineEditor.text, "hjkl")
+      lineEditor.cursorPosition = 2
+      keyClick(Qt.Key_Left)
+      compare(lineEditor.cursorPosition, 1)
+      keyClick(Qt.Key_Right)
+      compare(lineEditor.cursorPosition, 2)
+
+      var arrows = [Qt.Key_Up, Qt.Key_Down, Qt.Key_Left, Qt.Key_Right]
+      for (var i = 0; i < arrows.length; i++)
+        verify(!navigation.shouldHandleNavigationKey(
+          arrows[i], Qt.NoModifier, lineEditor))
+
+      multilineEditor.forceActiveFocus()
+      keyClick(Qt.Key_H)
+      keyClick(Qt.Key_J)
+      keyClick(Qt.Key_K)
+      keyClick(Qt.Key_L)
+      compare(multilineEditor.text, "hjkl")
+      verify(!navigation.shouldHandleNavigationKey(
+        Qt.Key_Up, Qt.NoModifier, multilineEditor))
+      verify(!navigation.shouldHandleNavigationKey(
+        Qt.Key_Down, Qt.NoModifier, multilineEditor))
+    }
+
+    function test_readOnlyEditorKeepsVimKeysAndArrows() {
+      readOnlyEditor.forceActiveFocus()
+      var navigationKeys = [
+        Qt.Key_H, Qt.Key_J, Qt.Key_K, Qt.Key_L,
+        Qt.Key_Up, Qt.Key_Down, Qt.Key_Left, Qt.Key_Right
+      ]
+      for (var i = 0; i < navigationKeys.length; i++) {
+        verify(!navigation.shouldHandleNavigationKey(
+          navigationKeys[i], Qt.NoModifier, readOnlyEditor))
+        keyClick(navigationKeys[i])
+        verify(readOnlyEditor.activeFocus)
+      }
+
+      compare(readOnlyEditor.text, "read\nonly")
+    }
+
+    function test_dropdownAndModalStatesSuppressPanelHandling() {
+      root.popupOpen = true
+      topButton.forceActiveFocus()
+      keyClick(Qt.Key_L)
+      verify(topButton.activeFocus)
+      keyClick(Qt.Key_A, Qt.ControlModifier | Qt.ShiftModifier)
+      compare(root.workInAppRequests, 0)
+      compare(root.draft, "")
+
+      root.popupOpen = false
+      root.permissionPending = true
+      keyClick(Qt.Key_A, Qt.ControlModifier | Qt.ShiftModifier)
+      compare(root.workInAppRequests, 0)
+
+      root.permissionPending = false
+      root.confirmationOpen = true
+      keyClick(Qt.Key_A, Qt.ControlModifier | Qt.ShiftModifier)
+      compare(root.workInAppRequests, 0)
+    }
+
+    function test_inactivePanelDoesNotHandleKeysOrShortcut() {
+      root.panelActive = false
+      topButton.forceActiveFocus()
+      keyClick(Qt.Key_L)
+      verify(topButton.activeFocus)
+      keyClick(Qt.Key_A, Qt.ControlModifier | Qt.ShiftModifier)
+      compare(root.workInAppRequests, 0)
+    }
+
+    function test_nativeTabAndShiftTabRemainAvailable() {
+      topButton.forceActiveFocus()
+      keyClick(Qt.Key_Tab)
+      verify(rightButton.activeFocus)
+      keyClick(Qt.Key_Tab, Qt.ShiftModifier)
+      verify(topButton.activeFocus)
+    }
+
+    function test_oldAltChordDoesNotTriggerFromEditor() {
+      root.draft = "Keep this draft"
+      readOnlyEditor.text = root.draft
+      readOnlyEditor.forceActiveFocus()
+      keySequence("Ctrl+Alt+A")
+      compare(root.workInAppRequests, 0)
+      compare(root.draft, "Keep this draft")
+      compare(readOnlyEditor.text, root.draft)
+      verify(readOnlyEditor.activeFocus)
+      compare(root.submissions, 0)
+    }
+
+    function test_busyDisablesWorkInAppShortcut() {
+      root.draft = "Busy draft"
+      lineEditor.text = root.draft
+      lineEditor.forceActiveFocus()
+      root.busy = true
+      keyClick(Qt.Key_A, Qt.ControlModifier | Qt.ShiftModifier)
+      compare(root.workInAppRequests, 0)
+      compare(root.draft, "Busy draft")
+      compare(lineEditor.text, root.draft)
+      verify(lineEditor.activeFocus)
+      compare(root.submissions, 0)
+    }
+
+    function test_workInAppUsesCustomizedPromptWithoutSubmitting() {
+      root.quickActionItems = [{
+        id: "work-in-app",
+        label: "Inspect active app",
+        prompt: "Inspect the active app, then help me edit: ",
+      }]
+      root.draft = "Replace this draft"
+      lineEditor.text = root.draft
+      lineEditor.forceActiveFocus()
+      keyClick(Qt.Key_A, Qt.ControlModifier | Qt.ShiftModifier)
+      compare(root.workInAppRequests, 1)
+      compare(root.draft, "Inspect the active app, then help me edit: ")
+      compare(lineEditor.text, root.draft)
+      verify(lineEditor.activeFocus)
+      compare(root.submissions, 0)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add focused, panel-local Arrow and `h/j/k/l` navigation over the existing native focus chain
- preserve TextField/TextArea editing, native Tab/Shift+Tab and Escape behavior, and suppress panel handling during popups, permissions, confirmations, and other modal interactions
- add a discoverable panel-local `Ctrl+Shift+A` shortcut that loads the currently configured `work-in-app` prompt into the composer without submitting, and disable it while OmaPilot is busy
- keep history list navigation frozen while clear confirmation is active
- leave modified navigation/action keys unclaimed while retaining unmodified and keypad history behavior
- add focused QML regressions for navigation, editable/read-only typing safety, modal and busy suppression, retired shortcut behavior, customized prompts, history confirmation, and modified-key safety

No Omarchy/Hyprland/global keybindings are added or changed.

## Validation

- `bash tests/check-ui-contract.sh` — passed (61 qmltestrunner cases plus smoke/probe checks)
- focused `qmllint` — passed
- tracked and untracked diff checks — passed
- `./scripts/validate.sh` — manifest and browser-companion checks passed, then stopped because repository dependencies are absent (`tsc: command not found`); `shellcheck` was also unavailable and skipped

Live installed-panel behavior was intentionally not tested or mutated.