### PR TITLE
Add built-in Pi coding agent harness

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+runtime/dist/quickchat-broker.js -whitespace
+runtime/dist/quickchat-broker.js.map -diff -whitespace

--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -174,7 +174,8 @@ BarWidget {
     fontFamily: root.bar ? root.bar.fontFamily : Style.font.family
     onProviderChanged: function(provider) { root.persist({ provider: provider }) }
     onModelChanged: function(provider, model) {
-      var value = {}; value[provider + "Model"] = model; root.persist(value)
+      var key = provider + "Model"
+      var value = {}; value[key] = model; root.persist(value)
     }
     onSubmitted: {
       root.inlineExpanded = false

--- a/Panel.qml
+++ b/Panel.qml
@@ -73,7 +73,6 @@ Panel {
   function selectProvider(provider) {
     var selected = String(provider || "")
     if (selected === "") return
-    Quickchat.QuickchatStore.selectProvider(selected)
     persistSettings({ provider: selected })
   }
 
@@ -157,7 +156,9 @@ Panel {
     return false
   }
 
-  function providerModelKey(provider) { return String(provider) + "Model" }
+  function providerModelKey(provider) {
+    return String(provider) + "Model"
+  }
 
   onSettingsChanged: Quickchat.QuickchatStore.configure(settings)
   Component.onCompleted: Quickchat.QuickchatStore.configure(settings)
@@ -376,7 +377,7 @@ Panel {
               QuickchatInternal.PermissionFocusGuard {
                 permissionId: Quickchat.QuickchatStore.pendingPermission
                   ? String(Quickchat.QuickchatStore.pendingPermission.id || "") : ""
-                defaultTarget: denyPermission
+                defaultTarget: denyPermission.visible ? denyPermission : permissionChoices.itemAt(0)
               }
 
               ColumnLayout {
@@ -390,8 +391,7 @@ Panel {
                 Text {
                   Layout.fillWidth: true
                   text: Quickchat.QuickchatStore.pendingPermission
-                    ? (Quickchat.QuickchatStore.pendingPermission.allowOnce ? "Allow once: " : "Blocked: ")
-                      + Quickchat.QuickchatStore.pendingPermission.title : ""
+                    ? "Approval required: " + Quickchat.QuickchatStore.pendingPermission.title : ""
                   color: root.foreground
                   font.family: root.fontFamily
                   font.pixelSize: Style.font.body
@@ -401,7 +401,7 @@ Panel {
 
                 Text {
                   Layout.fillWidth: true
-                  text: "Review the command and working directory. Allow once may read or change device data and access the network."
+                  text: "Review the exact request and choose how long this agent may retain the approval."
                   color: Qt.darker(root.foreground, 1.45)
                   font.family: root.fontFamily
                   font.pixelSize: Style.font.caption
@@ -432,11 +432,10 @@ Panel {
                   }
                 }
 
-                RowLayout {
+                Flow {
                   Layout.fillWidth: true
+                  Layout.preferredHeight: implicitHeight
                   spacing: Style.spacing.md
-
-                  Item { Layout.fillWidth: true }
 
                   Button {
                     id: denyPermission
@@ -445,20 +444,26 @@ Panel {
                     background: root.surface
                     bordered: true
                     focusable: true
-                    onClicked: Quickchat.QuickchatStore.respondPermission("reject_once")
+                    visible: Quickchat.QuickchatStore.hasPermissionDecision("reject_once")
+                    onClicked: Quickchat.QuickchatStore.respondPermission(
+                      "reject_once", Quickchat.QuickchatStore.permissionChoiceId("reject_once"))
                   }
 
-                  Button {
-                    text: "Allow once"
-                    foreground: root.foreground
-                    background: root.surface
-                    accent: root.accent
-                    active: true
-                    bordered: true
-                    focusable: true
-                    enabled: Quickchat.QuickchatStore.pendingPermission
-                      && Quickchat.QuickchatStore.pendingPermission.allowOnce
-                    onClicked: Quickchat.QuickchatStore.respondPermission("allow_once")
+                  Repeater {
+                    id: permissionChoices
+                    model: Quickchat.QuickchatStore.permissionOptionsWithoutDenyOnce()
+                    delegate: Button {
+                      required property var modelData
+                      id: permissionChoice
+                      text: modelData.label
+                      foreground: root.foreground
+                      background: root.surface
+                      accent: root.accent
+                      active: modelData.decision === "allow_once"
+                      bordered: true
+                      focusable: true
+                      onClicked: Quickchat.QuickchatStore.respondPermission(modelData.decision, modelData.id)
+                    }
                   }
                 }
               }

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ coding tools behind OmaPilot's approval broker. See [Native Pi harness configura
 The Harness setting explicitly selects **Built-in (OmaPilot)**, **Codex**,
 **Claude**, or **OpenCode**. The latter three are ACP harnesses and must already
 be installed and signed in. OmaPilot never substitutes one harness for another.
+When Built-in has no configured credential, its settings card offers
+**Authenticate Built-in**, opens Pi in OmaPilot's private auth directory, and
+keeps the harness unavailable until the user finishes `/login` and selects
+**Retry**.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -29,14 +29,21 @@ compact error notice opens an inspectable details pane.
 - Omarchy Quattro with the native shell plugin architecture.
 - Linux x86-64 for the initial prebuilt runtime.
 - Node.js 22 or newer for the broker and pinned ACP adapters.
-- At least one installed and authenticated harness: `codex`, `claude`, or `opencode`.
+- Credentials for the built-in harness, or an installed and authenticated ACP harness.
 - Optional: Voxtype for dictation and Herdr for durable continuation.
 - `grim` for contextual screenshots. ImageMagick, already used by OmaPilot's
   image policy, validates and normalizes every captured image.
 - Optional: Tesseract adds text-under-the-pointer extraction and the **Text**
   representation. Without it, screenshot and browser-element capture still work.
 
-OmaPilot does not install a harness, log you in, or read provider credentials. Authentication and model availability remain owned by the selected harness. The model picker is populated at startup from Codex's read-only app-server catalog, a non-persisted Claude ACP discovery session, or OpenCode's native catalog; if discovery is unavailable, OmaPilot safely falls back to the harness default.
+OmaPilot includes a native Pi-based harness for Codex subscription, OpenAI API,
+Claude, and configured OpenAI-compatible endpoints. It resolves credentials from
+environment variables or `${XDG_CONFIG_HOME:-$HOME/.config}/omapilot/auth.json`,
+discovers shared `~/.agents` skills and named agents, and exposes Pi's standard
+coding tools behind OmaPilot's approval broker. See [Native Pi harness configuration](docs/native-harness.md).
+The Harness setting explicitly selects **Built-in (OmaPilot)**, **Codex**,
+**Claude**, or **OpenCode**. The latter three are ACP harnesses and must already
+be installed and signed in. OmaPilot never substitutes one harness for another.
 
 ## Install
 
@@ -67,13 +74,17 @@ Omarchy BarWidget/Panel
         │ one JSON command/event per line
         ▼
 OmaPilot broker
-        │ Agent Client Protocol over stdio
-        ├── Codex ACP ── authenticated Codex CLI
-        ├── Claude ACP ─ authenticated Claude harness
-        └── OpenCode ACP ─ authenticated OpenCode CLI
+        ├── Built-in (selected) ─ Pi runtime ─ Codex / OpenAI / Claude / compatible APIs
+        ├── Codex (selected) ─── Codex ACP
+        ├── Claude (selected) ── Claude ACP
+        └── OpenCode (selected) ─ OpenCode ACP
 ```
 
-Codex and Claude use exact, source-pinned official ACP adapter packages bundled in the repository. OpenCode uses its native `opencode acp` command. The broker normalizes provider discovery, streamed text/images, cancellation, permissions, errors, and session identities; QML does not parse provider-specific output.
+The native runtime owns model discovery, auth resolution and refresh, skills,
+named agents, streaming, and Pi tool execution. The explicitly selected Codex
+and Claude ACP routes use exact, source-pinned adapter packages; OpenCode uses
+`opencode acp`.
+The broker normalizes both paths so QML does not parse provider-specific output.
 
 Every request uses the selected harness and its reviewed automatic policy.
 OmaPilot displays each exact device approval, or auto-selects its allow-once
@@ -81,28 +92,35 @@ option when the dangerous setting is enabled.
 Every harness can load relevant installed skills and decide whether a tool is
 needed:
 
-- **Codex** may use its read-only device tools and read files available to the
+- **Built-in (OmaPilot)** combines available Codex, OpenAI, Claude, and
+  OpenAI-compatible models in one catalog and loads
+  declarative skills and named agents from the documented `~/.agents` roots.
+  Pi's read, grep, find, and list tools may read files available to the current
+  user. Bash, edit, and write require review unless an exact session or durable
+  grant already exists. Executable Pi extensions are not loaded.
+- **Codex ACP** may use its read-only device tools and read files available to the
   current user without asking. Native web search stays disabled in the same
   session so those reads cannot become unapproved search queries. Any command
-  requesting network or broader device authority pauses behind an exact
-  **Allow once** or **Deny** card showing the adapter-normalized command and
-  working directory.
-- **Claude** may load installed skills from a disposable, MCP-free plugin copy,
+  requesting network or broader device authority pauses behind a card showing
+  the adapter-normalized command, working directory, and every provider-native
+  once, session, durable, or rejection choice supplied by the adapter.
+- **Claude ACP** may load installed skills from a disposable, MCP-free plugin copy,
   search the web, and run commands inside a disposable
   scratch workspace. Host paths and credential-bearing environment variables
   stay hidden, direct process network access is blocked, and writes remain
   confined to per-turn scratch. Commands inside that fixed boundary may run
   automatically. A command that needs host/device authority pauses behind the
-  same exact **Allow once** or **Deny** card. Approval applies only to that
-  command and runs it outside the disposable sandbox with the current user's
+  same broker-bound provider choices. An approval runs it outside the
+  disposable sandbox with the current user's
   device, network, host-file, and process-environment authority.
-- **OpenCode** may load installed skills and use its positively identified web
+- **OpenCode ACP** may load installed skills and use its positively identified web
   search tool automatically. Its native `bash` permission is fixed to `ask`;
   the broker accepts execution only after the exact command receives a
   request-bound **Allow once** decision. Other OpenCode tools remain denied.
 
-Every supported permission decision is bound to the exact in-flight request.
-Oversized or visually ambiguous requests, persistent grants, arbitrary MCP,
+Every supported permission decision is bound to a provider option. Native Pi
+session and durable grants match only the exact reviewed request and working
+directory. Oversized or visually ambiguous requests, arbitrary MCP,
 browser/computer control, unclassified tools, and uninspectable targets remain
 blocked. OmaPilot removes its per-turn working directory afterward. Raw tool
 requests, decisions, inputs, and outputs are not stored in chat history; a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,18 +8,27 @@ Security fixes are provided for the current OmaPilot release.
 
 Omarchy plugins run unsandboxed inside the long-lived `omarchy-shell` process. Review OmaPilot before enabling it. OmaPilot minimizes that authority by delegating provider traffic to a separate broker process and starting each agent with one provider-specific, fail-closed automatic policy.
 
+- The embedded Pi harness loads declarative skills, context files, and named
+  agent profiles from the standard `~/.agents` roots. It does not
+  auto-load executable Pi extensions. Read, grep, find, and list tools use the
+  current user's read authority. Every Pi bash, edit, and write call—including
+  calls made by a named agent—is intercepted before execution and requires the
+  broker's reviewed decision. Session and durable Pi grants match only the exact
+  request and working directory; durable records contain hashes, not commands.
+  Named agents cannot delegate recursively.
+
 - Codex starts in read-only, on-request mode with native web search disabled and only the
   strictly validated shell/unified-exec and skill-search features. It may read any file the current user can
   read without asking. Tool output is sent to Codex and may be retained in the
   saved answer. A request for broader access pauses behind the adapter-normalized
-  command and working directory, and only its provider-native allow-once or
-  reject-once decision is exposed.
+  command and working directory, and its provider-native approval choices are
+  exposed without collapsing their option identities.
   Approval can execute the command outside the read-only sandbox with the
   current user's authority, including host reads, state changes, and network
   access; the UI states this explicitly. When the user explicitly enables
   **Dangerous auto-approve**, each request may select the normalized request's
-  exact provider-native allow-once option without prompting. Persistent grants
-  are never exposed.
+  exact provider-native allow-once option without prompting. It never selects a
+  session or durable grant.
 - Claude loads installed skills through a per-turn plugin copy with MCP discovery
   disabled. Internal symlinks, oversized trees, and non-regular entries are
   skipped. It runs inside a disposable workspace that denies
@@ -28,8 +37,8 @@ Omarchy plugins run unsandboxed inside the long-lived `omarchy-shell` process. R
   per-turn scratch. WebSearch is available, while WebFetch and direct process
   network access remains blocked. Commands inside that fixed boundary may run
   automatically. A command that cannot run inside that boundary may proceed
-  only through the broker's exact allow-once device approval. Approving that
-  command explicitly lets it run outside the disposable sandbox with the
+  only through a broker-bound choice supplied by the Claude adapter. Approving
+  it explicitly lets it run outside the disposable sandbox with the
   current user's full process environment and device authority, including host
   reads, writes, credential-bearing environment variables, and network access.
 - OpenCode may load its positively identified skill tool and use websearch
@@ -43,10 +52,15 @@ Omarchy plugins run unsandboxed inside the long-lived `omarchy-shell` process. R
   device-approval policy and the same execute-kind, complete-input, and
   allow-once normalization. Missing or unreviewable choices are cancelled;
   blocked providers do not gain tool authority from this setting.
-- Arbitrary MCP, browser/computer control, subagents, unclassified requests, and requests
-  without an inspectable target are denied. Codex may edit, delete, move, or otherwise
-  mutate user-accessible state only after exact allow-once command approval.
-- Provider authentication remains in the installed harness. OmaPilot must not log, copy, or persist credential output.
+- Arbitrary MCP, browser/computer control, unclassified requests, and requests
+  without an inspectable target are denied. Codex may edit, delete, move, or
+  otherwise mutate user-accessible state only after an explicit provider-native
+  approval whose displayed label defines its duration.
+- Built-in authentication is resolved in memory by Pi from environment
+  variables or `${XDG_CONFIG_HOME:-$HOME/.config}/omapilot/auth.json`; authentication for an explicitly selected ACP harness remains in that
+  installed harness. OmaPilot must not log, copy, or persist credential output.
+  Credential entries may intentionally reference user-configured commands, so
+  `auth.json` is trusted executable configuration and must be user-owned.
 - Adapter bundles are generated from exact package-lock versions and reviewed as tracked files in the same Git commit as their source. Published release archives add SHA-256 verification, provenance, and an SBOM; the runtime does not download or replace adapters.
 - Remote images require a user action and are subject to scheme, redirect, address, MIME, byte-size, complete decode, pixel-area, and cache-quota checks before Quickshell sees them.
 - Context capture is an explicit overlay gesture. The active target is latched

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -4,6 +4,7 @@ OmaPilot's source is MIT licensed. Release bundles include third-party software 
 
 | Component | Pinned release | License | Source |
 | --- | --- | --- | --- |
+| Pi Coding Agent | `@earendil-works/pi-coding-agent@0.84.2` | MIT | <https://github.com/earendil-works/pi> |
 | Codex ACP | `@agentclientprotocol/codex-acp@1.1.14` | Apache-2.0 | <https://github.com/agentclientprotocol/codex-acp> |
 | Claude Agent ACP | `@agentclientprotocol/claude-agent-acp@0.66.0` | Apache-2.0 | <https://github.com/agentclientprotocol/claude-agent-acp> |
 | OpenCode ACP | Supplied by the user's installed OpenCode harness | See installed OpenCode distribution | <https://opencode.ai> |

--- a/components/ErrorDetailsView.qml
+++ b/components/ErrorDetailsView.qml
@@ -186,6 +186,19 @@ Item {
             Item { Layout.fillWidth: true }
 
             Button {
+              visible: root.backend && root.backend.provider === "builtin"
+                && root.backend.providers.length === 0
+              text: "Authenticate Built-in"
+              foreground: root.foreground
+              background: root.background
+              accent: root.accent
+              active: true
+              bordered: true
+              focusable: true
+              onClicked: root.backend.authenticateBuiltIn()
+            }
+
+            Button {
               visible: root.backend && root.backend.canRetry
               text: "Restart OmaPilot"
               foreground: root.foreground

--- a/components/Protocol.js
+++ b/components/Protocol.js
@@ -21,7 +21,7 @@ function submitCommand(id, question, provider, model, desktopContext, dangerousA
   var payload = command("submit", {
     id: String(id || ""),
     question: String(question || ""),
-    provider: normalizedProvider(provider) || "codex"
+    provider: normalizedProvider(provider) || "builtin"
   })
   var selectedModel = String(model || "").trim()
   if (selectedModel !== "") payload.model = selectedModel
@@ -331,11 +331,18 @@ function errorDiagnosticText(raw) {
 
 function normalizedProvider(value) {
   var provider = String(value || "").toLowerCase()
-  return ["codex", "claude", "opencode"].indexOf(provider) >= 0 ? provider : ""
+  return ["builtin", "codex", "claude", "opencode"].indexOf(provider) >= 0 ? provider : ""
+}
+
+function harnessOptions() {
+  return ["builtin", "codex", "claude", "opencode"].map(function(value) {
+    return { value: value, label: providerLabel(value) }
+  })
 }
 
 function providerLabel(value) {
   var provider = normalizedProvider(value)
+  if (provider === "builtin") return "Built-in (OmaPilot)"
   if (provider === "codex") return "Codex"
   if (provider === "claude") return "Claude"
   if (provider === "opencode") return "OpenCode"
@@ -422,8 +429,22 @@ function normalizedPermission(raw, currentRequestId) {
     kind: kind,
     authority: "device",
     detail: String(value.detail || "").slice(0, 3000),
-    allowOnce: value.allowOnce === true
+    options: normalizedPermissionOptions(value.options)
   }
+}
+
+function normalizedPermissionOptions(raw) {
+  var values = Array.isArray(raw) ? raw : []
+  var supported = ["allow_once", "allow_session", "allow_always", "reject_once", "reject_always"]
+  var result = []
+  for (var i = 0; i < values.length; i++) {
+    var decision = String(values[i] && values[i].decision || "")
+    if (supported.indexOf(decision) < 0) continue
+    var id = String(values[i] && values[i].id || "")
+    if (!/^option-[0-9]{1,3}$/.test(id)) continue
+    result.push({ id: id, decision: decision, label: String(values[i].label || "").slice(0, 48) })
+  }
+  return result
 }
 
 function isSafeExternalUrl(url) {
@@ -565,7 +586,7 @@ function normalizedHistory(input) {
       title: String(row.title || row.question || "Untitled question"),
       question: String(row.question || ""),
       answer: String(row.answer || row.markdown || ""),
-      provider: normalizedProvider(row.provider) || "codex",
+      provider: normalizedProvider(row.provider) || "builtin",
       model: String(row.model || ""),
       timestamp: String(row.createdAt || row.timestamp || ""),
       images: Array.isArray(row.images) ? row.images : [],

--- a/components/QuickchatStore.qml
+++ b/components/QuickchatStore.qml
@@ -32,7 +32,7 @@ Scope {
   property var images: []
   property var providers: []
   property var history: []
-  property string provider: "codex"
+  property string provider: "builtin"
   property string model: ""
   property var pendingPermission: null
   property var permissionQueue: []
@@ -42,7 +42,8 @@ Scope {
   property bool processStarted: false
   property var queuedCommands: []
   property string stderrTail: ""
-  property string configuredProvider: "codex"
+  property string configuredProvider: "builtin"
+  property string configuredBuiltinModel: ""
   property string configuredCodexModel: ""
   property string configuredClaudeModel: ""
   property string configuredOpencodeModel: ""
@@ -53,6 +54,7 @@ Scope {
   property var latchedCaptureTarget: null
   property var contextAttachments: []
   property bool brokerContextAttachmentsSupported: false
+  property bool harnessRestartPending: false
   property string pendingContextRequestId: ""
   property var browserCompanionStatus: ({
     phase: "ready", relayInstalled: false, setupAvailable: false,
@@ -62,7 +64,7 @@ Scope {
 
   readonly property bool busy: state === "preparing" || state === "dictating" || state === "streaming" || state === "stopping"
   readonly property bool canSubmit: initialized && providers.length > 0 && !busy
-  readonly property bool canRetry: !processStarted && !broker.running && state === "unavailable"
+  readonly property bool canRetry: state === "unavailable" && (!processStarted || providers.length === 0)
   readonly property var modelOptions: Protocol.modelOptions(providers, provider)
   readonly property var providerPolicy: Protocol.providerPolicy(providers, provider)
   readonly property bool desktopContextActive: desktopContextEnabled && brokerDesktopContextSupported
@@ -94,13 +96,16 @@ Scope {
 
   function configure(settings) {
     var source = settings || {}
-    var desiredProvider = Protocol.normalizedProvider(source.provider) || "codex"
+    var desiredProvider = Protocol.normalizedProvider(source.provider) || "builtin"
+    var desiredBuiltinModel = String(source.builtinModel || "")
     var desiredCodexModel = String(source.codexModel || "")
     var desiredClaudeModel = String(source.claudeModel || "")
     var desiredOpencodeModel = String(source.opencodeModel || "")
     var desiredDangerousAutoApprove = source.dangerousAutoApprove === true
     var desiredDesktopContext = String(source.desktopContext || "On") !== "Off"
-    var changed = desiredProvider !== configuredProvider
+    var harnessChanged = desiredProvider !== configuredProvider
+    var changed = harnessChanged
+      || desiredBuiltinModel !== configuredBuiltinModel
       || desiredCodexModel !== configuredCodexModel
       || desiredClaudeModel !== configuredClaudeModel
       || desiredOpencodeModel !== configuredOpencodeModel
@@ -108,17 +113,29 @@ Scope {
       || desiredDesktopContext !== desktopContextEnabled
     if (!changed) return
     configuredProvider = desiredProvider
+    configuredBuiltinModel = desiredBuiltinModel
     configuredCodexModel = desiredCodexModel
     configuredClaudeModel = desiredClaudeModel
     configuredOpencodeModel = desiredOpencodeModel
     configuredDangerousAutoApprove = desiredDangerousAutoApprove
     desktopContextEnabled = desiredDesktopContext
     if (!desktopContextEnabled) latchedActiveWindow = null
-    if (providers.length === 0 || providerAvailable(desiredProvider)) provider = desiredProvider
+    provider = desiredProvider
     var desiredModel = desiredProvider === "claude" ? desiredClaudeModel
       : desiredProvider === "opencode" ? desiredOpencodeModel : desiredCodexModel
+    if (desiredProvider === "builtin") desiredModel = desiredBuiltinModel
     model = desiredModel
     if (providers.length > 0) selectProvider(provider)
+    if (harnessChanged && processStarted) restartForHarnessChange()
+  }
+
+  function restartForHarnessChange() {
+    harnessRestartPending = true
+    initialized = false
+    providers = []
+    state = "preparing"
+    statusMessage = "Starting " + Protocol.providerLabel(provider) + "…"
+    broker.running = false
   }
 
   function providerAvailable(value) {
@@ -162,6 +179,7 @@ Scope {
   function initialize() {
     sendCommand(Protocol.command("initialize", {
       protocolVersion: protocolVersion,
+      harness: provider,
       client: "omarchy-quickchat"
     }))
   }
@@ -303,14 +321,36 @@ Scope {
     sendCommand(Protocol.command("cancel", { id: currentId }))
   }
 
-  function respondPermission(decision) {
+  function respondPermission(decision, choiceId) {
     if (!pendingPermission || !currentId) return
-    var selected = decision === "allow_once" ? "allow_once" : "reject_once"
     sendCommand(Protocol.command("permission_response", {
       id: currentId,
       permissionId: String(pendingPermission.id || ""),
-      decision: selected
+      choiceId: String(choiceId || ""),
+      decision: String(decision || "reject_once")
     }))
+  }
+
+  function permissionOptionsWithoutDenyOnce() {
+    var options = pendingPermission && Array.isArray(pendingPermission.options) ? pendingPermission.options : []
+    var result = []
+    for (var i = 0; i < options.length; i++)
+      if (options[i].decision !== "reject_once") result.push(options[i])
+    return result
+  }
+
+  function hasPermissionDecision(decision) {
+    var options = pendingPermission && Array.isArray(pendingPermission.options) ? pendingPermission.options : []
+    for (var i = 0; i < options.length; i++)
+      if (options[i].decision === decision) return true
+    return false
+  }
+
+  function permissionChoiceId(decision) {
+    var options = pendingPermission && Array.isArray(pendingPermission.options) ? pendingPermission.options : []
+    for (var i = 0; i < options.length; i++)
+      if (options[i].decision === decision) return String(options[i].id || "")
+    return ""
   }
 
   function closePermission(permissionId) {
@@ -361,7 +401,10 @@ Scope {
     statusMessage = "Restarting OmaPilot…"
     errorDetails = null
     stderrTail = ""
-    broker.running = true
+    if (broker.running) {
+      harnessRestartPending = true
+      broker.running = false
+    } else broker.running = true
   }
 
   function activateLink(url) {
@@ -407,12 +450,15 @@ Scope {
     providers = Protocol.normalizeProviders(raw)
     if (providers.length === 0) {
       state = "unavailable"
-      statusMessage = "Sign in to Codex, Claude, or OpenCode to begin."
+      var configHome = Quickshell.env("XDG_CONFIG_HOME") || (Quickshell.env("HOME") + "/.config")
+      statusMessage = provider === "builtin"
+        ? "Built-in (OmaPilot) needs authentication. In a terminal run PI_CODING_AGENT_DIR=\"" + configHome + "/omapilot\" pi, choose /login, then Retry."
+        : Protocol.providerLabel(provider) + " is unavailable. Install and sign in to it, then retry or choose another harness in Settings."
       errorDetails = Protocol.normalizedError({
         unavailable: true,
         code: "provider_unavailable",
         message: statusMessage,
-        retryable: false
+        retryable: true
       })
       return
     }
@@ -687,6 +733,11 @@ Scope {
       root.initialized = false
       root.pendingPermission = null
       root.permissionQueue = []
+      if (root.harnessRestartPending) {
+        root.harnessRestartPending = false
+        Qt.callLater(function() { broker.running = true })
+        return
+      }
       if (root.state !== "canceled") root.state = "unavailable"
       root.statusMessage = root.stderrTail || "OmaPilot is unavailable."
       root.errorDetails = Protocol.normalizedError({

--- a/components/QuickchatStore.qml
+++ b/components/QuickchatStore.qml
@@ -21,6 +21,10 @@ Scope {
     return url
   }
   readonly property string brokerPath: Quickshell.env("QUICKCHAT_BROKER_PATH") || bundledBrokerPath
+  readonly property string builtinAuthDirectory: {
+    var configHome = Quickshell.env("XDG_CONFIG_HOME") || (Quickshell.env("HOME") + "/.config")
+    return configHome + "/omapilot"
+  }
 
   property string state: "preparing"
   property string statusMessage: "Starting OmaPilot…"
@@ -407,6 +411,19 @@ Scope {
     } else broker.running = true
   }
 
+  function authenticateBuiltIn() {
+    if (provider !== "builtin") return
+    try {
+      Quickshell.execDetached([
+        "omarchy", "launch", "terminal", "env",
+        "PI_CODING_AGENT_DIR=" + builtinAuthDirectory, "pi"
+      ])
+      toastRequested("In Pi, enter /login and choose a provider. Return here and select Retry when finished.")
+    } catch (error) {
+      toastRequested("Could not open Pi. Install the pi command, then retry authentication.")
+    }
+  }
+
   function activateLink(url) {
     var value = String(url || "")
     if (Protocol.isImageLink(value)) {
@@ -450,9 +467,8 @@ Scope {
     providers = Protocol.normalizeProviders(raw)
     if (providers.length === 0) {
       state = "unavailable"
-      var configHome = Quickshell.env("XDG_CONFIG_HOME") || (Quickshell.env("HOME") + "/.config")
       statusMessage = provider === "builtin"
-        ? "Built-in (OmaPilot) needs authentication. In a terminal run PI_CODING_AGENT_DIR=\"" + configHome + "/omapilot\" pi, choose /login, then Retry."
+        ? "Built-in (OmaPilot) needs authentication. Choose Authenticate, enter /login in Pi, then return and select Retry."
         : Protocol.providerLabel(provider) + " is unavailable. Install and sign in to it, then retry or choose another harness in Settings."
       errorDetails = Protocol.normalizedError({
         unavailable: true,

--- a/components/SettingsView.qml
+++ b/components/SettingsView.qml
@@ -14,7 +14,7 @@ Item {
   property color background: Color.popups.background
   property color accent: Color.accent
   property string fontFamily: Style.font.family
-  readonly property var modeProviders: backend ? backend.providers : []
+  readonly property var modeProviders: Protocol.harnessOptions()
   readonly property var browserCompanion: backend && backend.browserCompanionStatus
     ? backend.browserCompanionStatus : ({
       phase: "ready", relayInstalled: false, setupAvailable: false,
@@ -476,10 +476,10 @@ Item {
             showLabel: false
             options: root.modeProviders
             value: root.backend ? root.backend.provider : ""
-            enabled: root.backend && !root.backend.busy && root.modeProviders.length > 0
+            enabled: root.backend && !root.backend.busy
             foreground: root.foreground
             background: root.background
-            Accessible.name: "AI harness"
+            Accessible.name: "Agent harness"
             onChanged: function(value) { root.providerChanged(value) }
           }
 

--- a/components/SettingsView.qml
+++ b/components/SettingsView.qml
@@ -483,6 +483,76 @@ Item {
             onChanged: function(value) { root.providerChanged(value) }
           }
 
+          BorderSurface {
+            Layout.fillWidth: true
+            visible: root.backend && root.backend.provider === "builtin"
+              && root.backend.state === "unavailable" && root.backend.providers.length === 0
+            implicitHeight: authContent.implicitHeight + contentTopInset + contentBottomInset
+              + Style.spacing.xl * 2
+            color: Style.normalFillFor(root.accent, root.accent)
+            borderSpec: Border.controlSpec("normal", root.accent, root.accent)
+            radius: Style.cornerRadius
+
+            ColumnLayout {
+              id: authContent
+              anchors.left: parent.left
+              anchors.right: parent.right
+              anchors.top: parent.top
+              anchors.leftMargin: parent.contentLeftInset + Style.spacing.xl
+              anchors.rightMargin: parent.contentRightInset + Style.spacing.xl
+              anchors.topMargin: parent.contentTopInset + Style.spacing.xl
+              spacing: Style.spacing.md
+
+              Text {
+                Layout.fillWidth: true
+                text: "Authentication required"
+                color: root.foreground
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.body
+                font.bold: true
+              }
+
+              Text {
+                Layout.fillWidth: true
+                text: "OmaPilot will open Pi using its private auth directory. Enter /login, choose Codex, OpenAI, Claude, or another configured provider, finish authentication, then return here."
+                color: Qt.darker(root.foreground, 1.35)
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.caption
+                wrapMode: Text.Wrap
+                Accessible.role: Accessible.StaticText
+                Accessible.name: text
+              }
+
+              RowLayout {
+                Layout.fillWidth: true
+                spacing: Style.spacing.md
+
+                Button {
+                  text: "Authenticate Built-in"
+                  iconText: "󰌾"
+                  foreground: root.foreground
+                  background: root.background
+                  accent: root.accent
+                  active: true
+                  bordered: true
+                  focusable: true
+                  onClicked: root.backend.authenticateBuiltIn()
+                }
+
+                Button {
+                  text: "Retry"
+                  foreground: root.foreground
+                  background: root.background
+                  bordered: true
+                  focusable: true
+                  onClicked: root.backend.retryBroker()
+                }
+
+                Item { Layout.fillWidth: true }
+              }
+            }
+          }
+
           Text {
             Layout.fillWidth: true
             text: "Model"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,7 +20,7 @@ Quickchat does not edit `shell.json`, Omarchy sources, Hyprland configuration, V
 
 ## Process boundary
 
-The UI starts a separate Quickchat broker and communicates using newline-delimited JSON on stdin/stdout. The broker owns provider discovery and authentication readiness, ACP lifecycle, permission handling, streaming, cancellation, validation, history, and optional integration commands. Provider stderr is diagnostic input and must never be forwarded to persisted history without redaction.
+The UI starts a separate Quickchat broker and communicates using newline-delimited JSON on stdin/stdout. The broker owns selected-harness discovery and authentication readiness, the embedded Pi lifecycle, ACP lifecycle, permission handling, streaming, cancellation, validation, history, and optional integration commands. Provider stderr is diagnostic input and must never be forwarded to persisted history without redaction.
 
 The reviewed plugin revision contains self-contained broker and adapter bundles usable immediately after a plain clone. Release builds package those tracked bundles into a deterministic, checksum-addressed `linux-x86_64` archive with lockfile-derived SBOM and provenance. Omarchy itself still performs no install hook. Contributors use `npm ci && npm run build` to reproduce checked-in bundles; missing or incompatible runtimes fail closed.
 
@@ -32,7 +32,9 @@ The UI sends commands whose `type` is one of `initialize`, `submit`, `context_be
 
 The broker emits events whose `type` is one of `ready`, `providers`, `state`, `content`, `context_ready`, `context_attachment`, `permission`, `permission_closed`, `image`, `complete`, `error`, `dictation`, `history`, `herdr`, `link`, or `copied`. The broker's protocol tests are authoritative for exact fields and version negotiation.
 
-ACP is the broker's normalization boundary, not the policy boundary. The submit
+The broker's internal run contract is the normalization boundary, not the policy
+boundary. Initialization selects exactly one harness: the embedded Pi runtime
+or one ACP harness. Discovery failure never switches harnesses. The submit
 command contains provider/model/question plus an optional versioned desktop
 snapshot and up to four opaque context-attachment selections. QML latches the active app and
 its capture rectangle immediately before the panel takes focus
@@ -129,18 +131,19 @@ fail-closed policy for that provider. Codex keeps the pinned adapter's read-only
 on-request mode, disables native web search, and exposes only its strictly validated
 shell/unified-exec and skill-search features. It may read any user-readable host file without
 asking; tool output is sent to Codex and may be retained in the saved answer.
-Each broader-access request is bound to a broker nonce. The UI exposes only
-provider-native allow-once or reject-once; approval may run that exact command
-with current-user device and network authority. Claude copies bounded, regular-file
+Each broader-access request is bound to a broker nonce. The UI preserves the
+provider's allow/reject option identities and distinguishes session labels from
+durable labels; approval may run commands with current-user device and network
+authority for the scope stated by that option. Claude copies bounded, regular-file
 installed skill trees into a per-turn local plugin with MCP discovery disabled,
 then uses a disposable
 workspace that dynamically denies every existing top-level host path except
 system executable/library roots, hides credential-bearing environment variables,
 blocks direct process network access and WebFetch, confines writes to per-turn
 scratch, and allows WebSearch. Commands inside that boundary may run
-automatically. An exact Claude command that needs device authority accepts a
-broker-bound allow-once or reject-once decision. Allowing it runs that exact
-command outside the disposable sandbox with the current user's full device,
+automatically. A Claude command that needs device authority accepts the
+broker-bound choices offered by its adapter. Allowing it runs outside the
+disposable sandbox with the current user's full device,
 network, host-file, and process-environment authority. OpenCode automatically permits
 only its exact skill and websearch identities. Its native bash permission is
 fixed to `ask`; the broker correlates the pending execution, permission request,

--- a/docs/native-harness.md
+++ b/docs/native-harness.md
@@ -1,0 +1,136 @@
+# Native Pi harness
+
+OmaPilot embeds a Pi coding-agent runtime. It does not require an external CLI for
+OpenAI API, Codex subscription, Anthropic, or OpenAI-compatible requests. The
+Codex, Claude, and OpenCode are separate ACP harness choices. They are never
+used as fallbacks for the built-in harness.
+
+## Configuration directory
+
+The native harness keeps OmaPilot-owned configuration under
+`${XDG_CONFIG_HOME:-$HOME/.config}/omapilot/`. Set `OMAPILOT_CONFIG_DIR` to an
+absolute path before starting Omarchy to use another location. Shared skills
+and named agents are discovered from `~/.agents/` (or `OMAPILOT_AGENTS_DIR`).
+
+```text
+~/.config/omapilot/
+├── auth.json
+├── models.json
+├── models-store.json
+└── approvals.json
+
+~/.agents/
+├── skills/example/SKILL.md
+└── agents/reviewer.md
+```
+
+Credentials are resolved by Pi's model runtime and are never copied to OmaPilot
+history. OAuth credentials refresh through the provider flow. API keys can come
+from `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `auth.json`:
+
+```json
+{
+  "openai": { "type": "api_key", "key": "$OPENAI_API_KEY" },
+  "anthropic": { "type": "api_key", "key": "$ANTHROPIC_API_KEY" }
+}
+```
+
+Codex subscription and Claude subscription OAuth entries use the
+`openai-codex` and `anthropic` keys respectively. A Pi CLI can initialize them
+in the same directory:
+
+```bash
+PI_CODING_AGENT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/omapilot" pi
+```
+
+Use Pi's `/login` command, exit Pi, then choose **Retry** in OmaPilot so provider
+discovery sees the new credential. OmaPilot never downloads or launches the Pi
+CLI; this is an explicit user-owned setup action.
+
+## OpenAI-compatible providers
+
+Add compatible endpoints to `${XDG_CONFIG_HOME:-$HOME/.config}/omapilot/models.json`. Providers using
+`openai-completions` or `openai-responses` appear as namespaced entries in the
+**Built-in (OmaPilot)** model picker.
+
+```json
+{
+  "providers": {
+    "local": {
+      "baseUrl": "http://127.0.0.1:11434/v1",
+      "api": "openai-completions",
+      "apiKey": "local-only-placeholder",
+      "compat": {
+        "supportsDeveloperRole": false,
+        "supportsReasoningEffort": false
+      },
+      "models": [
+        {
+          "id": "qwen-coder",
+          "name": "Qwen Coder",
+          "contextWindow": 131072,
+          "maxTokens": 16384
+        }
+      ]
+    }
+  }
+}
+```
+
+Remote compatible endpoints should use an environment reference or credential
+entry rather than a literal secret. Model IDs are namespaced internally so two
+configured providers may expose the same upstream model ID.
+
+## Skills and context
+
+The harness uses the Agent Skills `SKILL.md` format and progressively discloses
+skill descriptions to the model. It loads these roots when they exist:
+
+- `~/.agents/skills/`
+- `.agents/skills/` in the working directory
+- Pi's native project `.pi/skills/` discovery
+
+Project `AGENTS.md`/`CLAUDE.md` context is handled by the Pi resource loader.
+Executable Pi extensions are not auto-loaded because they would bypass
+OmaPilot's tool permission boundary.
+
+## Named agents
+
+Put named profiles in `~/.agents/agents/*.md` (or `.agents/agents/*.md` in the
+working directory). The root agent receives an `agent` tool and can delegate a
+bounded task when a profile description matches.
+
+```markdown
+---
+name: reviewer
+description: Reviews a proposed change for correctness and regressions
+tools: [read, grep, find, ls]
+model: openai/gpt-5.4
+---
+
+Review the requested change. Focus on concrete defects and missing tests.
+```
+
+`name` must be a safe 1–64 character identifier. `tools` is optional and is
+limited to `read`, `bash`, `edit`, `write`, `grep`, `find`, and `ls`. Named
+agents default to read-only discovery tools. A named agent's bash, edit, or
+write call goes through the same approval broker as its parent. Nested
+delegation is disabled to keep fan-out bounded.
+
+## Tools and permissions
+
+The root native agent has Pi's `read`, `bash`, `edit`, `write`, `grep`, `find`,
+and `ls` tools plus the named-agent tool. Reads run with the current user's
+read authority. Every bash, edit, and write call pauses before execution and
+shows its complete structured input in OmaPilot. Unreviewable or oversized
+inputs fail closed. Native Pi offers allow once, allow the exact request for the
+current turn, always allow the exact request in this working directory, deny,
+and always deny the exact request. Durable decisions are stored as SHA-256
+fingerprints in `approvals.json`; command text is not stored. ACP harnesses
+surface their provider-native choices, including distinct session and durable
+options when supplied. Dangerous auto-approve can select only allow once.
+
+The native harness keeps Pi sessions in memory for a Quickchat turn. OmaPilot
+stores the completed answer under its existing bounded history policy, but not
+raw tool input/output, credentials, or Pi conversation files. Continue in Herdr
+therefore uses the transcript handoff for native Pi chats.

--- a/manifest.json
+++ b/manifest.json
@@ -17,11 +17,12 @@
     "displayName": "OmaPilot",
     "description": "Work through an authenticated AI harness without leaving the Omarchy bar.",
     "category": "AI",
-    "aliases": ["ai", "chat", "pilot", "omapilot", "quickchat", "codex", "claude", "opencode"],
+    "aliases": ["ai", "chat", "pilot", "omapilot", "quickchat", "codex", "openai", "claude", "opencode", "pi"],
     "allowMultiple": false,
     "defaultSection": "right",
     "defaults": {
-      "provider": "codex",
+      "provider": "builtin",
+      "builtinModel": "",
       "codexModel": "",
       "claudeModel": "",
       "opencodeModel": "",
@@ -33,10 +34,17 @@
       {
         "key": "provider",
         "type": "enum",
-        "label": "Default harness",
-        "options": ["codex", "claude", "opencode"],
-        "defaultValue": "codex",
-        "description": "OmaPilot shows only installed, authenticated harnesses at runtime."
+        "label": "Harness",
+        "options": ["builtin", "codex", "claude", "opencode"],
+        "defaultValue": "builtin",
+        "description": "Choose one harness explicitly. Built-in uses OmaPilot's native Pi runtime; the others use their logged-in ACP harness without fallback."
+      },
+      {
+        "key": "builtinModel",
+        "type": "string",
+        "label": "Last built-in model",
+        "defaultValue": "",
+        "description": "Empty uses the built-in default; discovered OpenAI, Claude, and compatible models are selected in OmaPilot."
       },
       {
         "key": "codexModel",
@@ -72,7 +80,7 @@
         "type": "boolean",
         "label": "Dangerous auto-approve",
         "defaultValue": false,
-        "description": "Automatically select each exact ACP request's Allow once option instead of prompting."
+        "description": "Automatically select each exact tool request's Allow once option instead of prompting."
       }
     ]
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
         "@agentclientprotocol/claude-agent-acp": "0.66.0",
         "@agentclientprotocol/codex-acp": "1.1.14",
         "@agentclientprotocol/sdk": "1.3.0",
+        "@earendil-works/pi-coding-agent": "0.84.2",
+        "typebox": "1.3.7",
         "zod": "4.3.6"
       },
       "devDependencies": {
@@ -224,8 +226,1821 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.2.tgz",
+      "integrity": "sha512-l4E+B7hgXKWddRo8bC/eSue2aWZjEgJ9xIpf5p0Og+lq8a2TArCwJ0HCoCPCgaBP/tN4zbYH/wOwvx9pJpeLCA==",
+      "hasShrinkwrap": true,
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-agent-core": "^0.84.2",
+        "@earendil-works/pi-ai": "^0.84.2",
+        "@earendil-works/pi-client": "^0.84.2",
+        "@earendil-works/pi-protocol": "^0.84.2",
+        "@earendil-works/pi-tui": "^0.84.2",
+        "@silvia-odwyer/photon-node": "0.3.4",
+        "chalk": "5.6.2",
+        "cross-spawn": "7.0.6",
+        "diff": "8.0.4",
+        "glob": "13.0.6",
+        "grok-mermaid": "0.2.2",
+        "highlight.js": "10.7.3",
+        "hosted-git-info": "9.0.3",
+        "ignore": "7.0.5",
+        "jiti": "2.7.0",
+        "minimatch": "10.2.5",
+        "proper-lockfile": "4.1.2",
+        "semver": "7.8.0",
+        "typebox": "1.3.7",
+        "undici": "8.9.0",
+        "yaml": "2.9.0"
+      },
+      "bin": {
+        "pi": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard": "0.3.9"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
+      "version": "3.974.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
+      "integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
+      "integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
+      "integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
+      "integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-login": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
+      "integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
+      "integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-ini": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
+      "integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
+      "integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
+      "integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
+      "integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
+      "integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
+      "integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
+      "integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.2.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.84.2",
+        "@earendil-works/pi-telemetry": "^0.84.2",
+        "diff": "8.0.4",
+        "ignore": "7.0.5",
+        "typebox": "1.3.7",
+        "yaml": "2.9.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.2.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@earendil-works/pi-telemetry": "^0.84.2",
+        "@google/genai": "1.52.0",
+        "@opentelemetry/api": "1.9.0",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.40.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.3.7"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-client": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.2.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-protocol": "^0.84.2"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-protocol": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.2.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "typebox": "1.3.7"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-telemetry": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.2.tgz",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.2.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "18.0.5"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
+      "integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard-darwin-arm64": "0.3.9",
+        "@mariozechner/clipboard-darwin-universal": "0.3.9",
+        "@mariozechner/clipboard-darwin-x64": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.9",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
+      "integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
+      "integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
+      "integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
+      "integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
+      "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
+      "integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
+      "integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
+      "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
+      "integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
+      "integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/grok-mermaid": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/grok-mermaid/-/grok-mermaid-0.2.2.tgz",
+      "integrity": "sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+      "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -843,6 +2658,7 @@
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
       "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -1457,7 +3273,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -1504,7 +3321,6 @@
       "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1554,7 +3370,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -1882,6 +3697,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
@@ -1896,7 +3712,6 @@
       "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1919,6 +3734,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1935,6 +3751,7 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -1992,6 +3809,7 @@
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
       "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^2.0.0",
@@ -2016,6 +3834,7 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2055,6 +3874,7 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2064,6 +3884,7 @@
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -2077,6 +3898,7 @@
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -2157,6 +3979,7 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2170,6 +3993,7 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2179,6 +4003,7 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2188,6 +4013,7 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.6.0"
       }
@@ -2197,6 +4023,7 @@
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -2292,6 +4119,7 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2310,6 +4138,7 @@
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -2323,13 +4152,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2339,6 +4170,7 @@
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -2348,6 +4180,7 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -2364,6 +4197,7 @@
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -2417,7 +4251,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -2438,7 +4273,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2626,6 +4460,7 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2635,6 +4470,7 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eventsource-parser": "^3.0.1"
       },
@@ -2647,6 +4483,7 @@
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
       "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -2710,6 +4547,7 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
       "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
         "ip-address": "^10.2.0"
@@ -2748,7 +4586,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
-      "license": "Unlicense"
+      "license": "Unlicense",
+      "peer": true
     },
     "node_modules/fast-uri": {
       "version": "3.1.5",
@@ -2764,7 +4603,8 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2802,6 +4642,7 @@
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "encodeurl": "^2.0.0",
@@ -2861,6 +4702,7 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2870,6 +4712,7 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2894,6 +4737,7 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2903,6 +4747,7 @@
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -2927,6 +4772,7 @@
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -2966,6 +4812,7 @@
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -2988,6 +4835,7 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3000,6 +4848,7 @@
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -3022,6 +4871,7 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "depd": "~2.0.0",
         "inherits": "~2.0.4",
@@ -3042,6 +4892,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
       "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -3094,13 +4945,15 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/ip-address": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
       "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -3110,6 +4963,7 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -3186,7 +5040,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-wsl": {
       "version": "3.1.1",
@@ -3214,6 +5069,7 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
       "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -3253,6 +5109,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "ts-algebra": "^2.0.0"
@@ -3265,13 +5122,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -3342,6 +5201,7 @@
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -3351,6 +5211,7 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
       "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       },
@@ -3364,6 +5225,7 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -3376,6 +5238,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3385,6 +5248,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -3446,6 +5310,7 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3455,6 +5320,7 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3464,6 +5330,7 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3490,6 +5357,7 @@
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -3502,6 +5370,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -3594,6 +5463,7 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3622,6 +5492,7 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
@@ -3647,7 +5518,6 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3660,6 +5530,7 @@
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -3720,6 +5591,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -3743,6 +5615,7 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
       "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "es-define-property": "^1.0.1",
         "side-channel": "^1.1.1"
@@ -3759,6 +5632,7 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
       "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       },
@@ -3772,6 +5646,7 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes": "~3.1.2",
         "http-errors": "~2.0.1",
@@ -3787,6 +5662,7 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3852,6 +5728,7 @@
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "depd": "^2.0.0",
@@ -3879,7 +5756,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "7.8.5",
@@ -3899,6 +5777,7 @@
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
@@ -3925,6 +5804,7 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
@@ -3943,7 +5823,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3971,6 +5852,7 @@
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
       "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.4",
@@ -3990,6 +5872,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.4"
@@ -4006,6 +5889,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -4024,6 +5908,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -4067,6 +5952,7 @@
       "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
       "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@stablelib/base64": "^1.0.0",
         "fast-sha256": "^1.3.0"
@@ -4077,6 +5963,7 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -4163,6 +6050,7 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -4171,7 +6059,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -4204,6 +6093,7 @@
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
       "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
@@ -4222,6 +6112,7 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -4230,13 +6121,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/typebox": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4281,6 +6177,7 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -4300,6 +6197,7 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -4310,7 +6208,6 @@
       "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
@@ -4513,7 +6410,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/wsl-utils": {
       "version": "0.3.1",
@@ -4549,7 +6447,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -4559,6 +6456,7 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "@agentclientprotocol/claude-agent-acp": "0.66.0",
     "@agentclientprotocol/codex-acp": "1.1.14",
     "@agentclientprotocol/sdk": "1.3.0",
+    "@earendil-works/pi-coding-agent": "0.84.2",
+    "typebox": "1.3.7",
     "zod": "4.3.6"
   },
   "devDependencies": {

--- a/runtime/dist/quickchat-broker.js.LEGAL.txt
+++ b/runtime/dist/quickchat-broker.js.LEGAL.txt
@@ -1,0 +1,33 @@
+Bundled license information:
+
+web-streams-polyfill/dist/ponyfill.es2018.js:
+  /**
+   * @license
+   * web-streams-polyfill v3.3.3
+   * Copyright 2024 Mattias Buelens, Diwank Singh Tomer and other contributors.
+   * This code is released under the MIT license.
+   * SPDX-License-Identifier: MIT
+   */
+
+fetch-blob/index.js:
+  /*! fetch-blob. MIT License. Jimmy Wärting <https://jimmy.warting.se/opensource> */
+
+formdata-polyfill/esm.min.js:
+undici/lib/web/fetch/body.js:
+  /*! formdata-polyfill. MIT License. Jimmy Wärting <https://jimmy.warting.se/opensource> */
+
+node-domexception/index.js:
+  /*! node-domexception. MIT License. Jimmy Wärting <https://jimmy.warting.se/opensource> */
+
+safe-buffer/index.js:
+  /*! safe-buffer. MIT License. Feross Aboukhadijeh <https://feross.org/opensource> */
+
+@google/genai/dist/node/index.mjs:
+  /**
+   * @license
+   * Copyright 2025 Google LLC
+   * SPDX-License-Identifier: Apache-2.0
+   */
+
+undici/lib/web/websocket/frame.js:
+  /*! ws. MIT License. Einar Otto Stangvik <einaros@gmail.com> */

--- a/runtime/scripts/build.mjs
+++ b/runtime/scripts/build.mjs
@@ -16,7 +16,7 @@ await build({
   target: "node22",
   format: "esm",
   sourcemap: true,
-  banner: { js: "#!/usr/bin/env node" },
+  banner: { js: "#!/usr/bin/env node\nimport { createRequire as __quickchatCreateRequire } from \"node:module\";\nvar require = __quickchatCreateRequire(import.meta.url);" },
   legalComments: "external",
   absWorkingDir: projectRoot
 });

--- a/runtime/src/acp.ts
+++ b/runtime/src/acp.ts
@@ -267,7 +267,7 @@ export function runAcpQuestion(
           }
           const optionId = typeof decision === "string" ? decision : decision?.optionId;
           const optionKind = params.options.find((option) => option.optionId === optionId)?.kind;
-          if (optionKind !== "allow_once") unapprovedToolAttempt = true;
+          if (optionKind !== "allow_once" && optionKind !== "allow_always") unapprovedToolAttempt = true;
           if (provider.id === "opencode") {
             if (optionKind === "allow_once") {
               const command = openCodeCommand(params.toolCall.rawInput);

--- a/runtime/src/broker.ts
+++ b/runtime/src/broker.ts
@@ -9,7 +9,7 @@ import { HistoryStore, presentChat, presentImage } from "./history.js";
 import { continueInHerdr, describeHerdrError } from "./herdr.js";
 import { ImagePolicyError, ImageStore, isAllowedExternalLink } from "./images.js";
 import { normalizeToolPermission, type PendingToolPermission } from "./permissions.js";
-import { discoverProviders, fallbackModels, type DiscoveredProvider } from "./providers.js";
+import { discoverProviders, fallbackModels, isPiProvider, type DiscoveredProvider } from "./providers.js";
 import { resolveExecutable, runCommand } from "./process.js";
 import type { BrokerCommand, BrokerEvent, ChatRecord, ProviderId, ProviderInfo } from "./types.js";
 import type { RequestPermissionRequest } from "@agentclientprotocol/sdk";
@@ -70,7 +70,9 @@ export class QuickchatBroker {
       statusChanged: () => { void this.#emitBrowserCompanionStatus(); }
     });
     this.#dictation = options.dictation ?? new DictationService();
-    this.#sessionCleaner = options.sessionCleaner ?? deleteAcpSession;
+    this.#sessionCleaner = options.sessionCleaner ?? ((provider, sessionId) => isPiProvider(provider)
+      ? Promise.resolve(true)
+      : deleteAcpSession(provider, sessionId));
     this.#herdrContinue = options.herdrContinue ?? continueInHerdr;
     this.#env = options.env ?? process.env;
     this.#permissionTimeoutMs = options.permissionTimeoutMs ?? 60_000;
@@ -124,10 +126,11 @@ export class QuickchatBroker {
       this.#error("unsupported_protocol", "Quickchat supports broker protocol version 2", false);
       return;
     }
-    const discovered = await discoverProviders(this.#env);
+    const discovered = await discoverProviders(this.#env, command.harness);
     await this.#browserCompanion.start().catch(() => undefined);
     await this.#emitBrowserCompanionStatus();
     await Promise.all(discovered.map(async (provider) => {
+      if (isPiProvider(provider)) return;
       const acpModels = await probeAcpModels(provider);
       const models = acpModels.models.length > 0 ? acpModels.models : await fallbackModels(provider);
       provider.models = models;
@@ -172,13 +175,16 @@ export class QuickchatBroker {
       }
       throw error;
     }
-    const run = runAcpQuestion(
-      provider, command.id, promptWithContextAttachments(command.question, command.desktopContext, attachmentBlocks), command.model,
-      this.#emit, 180_000, this.#images,
-      (request) => this.#requestToolPermission(
-        command.id, provider.id, request, dangerousAutoApprove),
-      () => this.#cancelPermissions(command.id)
-    );
+    const permission = (request: RequestPermissionRequest) => this.#requestToolPermission(
+      command.id, provider.id, request, dangerousAutoApprove);
+    const prompt = promptWithContextAttachments(command.question, command.desktopContext, attachmentBlocks);
+    const run = isPiProvider(provider)
+      ? (await import("./pi-harness.js")).runPiQuestion(
+        provider, command.id, prompt, command.model, this.#emit, 180_000, permission,
+        () => this.#cancelPermissions(command.id))
+      : runAcpQuestion(provider, command.id, prompt, command.model,
+        this.#emit, 180_000, this.#images, permission,
+        () => this.#cancelPermissions(command.id));
     this.#runs.set(command.id, run);
     this.#emit({ type: "state", id: command.id, state: "streaming", message: `Waiting for ${provider.name}…` });
     try {
@@ -211,7 +217,7 @@ export class QuickchatBroker {
       this.#emit({ type: "complete", chat: presentChat(chat) });
       this.#emit({ type: "state", id: command.id, state: "idle" });
     } catch (error) {
-      if (error instanceof BrokerAcpError) this.#error(error.code, error.message, error.retryable, command.id);
+      if (error instanceof BrokerAcpError || isBrokerRunError(error)) this.#error(error.code, error.message, error.retryable, command.id);
       else this.#error("agent_failed", "The selected harness stopped unexpectedly", true, command.id);
     } finally {
       this.#cancelPermissions(command.id);
@@ -344,10 +350,11 @@ export class QuickchatBroker {
     const permissionId = randomUUID();
     const pending = normalizeToolPermission(requestId, permissionId, provider, request);
     if (pending === undefined) return { invalid: true };
-    if (dangerousAutoApprove)
-      return pending.allowOptionId === undefined
-        ? { invalid: true }
-        : { optionId: pending.allowOptionId };
+    if (dangerousAutoApprove) {
+      const choice = pending.view.options.find((option) => option.decision === "allow_once");
+      const optionId = choice === undefined ? undefined : pending.optionIds[choice.id];
+      return optionId === undefined ? { invalid: true } : { optionId };
+    }
     return new Promise<PermissionDecision>((resolvePermission) => {
       const timeout = setTimeout(() => {
         this.#permissions.delete(permissionId);
@@ -366,7 +373,8 @@ export class QuickchatBroker {
     this.#permissions.delete(command.permissionId);
     clearTimeout(pending.timeout);
     this.#emit({ type: "permission_closed", id: command.id, permissionId: command.permissionId, reason: "decided" });
-    const optionId = command.decision === "allow_once" ? pending.allowOptionId : pending.rejectOptionId;
+    const choice = pending.view.options.find((option) => option.id === command.choiceId && option.decision === command.decision);
+    const optionId = choice === undefined ? undefined : pending.optionIds[choice.id];
     pending.resolve(optionId === undefined ? {} : { optionId });
   }
 
@@ -490,4 +498,10 @@ function publicProvider(provider: DiscoveredProvider): ProviderInfo {
     ...(provider.version === undefined ? {} : { version: provider.version }),
     ...(provider.defaultModel === undefined ? {} : { defaultModel: provider.defaultModel })
   };
+}
+
+function isBrokerRunError(error: unknown): error is Error & { code: string; retryable: boolean } {
+  return error instanceof Error
+    && typeof (error as { code?: unknown }).code === "string"
+    && typeof (error as { retryable?: unknown }).retryable === "boolean";
 }

--- a/runtime/src/history.ts
+++ b/runtime/src/history.ts
@@ -128,7 +128,7 @@ function isChatRecord(value: unknown): value is ChatRecord {
   return "schemaVersion" in value && value.schemaVersion === 1 &&
     "id" in value && typeof value.id === "string" && isUuid(value.id) &&
     "createdAt" in value && typeof value.createdAt === "string" &&
-    "provider" in value && ["codex", "claude", "opencode"].includes(String(value.provider)) &&
+    "provider" in value && ["builtin", "codex", "openai", "claude", "openai-compatible", "opencode"].includes(String(value.provider)) &&
     "question" in value && typeof value.question === "string" &&
     "answer" in value && typeof value.answer === "string" &&
     "images" in value && Array.isArray(value.images);

--- a/runtime/src/paths.ts
+++ b/runtime/src/paths.ts
@@ -2,6 +2,7 @@ import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 
 export type QuickchatPaths = {
+  config: string;
   state: string;
   records: string;
   cache: string;
@@ -17,10 +18,12 @@ function xdg(env: NodeJS.ProcessEnv, key: string, fallback: string): string {
 
 export function quickchatPaths(env: NodeJS.ProcessEnv = process.env): QuickchatPaths {
   const home = env.HOME ?? homedir();
+  const configRoot = xdg(env, "XDG_CONFIG_HOME", join(home, ".config"));
   const stateRoot = xdg(env, "XDG_STATE_HOME", join(home, ".local/state"));
   const cacheRoot = xdg(env, "XDG_CACHE_HOME", join(home, ".cache"));
   const runtimeRoot = xdg(env, "XDG_RUNTIME_DIR", tmpdir());
   return {
+    config: join(configRoot, "omapilot"),
     state: join(stateRoot, "quickchat"),
     records: join(stateRoot, "quickchat/chats"),
     cache: join(cacheRoot, "quickchat"),

--- a/runtime/src/permissions.ts
+++ b/runtime/src/permissions.ts
@@ -3,8 +3,7 @@ import type { ProviderId, ToolPermission } from "./types.js";
 
 export type PendingToolPermission = {
   view: ToolPermission;
-  allowOptionId?: string;
-  rejectOptionId?: string;
+  optionIds: Record<string, string>;
 };
 
 export function normalizeToolPermission(
@@ -16,13 +15,18 @@ export function normalizeToolPermission(
   const kind = request.toolCall.kind ?? "other";
   if (kind !== "execute") return undefined;
 
-  const rejectOptionId = request.options.find((option) => option.kind === "reject_once")?.optionId;
   const title = boundedText(request.toolCall.title ?? request.toolCall.name ?? `${kind} tool`, 120);
   const detail = permissionDetail(kind, request.toolCall.rawInput);
   const reviewable = detail !== undefined;
-  const allowOptionId = reviewable
-    ? request.options.find((option) => option.kind === "allow_once")?.optionId
-    : undefined;
+  const optionIds: PendingToolPermission["optionIds"] = {};
+  const options: ToolPermission["options"] = [];
+  for (const [index, option] of request.options.entries()) {
+    const decision = permissionDecision(option.kind, option.name, option.optionId);
+    if (decision === undefined || (!reviewable && decision.startsWith("allow_"))) continue;
+    const id = `option-${index}`;
+    optionIds[id] = option.optionId;
+    options.push({ id, decision, label: boundedText(option.name, 48) || defaultLabel(decision) });
+  }
 
   return {
     view: {
@@ -31,12 +35,27 @@ export function normalizeToolPermission(
       title: reviewable ? (title === "" ? `${kind} tool` : title) : "Command blocked",
       kind,
       authority: "device",
-      detail: detail ?? "Quickchat blocked this command because its complete contents cannot be displayed safely.",
-      allowOnce: allowOptionId !== undefined
+      detail: detail ?? "OmaPilot blocked this command because its complete contents cannot be displayed safely.",
+      options
     },
-    ...(allowOptionId === undefined ? {} : { allowOptionId }),
-    ...(rejectOptionId === undefined ? {} : { rejectOptionId })
+    optionIds
   };
+}
+
+function permissionDecision(kind: string, name: string, optionId: string): ToolPermission["options"][number]["decision"] | undefined {
+  if (kind === "allow_once" || kind === "reject_once" || kind === "reject_always") return kind;
+  if (kind !== "allow_always") return undefined;
+  return /session/iu.test(`${name} ${optionId}`) ? "allow_session" : "allow_always";
+}
+
+function defaultLabel(decision: ToolPermission["options"][number]["decision"]): string {
+  return ({
+    allow_once: "Allow once",
+    allow_session: "Allow for session",
+    allow_always: "Always allow",
+    reject_once: "Deny once",
+    reject_always: "Always deny"
+  } as const)[decision];
 }
 
 function permissionDetail(
@@ -64,7 +83,7 @@ function hasUnsafeCommandText(value: string): boolean {
 }
 
 function hasUnsafeText(value: unknown, seen = new Set<object>()): boolean {
-  if (typeof value === "string") return /[\u0000-\u001f\u007f-\u009f\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/u.test(value);
+  if (typeof value === "string") return hasUnsafeCommandText(value);
   if (value === null || typeof value !== "object") return false;
   if (seen.has(value)) return true;
   seen.add(value);

--- a/runtime/src/pi-harness.ts
+++ b/runtime/src/pi-harness.ts
@@ -1,0 +1,545 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import { homedir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { createAgentSession } from "../../node_modules/@earendil-works/pi-coding-agent/dist/core/sdk.js";
+import { DefaultResourceLoader } from "../../node_modules/@earendil-works/pi-coding-agent/dist/core/resource-loader.js";
+import { ModelRuntime } from "../../node_modules/@earendil-works/pi-coding-agent/dist/core/model-runtime.js";
+import { SessionManager } from "../../node_modules/@earendil-works/pi-coding-agent/dist/core/session-manager.js";
+import { SettingsManager } from "../../node_modules/@earendil-works/pi-coding-agent/dist/core/settings-manager.js";
+import { parseFrontmatter } from "../../node_modules/@earendil-works/pi-coding-agent/dist/utils/frontmatter.js";
+import type { InlineExtension, ToolDefinition } from "../../node_modules/@earendil-works/pi-coding-agent/dist/core/extensions/types.js";
+import { registerBundledOAuthFlowLoaders } from "../../node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/auth/oauth/load.js";
+import { anthropicOAuth } from "../../node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/auth/oauth/anthropic.js";
+import { openaiCodexOAuth } from "../../node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/auth/oauth/openai-codex.js";
+import { githubCopilotOAuth } from "../../node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/auth/oauth/github-copilot.js";
+import { openRouterOAuth } from "../../node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/auth/oauth/openrouter.js";
+import { kimiCodingOAuth } from "../../node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/auth/oauth/kimi-coding.js";
+import { xaiOAuth } from "../../node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/auth/oauth/xai.js";
+import { createRadiusOAuth } from "../../node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/auth/oauth/radius.js";
+import { Type } from "typebox";
+import type { RequestPermissionRequest } from "@agentclientprotocol/sdk";
+import type { AcpPrompt } from "./context.js";
+import type { AcpResult, AcpRun, PermissionHandler } from "./acp.js";
+import { automaticInstructions, type PiDiscoveredProvider } from "./providers.js";
+import type { BrokerEvent, ModelOption, ProviderPolicyInfo } from "./types.js";
+import { quickchatPaths } from "./paths.js";
+
+const PROVIDER_GROUPS = [
+  { id: "codex", name: "Codex", piProviderIds: ["openai-codex"] },
+  { id: "openai", name: "OpenAI", piProviderIds: ["openai"] },
+  { id: "claude", name: "Claude", piProviderIds: ["anthropic"] }
+] as const;
+const BUILTIN_PROVIDER_IDS = new Set(["openai-codex", "openai", "anthropic"]);
+const MUTATING_TOOLS = new Set(["bash", "edit", "write"]);
+const BASIC_TOOLS = ["read", "bash", "edit", "write", "grep", "find", "ls", "agent"];
+const SAFE_AGENT_NAME = /^[a-z0-9][a-z0-9._-]{0,63}$/u;
+const MAX_AGENT_FILE_BYTES = 128 * 1024;
+
+registerBundledOAuthFlowLoaders({
+  anthropic: () => anthropicOAuth,
+  openaiCodex: () => openaiCodexOAuth,
+  githubCopilot: () => githubCopilotOAuth,
+  openrouter: () => openRouterOAuth,
+  kimiCoding: () => kimiCodingOAuth,
+  xai: () => xaiOAuth,
+  radius: (options) => createRadiusOAuth(options)
+});
+
+export type AgentProfile = {
+  name: string;
+  description: string;
+  tools?: string[];
+  model?: string;
+  systemPrompt: string;
+  filePath: string;
+};
+
+export class BrokerPiError extends Error {
+  readonly code: string;
+  readonly retryable: boolean;
+
+  constructor(code: string, message: string, retryable: boolean) {
+    super(message);
+    this.name = "BrokerPiError";
+    this.code = code;
+    this.retryable = retryable;
+  }
+}
+
+export function configDirectory(env: NodeJS.ProcessEnv): string {
+  const explicit = env.OMAPILOT_CONFIG_DIR?.trim();
+  if (explicit !== undefined && explicit.startsWith("/")) return explicit;
+  return quickchatPaths(env).config;
+}
+
+export function agentDirectory(env: NodeJS.ProcessEnv): string {
+  const explicit = env.OMAPILOT_AGENTS_DIR?.trim();
+  if (explicit !== undefined && explicit.startsWith("/")) return explicit;
+  return join(env.HOME ?? homedir(), ".agents");
+}
+
+async function createRuntime(env: NodeJS.ProcessEnv, directory: string): Promise<ModelRuntime> {
+  const runtime = await ModelRuntime.create({
+    authPath: join(directory, "auth.json"),
+    modelsPath: join(directory, "models.json"),
+    modelsStorePath: join(directory, "models-store.json"),
+    refreshOnCreate: false,
+    allowModelNetwork: false
+  });
+  for (const [provider, key] of [
+    ["openai", env.OPENAI_API_KEY],
+    ["anthropic", env.ANTHROPIC_API_KEY]
+  ] as const) {
+    if (key?.trim()) await runtime.setRuntimeApiKey(provider, key.trim());
+  }
+  return runtime;
+}
+
+function optionId(providerId: string, modelId: string, grouped: boolean): string {
+  return grouped ? `${providerId}::${modelId}` : modelId;
+}
+
+function modelOptions(models: readonly ModelShape[], grouped: boolean): ModelOption[] {
+  return models.slice(0, 200).map((model) => ({
+    id: optionId(model.provider, model.id, grouped),
+    name: grouped ? `${model.name} (${model.provider})` : model.name,
+    description: `${model.provider} · ${model.contextWindow.toLocaleString()} token context`
+  }));
+}
+
+type ModelShape = {
+  id: string;
+  name: string;
+  provider: string;
+  contextWindow: number;
+};
+
+export async function discoverPiProviders(env: NodeJS.ProcessEnv = process.env): Promise<PiDiscoveredProvider[]> {
+  const directory = configDirectory(env);
+  const sharedAgentsDir = agentDirectory(env);
+  const runtime = await createRuntime(env, directory);
+  const providerIds: string[] = [];
+  const models: ModelShape[] = [];
+  const policy: ProviderPolicyInfo = { tools: "device-approval", web: "approved-command", hostReads: true };
+  const cwd = env.HOME?.startsWith("/") === true ? env.HOME : process.cwd();
+
+  for (const group of PROVIDER_GROUPS) {
+    const available = await runtime.getAvailable(group.piProviderIds[0]) as readonly ModelShape[];
+    if (available.length === 0) continue;
+    providerIds.push(...group.piProviderIds);
+    models.push(...available);
+  }
+
+  const compatibleIds = configuredProviderIds(directory).filter((id) => {
+    if (BUILTIN_PROVIDER_IDS.has(id)) return false;
+    return runtime.getModels(id).some((model) => model.api === "openai-completions" || model.api === "openai-responses");
+  });
+  const compatibleModels = (await Promise.all(compatibleIds.map((id) => runtime.getAvailable(id))))
+    .flat() as ModelShape[];
+  providerIds.push(...compatibleIds);
+  models.push(...compatibleModels);
+  const firstModel = models[0];
+  if (firstModel === undefined) return [];
+  return [{
+    kind: "pi",
+    id: "builtin",
+    name: "Built-in (OmaPilot)",
+    version: "Pi 0.84.2",
+    models: modelOptions(models, true),
+    defaultModel: optionId(firstModel.provider, firstModel.id, true),
+    policy,
+    runtime,
+    piProviderIds: providerIds,
+    agentDir: directory,
+    sharedAgentsDir,
+    cwd,
+    harnessPath: "native:pi",
+    agent: { executable: process.execPath, args: [], env }
+  }];
+}
+
+function configuredProviderIds(directory: string): string[] {
+  const path = join(directory, "models.json");
+  try {
+    if (statSync(path).size > 1024 * 1024) return [];
+    const value: unknown = JSON.parse(readFileSync(path, "utf8"));
+    if (!isObject(value) || !isObject(value.providers)) return [];
+    return Object.keys(value.providers).filter((id) => /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/u.test(id));
+  } catch {
+    return [];
+  }
+}
+
+export function runPiQuestion(
+  provider: PiDiscoveredProvider,
+  requestId: string,
+  prompt: AcpPrompt,
+  selectedModel: string | undefined,
+  emit: (event: BrokerEvent) => void,
+  timeoutMs = 180_000,
+  requestPermission?: PermissionHandler,
+  cancelPermissions?: () => void
+): AcpRun {
+  const controller = new AbortController();
+  let activeSession: { abort: () => Promise<void>; dispose: () => void } | undefined;
+  const cancel = async (): Promise<void> => {
+    controller.abort();
+    cancelPermissions?.();
+    await activeSession?.abort().catch(() => undefined);
+    activeSession?.dispose();
+  };
+
+  const result = (async (): Promise<AcpResult> => {
+    const model = resolveModel(provider, selectedModel);
+    if (model === undefined) throw new BrokerPiError("model_unavailable", "The selected model is not available", false);
+    const profiles = discoverAgentProfiles(provider.sharedAgentsDir, provider.cwd);
+    const approvals = new PiApprovalState(join(provider.agentDir, "approvals.json"), provider.cwd);
+    const permissionExtension = createPermissionExtension(requestId, requestPermission, approvals);
+    const loader = new DefaultResourceLoader({
+      cwd: provider.cwd,
+      agentDir: provider.agentDir,
+      noExtensions: true,
+      noSkills: true,
+      additionalSkillPaths: existingSkillPaths(provider.sharedAgentsDir, provider.cwd),
+      extensionFactories: [permissionExtension],
+      appendSystemPrompt: [automaticInstructions(), formatAgentProfiles(profiles)]
+    });
+    await loader.reload();
+    const agentTool = createAgentTool(provider, model, profiles, requestId, requestPermission, approvals);
+    const settings = SettingsManager.inMemory({
+      compaction: { enabled: true },
+      retry: { enabled: true, maxRetries: 2 }
+    });
+    const { session } = await createAgentSession({
+      cwd: provider.cwd,
+      agentDir: provider.agentDir,
+      model,
+      modelRuntime: provider.runtime,
+      resourceLoader: loader,
+      sessionManager: SessionManager.inMemory(provider.cwd),
+      settingsManager: settings,
+      tools: BASIC_TOOLS,
+      customTools: [agentTool]
+    });
+    activeSession = session;
+    let answer = "";
+    const unsubscribe = session.subscribe((event) => {
+      if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
+        answer += event.assistantMessageEvent.delta;
+        emit({ type: "content", id: requestId, delta: event.assistantMessageEvent.delta });
+      }
+    });
+    const timeout = setTimeout(() => { void cancel(); }, timeoutMs);
+    timeout.unref();
+    try {
+      const normalized = normalizePrompt(prompt);
+      await session.prompt(normalized.text, normalized.images.length === 0 ? undefined : { images: normalized.images });
+      if (controller.signal.aborted) throw new BrokerPiError("cancelled", "The request was cancelled", false);
+      if (answer.trim() === "") answer = finalAssistantText(session.state.messages);
+      if (answer.trim() === "") {
+        if (provider.agent.env.QUICKCHAT_DEBUG_PI === "1") {
+          process.stderr.write(`OmaPilot Pi empty response: ${assistantDiagnostics(session.state.messages)}\n`);
+        }
+        throw new BrokerPiError("empty_response", "The model returned no answer", true);
+      }
+      return {
+        answer,
+        images: [],
+        sessionId: session.sessionId,
+        models: provider.models,
+        defaultModel: optionId(model.provider, model.id, provider.id === "builtin"),
+        resumable: false
+      };
+    } catch (error) {
+      if (error instanceof BrokerPiError) throw error;
+      const message = error instanceof Error ? error.message : "";
+      if (/api key|credential|auth|login/iu.test(message))
+        throw new BrokerPiError("authentication_required", "Authentication for this provider is missing or expired", false);
+      throw new BrokerPiError("agent_failed", "The Pi harness could not complete the request", true);
+    } finally {
+      clearTimeout(timeout);
+      unsubscribe();
+      session.dispose();
+      activeSession = undefined;
+    }
+  })();
+  return { result, cancel };
+}
+
+type PiModel = ReturnType<PiDiscoveredProvider["runtime"]["getModels"]>[number];
+
+function resolveModel(provider: PiDiscoveredProvider, selected: string | undefined): PiModel | undefined {
+  const models = provider.piProviderIds.flatMap((id) => [...provider.runtime.getModels(id)]);
+  if (selected === undefined || selected === "") return models[0];
+  if (provider.id === "builtin") {
+    return models.find((model) => optionId(model.provider, model.id, true) === selected);
+  }
+  return models.find((model) => model.id === selected);
+}
+
+function normalizePrompt(prompt: AcpPrompt): { text: string; images: Array<{ type: "image"; data: string; mimeType: string }> } {
+  if (typeof prompt === "string") return { text: prompt, images: [] };
+  return {
+    text: prompt.filter((block) => block.type === "text").map((block) => block.text).join("\n\n"),
+    images: prompt.filter((block): block is Extract<(typeof prompt)[number], { type: "image" }> => block.type === "image")
+  };
+}
+
+type PersistedApprovals = { version: 1; allow: string[]; deny: string[] };
+
+export class PiApprovalState {
+  readonly #path: string;
+  readonly #cwd: string;
+  readonly #session = new Set<string>();
+  readonly #allow: Set<string>;
+  readonly #deny: Set<string>;
+
+  constructor(path: string, cwd: string) {
+    this.#path = path;
+    this.#cwd = cwd;
+    const persisted = readApprovals(path);
+    this.#allow = new Set(persisted.allow);
+    this.#deny = new Set(persisted.deny);
+  }
+
+  key(tool: string, rawInput: Record<string, unknown>): string {
+    return createHash("sha256").update(JSON.stringify({ cwd: this.#cwd, tool, rawInput: stableValue(rawInput) })).digest("hex");
+  }
+
+  allowed(key: string): boolean { return this.#session.has(key) || this.#allow.has(key); }
+  denied(key: string): boolean { return this.#deny.has(key); }
+  allowSession(key: string): void { this.#session.add(key); }
+  allowAlways(key: string): void { this.#deny.delete(key); this.#allow.add(key); this.#save(); }
+  denyAlways(key: string): void { this.#session.delete(key); this.#allow.delete(key); this.#deny.add(key); this.#save(); }
+
+  #save(): void {
+    mkdirSync(dirname(this.#path), { recursive: true, mode: 0o700 });
+    const temporary = `${this.#path}.${randomUUID()}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify({ version: 1, allow: [...this.#allow], deny: [...this.#deny] })}\n`, { mode: 0o600 });
+    renameSync(temporary, this.#path);
+  }
+}
+
+function readApprovals(path: string): PersistedApprovals {
+  try {
+    if (statSync(path).size > 1024 * 1024) return { version: 1, allow: [], deny: [] };
+    const value: unknown = JSON.parse(readFileSync(path, "utf8"));
+    if (!isObject(value)) return { version: 1, allow: [], deny: [] };
+    const hashes = (candidate: unknown): string[] => Array.isArray(candidate)
+      ? candidate.filter((item): item is string => typeof item === "string" && /^[a-f0-9]{64}$/u.test(item)).slice(0, 10_000)
+      : [];
+    return { version: 1, allow: hashes(value.allow), deny: hashes(value.deny) };
+  } catch { return { version: 1, allow: [], deny: [] }; }
+}
+
+function stableValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (!isObject(value)) return value;
+  return Object.fromEntries(Object.keys(value).sort().map((key) => [key, stableValue(value[key])]));
+}
+
+function createPermissionExtension(requestId: string, handler: PermissionHandler | undefined, approvals: PiApprovalState): InlineExtension {
+  return {
+    name: "omapilot-permissions",
+    hidden: true,
+    factory: (pi) => {
+      pi.on("tool_call", async (event) => {
+        if (!MUTATING_TOOLS.has(event.toolName)) return undefined;
+        if (handler === undefined) return { block: true, reason: "OmaPilot did not provide a permission handler" };
+        const rawInput = reviewableToolInput(event.toolName, event.input);
+        const approvalKey = approvals.key(event.toolName, rawInput);
+        if (approvals.denied(approvalKey)) return { block: true, reason: "This exact tool request is always denied" };
+        if (approvals.allowed(approvalKey)) return undefined;
+        const request: RequestPermissionRequest = {
+          sessionId: requestId,
+          toolCall: {
+            toolCallId: event.toolCallId,
+            kind: "execute",
+            title: toolTitle(event.toolName, event.input),
+            rawInput
+          },
+          options: [
+            { optionId: `allow-${event.toolCallId}`, name: "Allow once", kind: "allow_once" },
+            { optionId: `session-${event.toolCallId}`, name: "Allow exact request for this session", kind: "allow_always" },
+            { optionId: `always-${event.toolCallId}`, name: "Always allow exact request", kind: "allow_always" },
+            { optionId: `reject-${event.toolCallId}`, name: "Deny", kind: "reject_once" },
+            { optionId: `reject-always-${event.toolCallId}`, name: "Always deny exact request", kind: "reject_always" }
+          ]
+        };
+        const decision = await handler(request);
+        const option = typeof decision === "string" ? decision : decision?.optionId;
+        if (option === `session-${event.toolCallId}`) approvals.allowSession(approvalKey);
+        if (option === `always-${event.toolCallId}`) approvals.allowAlways(approvalKey);
+        if (option === `reject-always-${event.toolCallId}`) approvals.denyAlways(approvalKey);
+        return option === `allow-${event.toolCallId}` || option === `session-${event.toolCallId}` || option === `always-${event.toolCallId}`
+          ? undefined : { block: true, reason: "The user denied this tool call" };
+      });
+    }
+  };
+}
+
+function reviewableToolInput(name: string, input: Record<string, unknown>): Record<string, unknown> {
+  if (name === "bash") return { ...input, command: typeof input.command === "string" ? input.command : "" };
+  const path = typeof input.path === "string" ? input.path : "unknown";
+  return { command: `${name} ${path}`, ...input };
+}
+
+function toolTitle(name: string, input: Record<string, unknown>): string {
+  if (name === "bash") return "Run a command";
+  const path = typeof input.path === "string" ? basename(input.path) : "file";
+  return `${name === "write" ? "Write" : "Edit"} ${path}`;
+}
+
+export function existingSkillPaths(directory: string, cwd: string): string[] {
+  const candidates = [
+    join(directory, "skills"),
+    join(cwd, ".agents/skills"),
+    join(cwd, ".pi/skills")
+  ];
+  return [...new Set(candidates.filter((path) => existsSync(path)))];
+}
+
+export function discoverAgentProfiles(directory: string, cwd: string): AgentProfile[] {
+  const directories = [...new Set([join(directory, "agents"), join(cwd, ".agents/agents")])];
+  const profiles = new Map<string, AgentProfile>();
+  for (const path of directories) {
+    if (!existsSync(path)) continue;
+    let entries;
+    try { entries = readdirSync(path, { withFileTypes: true }); } catch { continue; }
+    for (const entry of entries) {
+      if (!entry.name.endsWith(".md") || (!entry.isFile() && !entry.isSymbolicLink())) continue;
+      const filePath = join(path, entry.name);
+      try {
+        if (statSync(filePath).size > MAX_AGENT_FILE_BYTES) continue;
+        const parsed = parseFrontmatter(readFileSync(filePath, "utf8"));
+        const name = typeof parsed.frontmatter.name === "string" ? parsed.frontmatter.name.trim() : basename(entry.name, ".md");
+        const description = typeof parsed.frontmatter.description === "string" ? parsed.frontmatter.description.trim() : "";
+        if (!SAFE_AGENT_NAME.test(name) || description === "") continue;
+        const tools = parseTools(parsed.frontmatter.tools);
+        profiles.set(name, {
+          name,
+          description: description.slice(0, 500),
+          systemPrompt: parsed.body.trim(),
+          filePath,
+          ...(tools === undefined ? {} : { tools }),
+          ...(typeof parsed.frontmatter.model !== "string" ? {} : { model: parsed.frontmatter.model.trim() })
+        });
+      } catch { /* Skip an unreadable or malformed agent without disabling the harness. */ }
+    }
+  }
+  return [...profiles.values()].slice(0, 32);
+}
+
+function parseTools(value: unknown): string[] | undefined {
+  const values = Array.isArray(value) ? value : typeof value === "string" ? value.split(",") : [];
+  const tools = values.filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim()).filter((item) => BASIC_TOOLS.includes(item) && item !== "agent");
+  return tools.length === 0 ? undefined : [...new Set(tools)];
+}
+
+function formatAgentProfiles(profiles: AgentProfile[]): string {
+  if (profiles.length === 0) return "No named agents are installed.";
+  return [
+    "Named agents are available through the agent tool. Delegate only when a profile clearly matches the task.",
+    ...profiles.map((profile) => `- ${profile.name}: ${profile.description} (${profile.filePath})`)
+  ].join("\n");
+}
+
+const agentToolParameters = Type.Object({
+  name: Type.String({ description: "Installed agent name", minLength: 1, maxLength: 64 }),
+  task: Type.String({ description: "Self-contained task for the agent", minLength: 1, maxLength: 100_000 })
+});
+
+function createAgentTool(
+  provider: PiDiscoveredProvider,
+  parentModel: PiModel,
+  profiles: AgentProfile[],
+  requestId: string,
+  requestPermission: PermissionHandler | undefined,
+  approvals: PiApprovalState
+): ToolDefinition<typeof agentToolParameters> {
+  return {
+    name: "agent",
+    label: "Agent",
+    description: "Delegate a bounded task to an installed named agent profile.",
+    promptSnippet: "Delegate a task to a named agent from ~/.agents/agents",
+    parameters: agentToolParameters,
+    async execute(_toolCallId, input) {
+      const profile = profiles.find((candidate) => candidate.name === input.name);
+      if (profile === undefined) return { content: [{ type: "text", text: `Unknown agent: ${input.name}` }], details: undefined, isError: true };
+      const model = profile.model === undefined ? parentModel : resolveProfileModel(provider, profile.model) ?? parentModel;
+      const loader = new DefaultResourceLoader({
+        cwd: provider.cwd,
+        agentDir: provider.agentDir,
+        noExtensions: true,
+        noSkills: true,
+        additionalSkillPaths: existingSkillPaths(provider.sharedAgentsDir, provider.cwd),
+        extensionFactories: [createPermissionExtension(requestId, requestPermission, approvals)],
+        systemPrompt: [automaticInstructions(), profile.systemPrompt].join("\n\n")
+      });
+      await loader.reload();
+      const sessionResult = await createAgentSession({
+        cwd: provider.cwd,
+        agentDir: provider.agentDir,
+        model,
+        modelRuntime: provider.runtime,
+        resourceLoader: loader,
+        sessionManager: SessionManager.inMemory(provider.cwd),
+        settingsManager: SettingsManager.inMemory({ compaction: { enabled: true } }),
+        tools: profile.tools ?? ["read", "grep", "find", "ls"]
+      });
+      try {
+        await sessionResult.session.prompt(input.task);
+        const output = finalAssistantText(sessionResult.session.state.messages);
+        return { content: [{ type: "text", text: output || "The agent returned no answer." }], details: { agent: profile.name } };
+      } finally {
+        sessionResult.session.dispose();
+      }
+    }
+  };
+}
+
+function resolveProfileModel(provider: PiDiscoveredProvider, value: string): PiModel | undefined {
+  const all = provider.runtime.getModels();
+  const separator = value.indexOf("/");
+  if (separator > 0) {
+    const providerId = value.slice(0, separator);
+    const modelId = value.slice(separator + 1);
+    return provider.runtime.getModel(providerId, modelId);
+  }
+  return all.find((model) => model.id === value);
+}
+
+function finalAssistantText(messages: readonly unknown[]): string {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!isObject(message) || message.role !== "assistant" || !Array.isArray(message.content)) continue;
+    const text = message.content.filter((part) => isObject(part) && part.type === "text" && typeof part.text === "string")
+      .map((part) => String((part as Record<string, unknown>).text)).join("");
+    if (text !== "") return text;
+  }
+  return "";
+}
+
+function assistantDiagnostics(messages: readonly unknown[]): string {
+  const value = messages.flatMap((raw) => {
+    if (!isObject(raw) || raw.role !== "assistant") return [];
+    return [{
+      stopReason: typeof raw.stopReason === "string" ? boundedDiagnostic(raw.stopReason) : "",
+      error: typeof raw.errorMessage === "string" ? boundedDiagnostic(raw.errorMessage) : "",
+      content: Array.isArray(raw.content)
+        ? raw.content.map((part: unknown) => isObject(part) && typeof part.type === "string" ? boundedDiagnostic(part.type) : "unknown")
+        : []
+    }];
+  }).slice(-3);
+  return JSON.stringify(value);
+}
+
+function boundedDiagnostic(value: string): string {
+  return value.replaceAll(/[\u0000-\u001f\u007f-\u009f]/gu, " ").slice(0, 300);
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/runtime/src/providers.ts
+++ b/runtime/src/providers.ts
@@ -3,12 +3,31 @@ import { access } from "node:fs/promises";
 import { constants } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { ProviderId, ProviderInfo, ProviderPolicyInfo } from "./types.js";
+import type { HarnessId, ProviderId, ProviderInfo, ProviderPolicyInfo } from "./types.js";
+import type { ModelRuntime } from "../../node_modules/@earendil-works/pi-coding-agent/dist/core/model-runtime.js";
 import { quickchatPaths } from "./paths.js";
 import { resolveExecutable, runCommand, stripAnsi } from "./process.js";
 
 export type AgentCommand = { executable: string; args: string[]; env: NodeJS.ProcessEnv };
-export type DiscoveredProvider = ProviderInfo & { harnessPath: string; agent: AgentCommand; lockdownFeatures?: string[] };
+export type DiscoveredProvider = ProviderInfo & {
+  kind?: "acp" | "pi";
+  harnessPath: string;
+  agent: AgentCommand;
+  lockdownFeatures?: string[];
+};
+export type AcpDiscoveredProvider = DiscoveredProvider;
+export type PiDiscoveredProvider = DiscoveredProvider & {
+  kind: "pi";
+  runtime: ModelRuntime;
+  piProviderIds: string[];
+  agentDir: string;
+  sharedAgentsDir: string;
+  cwd: string;
+};
+
+export function isPiProvider(provider: DiscoveredProvider): provider is PiDiscoveredProvider {
+  return provider.kind === "pi" && "runtime" in provider && "piProviderIds" in provider;
+}
 
 const OPEN_CODE_PERMISSION = {
   "*": "deny",
@@ -33,12 +52,14 @@ const OPEN_CODE_PERMISSION = {
 } as const;
 
 const providerNames: Record<ProviderId, string> = {
+  builtin: "Built-in (OmaPilot)",
   codex: "Codex",
   claude: "Claude",
   opencode: "OpenCode"
 };
 
 const providerPolicies: Record<ProviderId, ProviderPolicyInfo> = {
+  builtin: { tools: "device-approval", web: "approved-command", hostReads: true },
   codex: { tools: "device-approval", web: "approved-command", hostReads: true },
   claude: { tools: "device-approval", web: "search", hostReads: false },
   opencode: { tools: "device-approval", web: "search", hostReads: false }
@@ -132,9 +153,29 @@ function agentEnvironment(provider: ProviderId, harnessPath: string, env: NodeJS
   return openCodePolicyEnvironment(env);
 }
 
-export async function discoverProviders(env: NodeJS.ProcessEnv = process.env): Promise<DiscoveredProvider[]> {
+export async function discoverProviders(
+  env: NodeJS.ProcessEnv = process.env,
+  harness: HarnessId = "builtin"
+): Promise<DiscoveredProvider[]> {
+  if (harness === "builtin") {
+    try {
+      if (env.QUICKCHAT_DISABLE_PI === "1") return [];
+      const { discoverPiProviders } = await import("./pi-harness.js");
+      const providers = await discoverPiProviders(env);
+      return providers;
+    } catch (error) {
+      if (env.QUICKCHAT_DEBUG_PI === "1") {
+        const detail = error instanceof Error ? `${error.name}: ${error.message}` : "unknown error";
+        process.stderr.write(`OmaPilot Pi discovery failed: ${detail.replaceAll(/[\u0000-\u001f\u007f-\u009f]/gu, " ").slice(0, 500)}\n`);
+      }
+      return [];
+    }
+  }
+
+  const requested = harness;
   const found: DiscoveredProvider[] = [];
   for (const id of ["codex", "claude", "opencode"] satisfies ProviderId[]) {
+    if (id !== requested) continue;
     const harnessPath = await resolveExecutable(id, env);
     if (harnessPath === undefined || !await authenticated(id, harnessPath, env)) continue;
     let executable: string | undefined;
@@ -165,6 +206,7 @@ export async function discoverProviders(env: NodeJS.ProcessEnv = process.env): P
     }
     const providerVersion = await version(harnessPath, env);
     found.push({
+      kind: "acp",
       id,
       name: providerNames[id],
       ...(providerVersion === undefined ? {} : { version: providerVersion }),

--- a/runtime/src/types.ts
+++ b/runtime/src/types.ts
@@ -1,7 +1,9 @@
 import { z } from "zod";
 
-export const providerIdSchema = z.enum(["codex", "claude", "opencode"]);
+export const providerIdSchema = z.enum(["builtin", "codex", "claude", "opencode"]);
 export type ProviderId = z.infer<typeof providerIdSchema>;
+export const harnessIdSchema = providerIdSchema;
+export type HarnessId = z.infer<typeof harnessIdSchema>;
 
 const contextText = (max: number) => z.string().min(1).max(max).refine(
   (value) => !/[\u0000-\u001f\u007f-\u009f\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/.test(value),
@@ -56,8 +58,9 @@ export type ContextAttachmentSelection = z.infer<typeof contextAttachmentSelecti
 const initializeCommand = z.object({
   type: z.literal("initialize"),
   protocolVersion: z.number().int().positive(),
+  harness: harnessIdSchema,
   client: z.string().max(120).optional()
-});
+}).strict();
 const submitCommand = z.object({
   type: z.literal("submit"),
   id: z.string().min(1).max(120),
@@ -97,7 +100,8 @@ const permissionResponseCommand = z.object({
   type: z.literal("permission_response"),
   id: z.string().min(1).max(120),
   permissionId: z.string().uuid(),
-  decision: z.enum(["allow_once", "reject_once"])
+  choiceId: z.string().regex(/^option-[0-9]{1,3}$/u),
+  decision: z.enum(["allow_once", "allow_session", "allow_always", "reject_once", "reject_always"])
 });
 const chatCommand = z.object({ type: z.enum(["continue_in_herdr", "history_delete"]), chatId: z.string().uuid() });
 const linkCommand = z.object({ type: z.literal("open_link"), url: z.string().max(8_192) });
@@ -175,7 +179,11 @@ export type ToolPermission = {
   kind: "execute";
   authority: "device";
   detail: string;
-  allowOnce: boolean;
+  options: Array<{
+    id: string;
+    decision: "allow_once" | "allow_session" | "allow_always" | "reject_once" | "reject_always";
+    label: string;
+  }>;
 };
 
 export type ChatRecord = {

--- a/runtime/test/broker-lifecycle.test.ts
+++ b/runtime/test/broker-lifecycle.test.ts
@@ -23,7 +23,7 @@ describe("broker lifecycle cleanup", () => {
       history: fixture.history, images: new ImageStore(fixture.paths), env: fixture.env,
       sessionCleaner: (_provider, sessionId) => { cleaned.push(sessionId); return Promise.reject(new Error("provider offline")); }
     });
-    await broker.handle({ type: "initialize", protocolVersion: 2 });
+    await broker.handle({ type: "initialize", protocolVersion: 2, harness: "codex" });
     await broker.handle({ type: "history_delete", chatId: record(1).id });
     expect(await fixture.history.list()).toEqual([]);
     expect(cleaned).toEqual(["provider-session-1"]);
@@ -39,7 +39,7 @@ describe("broker lifecycle cleanup", () => {
       history: fixture.history, images: new ImageStore(fixture.paths), env: fixture.env,
       sessionCleaner: (_provider, sessionId) => { cleaned.push(sessionId); return Promise.resolve(sessionId !== "provider-session-1"); }
     });
-    await broker.handle({ type: "initialize", protocolVersion: 2 });
+    await broker.handle({ type: "initialize", protocolVersion: 2, harness: "codex" });
     await broker.handle({ type: "history_clear" });
     expect(await fixture.history.list()).toEqual([]);
     expect(cleaned.sort()).toEqual(["provider-session-1", "provider-session-2"]);
@@ -53,7 +53,7 @@ describe("broker lifecycle cleanup", () => {
       history: fixture.history, images: new ImageStore(fixture.paths), env: fixture.env,
       sessionCleaner: (_provider, sessionId) => { cleaned.push(sessionId); return Promise.resolve(true); }
     });
-    await broker.handle({ type: "initialize", protocolVersion: 2 });
+    await broker.handle({ type: "initialize", protocolVersion: 2, harness: "codex" });
     await broker.handle({ type: "submit", id: "evict", question: "Newest", provider: "codex" });
     expect((await fixture.history.list())).toHaveLength(30);
     expect(cleaned).toContain("provider-session-0");
@@ -102,7 +102,7 @@ describe("tool permission lifecycle", () => {
       env: { ...fixture.env, FAKE_ACP_PERMISSION_ATTEMPT: "1" },
       permissionTimeoutMs: 20
     });
-    await broker.handle({ type: "initialize", protocolVersion: 2 });
+    await broker.handle({ type: "initialize", protocolVersion: 2, harness: "claude" });
     await broker.handle({ type: "submit", id: "expires", question: "Run uname", provider: "claude" });
     const permission = fixture.events.find((event) => event.type === "permission");
     expect(permission?.type).toBe("permission");

--- a/runtime/test/claude-live.test.ts
+++ b/runtime/test/claude-live.test.ts
@@ -14,7 +14,7 @@ afterEach(async () => Promise.all(roots.splice(0).map((root) => rm(root, { recur
 
 describe("live automatic Claude boundary", () => {
   it.runIf(live)("loads the installed Omarchy skill", async () => {
-    const provider = (await discoverProviders()).find((candidate) => candidate.id === "claude");
+    const provider = (await discoverProviders(process.env, "claude")).find((candidate) => candidate.id === "claude");
     expect(provider, "authenticated Claude must be discoverable for the opt-in live test").toBeDefined();
     if (provider === undefined) return;
     const tools: ToolObservation[] = [];
@@ -36,7 +36,7 @@ describe("live automatic Claude boundary", () => {
   }, 120_000);
 
   it.runIf(live)("runs a harmless command automatically inside disposable scratch", async () => {
-    const provider = (await discoverProviders()).find((candidate) => candidate.id === "claude");
+    const provider = (await discoverProviders(process.env, "claude")).find((candidate) => candidate.id === "claude");
     expect(provider, "authenticated Claude must be discoverable for the opt-in live test").toBeDefined();
     if (provider === undefined) return;
     const events: BrokerEvent[] = [];
@@ -61,7 +61,7 @@ describe("live automatic Claude boundary", () => {
   }, 120_000);
 
   it.runIf(live)("runs an exact device command only after allow-once approval", async () => {
-    const provider = (await discoverProviders()).find((candidate) => candidate.id === "claude");
+    const provider = (await discoverProviders(process.env, "claude")).find((candidate) => candidate.id === "claude");
     expect(provider, "authenticated Claude must be discoverable for the opt-in live test").toBeDefined();
     if (provider === undefined) return;
     const root = await mkdtemp(join(tmpdir(), "quickchat-claude-host-boundary-"));
@@ -90,7 +90,7 @@ describe("live automatic Claude boundary", () => {
   }, 120_000);
 
   it.runIf(live)("does not expose a host file when device approval is denied", async () => {
-    const provider = (await discoverProviders()).find((candidate) => candidate.id === "claude");
+    const provider = (await discoverProviders(process.env, "claude")).find((candidate) => candidate.id === "claude");
     expect(provider, "authenticated Claude must be discoverable for the opt-in live test").toBeDefined();
     if (provider === undefined) return;
     const root = await mkdtemp(join(tmpdir(), "quickchat-claude-denied-host-read-"));
@@ -121,7 +121,7 @@ describe("live automatic Claude boundary", () => {
   }, 120_000);
 
   it.runIf(live)("uses WebSearch automatically without a permission prompt", async () => {
-    const provider = (await discoverProviders()).find((candidate) => candidate.id === "claude");
+    const provider = (await discoverProviders(process.env, "claude")).find((candidate) => candidate.id === "claude");
     expect(provider, "authenticated Claude must be discoverable for the opt-in live test").toBeDefined();
     if (provider === undefined) return;
     let permissionCount = 0;

--- a/runtime/test/codex-live.test.ts
+++ b/runtime/test/codex-live.test.ts
@@ -11,7 +11,7 @@ const live = process.env.QUICKCHAT_LIVE_CODEX_BEHAVIOR === "1";
 
 describe("live automatic Codex boundary", () => {
   it.runIf(live)("loads the installed Omarchy skill", async () => {
-    const provider = (await discoverProviders()).find((candidate) => candidate.id === "codex");
+    const provider = (await discoverProviders(process.env, "codex")).find((candidate) => candidate.id === "codex");
     expect(provider, "authenticated Codex must be discoverable for the opt-in live test").toBeDefined();
     if (provider === undefined) return;
     const tools: ToolObservation[] = [];
@@ -33,7 +33,7 @@ describe("live automatic Codex boundary", () => {
   }, 120_000);
 
   it.runIf(live)("uses the reviewed automatic read-only policy", async () => {
-    const provider = (await discoverProviders()).find((candidate) => candidate.id === "codex");
+    const provider = (await discoverProviders(process.env, "codex")).find((candidate) => candidate.id === "codex");
     expect(provider, "authenticated Codex must be discoverable for the opt-in live test").toBeDefined();
     if (provider === undefined) return;
     expect(provider.lockdownFeatures).toEqual(expect.arrayContaining(["shell_tool", "unified_exec", "skill_search"]));
@@ -43,7 +43,7 @@ describe("live automatic Codex boundary", () => {
   }, 120_000);
 
   it.runIf(live)("runs a generic automatic command after exactly one allow-once approval", async () => {
-    const provider = (await discoverProviders()).find((candidate) => candidate.id === "codex");
+    const provider = (await discoverProviders(process.env, "codex")).find((candidate) => candidate.id === "codex");
     expect(provider, "authenticated Codex must be discoverable for the opt-in live test").toBeDefined();
     if (provider === undefined) return;
     const root = await mkdtemp(join(tmpdir(), "quickchat-codex-tools-"));

--- a/runtime/test/history.test.ts
+++ b/runtime/test/history.test.ts
@@ -81,7 +81,7 @@ function record(index: number): ChatRecord {
   const suffix = index.toString(16).padStart(12, "0");
   return {
     schemaVersion: 1, id: `00000000-0000-4000-8000-${suffix}`, createdAt: new Date(Date.UTC(2026, 7, 11, 0, 0, index)).toISOString(),
-    title: `Chat ${String(index)}`, provider: "codex", question: "Q", answer: "A", images: [],
+    title: `Chat ${String(index)}`, provider: "builtin", question: "Q", answer: "A", images: [],
     session: { resumable: false, resumeKind: "transcript" }
   };
 }

--- a/runtime/test/opencode-live.test.ts
+++ b/runtime/test/opencode-live.test.ts
@@ -16,7 +16,7 @@ afterEach(async () => {
 
 describe("live automatic OpenCode boundary", () => {
   it.runIf(live)("loads the installed Omarchy skill through the exact skill tool", async () => {
-    const provider = (await discoverProviders()).find((candidate) => candidate.id === "opencode");
+    const provider = (await discoverProviders(process.env, "opencode")).find((candidate) => candidate.id === "opencode");
     expect(provider, "authenticated OpenCode must be discoverable for the opt-in live test").toBeDefined();
     if (provider === undefined) return;
     const tools: ToolObservation[] = [];
@@ -42,7 +42,7 @@ describe("live automatic OpenCode boundary", () => {
   }, 120_000);
 
   it.runIf(live)("uses web search automatically without a device permission", async () => {
-    const provider = (await discoverProviders()).find((candidate) => candidate.id === "opencode");
+    const provider = (await discoverProviders(process.env, "opencode")).find((candidate) => candidate.id === "opencode");
     expect(provider, "authenticated OpenCode must be discoverable for the opt-in live test").toBeDefined();
     if (provider === undefined) return;
     let permissionCount = 0;
@@ -64,7 +64,7 @@ describe("live automatic OpenCode boundary", () => {
   }, 120_000);
 
   it.runIf(live)("runs a generic device command after exactly one allow-once approval", async () => {
-    const provider = (await discoverProviders()).find((candidate) => candidate.id === "opencode");
+    const provider = (await discoverProviders(process.env, "opencode")).find((candidate) => candidate.id === "opencode");
     expect(provider, "authenticated OpenCode must be discoverable for the opt-in live test").toBeDefined();
     if (provider === undefined) return;
     const root = await mkdtemp(join(tmpdir(), "quickchat-opencode-tools-"));
@@ -98,7 +98,7 @@ describe("live automatic OpenCode boundary", () => {
   }, 120_000);
 
   it.runIf(live)("does not execute or claim success after a device-command denial", async () => {
-    const provider = (await discoverProviders()).find((candidate) => candidate.id === "opencode");
+    const provider = (await discoverProviders(process.env, "opencode")).find((candidate) => candidate.id === "opencode");
     expect(provider, "authenticated OpenCode must be discoverable for the opt-in live test").toBeDefined();
     if (provider === undefined) return;
     const root = await mkdtemp(join(tmpdir(), "quickchat-opencode-deny-"));

--- a/runtime/test/permissions.test.ts
+++ b/runtime/test/permissions.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { normalizeToolPermission } from "../src/permissions.js";
 
 describe("tool permission presentation", () => {
-  it("exposes only exact allow-once command requests", () => {
+  it("preserves exact provider approval choices without exposing provider IDs", () => {
     const permission = normalizeToolPermission("turn-1", "11111111-1111-4111-8111-111111111111", "codex", {
       sessionId: "session",
       toolCall: { toolCallId: "tool", kind: "execute", title: "Run uname", rawInput: { command: "uname -s", cwd: "/tmp/chat", timeout: 10 } },
@@ -20,12 +20,19 @@ describe("tool permission presentation", () => {
         kind: "execute",
         authority: "device",
         detail: '{\n  "command": "uname -s",\n  "cwd": "/tmp/chat",\n  "timeout": 10\n}',
-        allowOnce: true
+        options: [
+          { id: "option-0", decision: "allow_once", label: "Yes" },
+          { id: "option-1", decision: "allow_always", label: "Always" },
+          { id: "option-2", decision: "reject_once", label: "No" }
+        ]
       },
-      allowOptionId: "provider-allow",
-      rejectOptionId: "provider-deny"
+      optionIds: {
+        "option-0": "provider-allow",
+        "option-1": "provider-always",
+        "option-2": "provider-deny"
+      }
     });
-    expect(JSON.stringify(permission)).not.toContain("provider-always");
+    expect(JSON.stringify(permission?.view)).not.toContain("provider-");
   });
 
   it.each(["read", "search", "fetch", "edit", "delete", "move", "switch_mode", "other"] as const)("rejects %s before it reaches the UI", (kind) => {
@@ -36,12 +43,12 @@ describe("tool permission presentation", () => {
     })).toBeUndefined();
   });
 
-  it("does not invent a positive decision when allow-once is absent", () => {
+  it("does not invent approval choices", () => {
     expect(normalizeToolPermission("turn-1", "11111111-1111-4111-8111-111111111111", "codex", {
       sessionId: "session",
       toolCall: { toolCallId: "tool", kind: "execute", rawInput: { command: "uname -s" } },
       options: [{ optionId: "always", name: "Always", kind: "allow_always" }]
-    })?.view.allowOnce).toBe(false);
+    })?.view.options).toEqual([{ id: "option-0", decision: "allow_always", label: "Always" }]);
   });
 
   it.each(["x".repeat(3_001), "echo safe\u202eevil", "echo safe\u061cevil", "echo safe\u0085evil"])("rejects oversized, controlled, or directionally ambiguous commands", (command) => {
@@ -54,10 +61,10 @@ describe("tool permission presentation", () => {
       ]
     });
     expect(pending).toMatchObject({
-      view: { title: "Command blocked", authority: "device", allowOnce: false },
-      rejectOptionId: "deny"
+      view: { title: "Command blocked", authority: "device", options: [{ id: "option-1", decision: "reject_once", label: "Deny" }] },
+      optionIds: { "option-1": "deny" }
     });
-    expect(pending?.allowOptionId).toBeUndefined();
+    expect(pending?.view.options.some((option) => option.decision.startsWith("allow_"))).toBe(false);
   });
 
   it("fails closed when the adapter omits a classifiable target", () => {
@@ -65,7 +72,7 @@ describe("tool permission presentation", () => {
       sessionId: "session",
       toolCall: { toolCallId: "tool", kind: "execute", rawInput: { opaque: "do something" } },
       options: [{ optionId: "allow", name: "Allow", kind: "allow_once" }]
-    })?.view.allowOnce).toBe(false);
+    })?.view.options).toEqual([]);
   });
 
   it("preserves complete multiline and tabbed commands in a device-authority card", () => {
@@ -79,7 +86,48 @@ describe("tool permission presentation", () => {
       ]
     });
     expect(permission?.view.detail).toContain("cat <<'EOF'\\nhello\\tworld\\nEOF\\n");
-    expect(permission?.view).toMatchObject({ authority: "device", allowOnce: true });
+    expect(permission?.view).toMatchObject({ authority: "device", options: expect.arrayContaining([{ id: "option-0", decision: "allow_once", label: "Allow" }]) });
+  });
+
+  it("renders multiline edit and write payloads instead of making basic Pi tools unusable", () => {
+    const permission = normalizeToolPermission("turn-1", "11111111-1111-4111-8111-111111111111", "builtin", {
+      sessionId: "session",
+      toolCall: {
+        toolCallId: "tool", kind: "execute",
+        rawInput: { command: "write /tmp/example", path: "/tmp/example", content: "first\nsecond\tcolumn\n" }
+      },
+      options: [{ optionId: "allow", name: "Allow once", kind: "allow_once" }]
+    });
+    expect(permission?.view.options).toEqual([{ id: "option-0", decision: "allow_once", label: "Allow once" }]);
+    expect(permission?.view.detail).toContain("first\\nsecond\\tcolumn\\n");
+  });
+
+  it("distinguishes provider session approval from durable approval", () => {
+    const permission = normalizeToolPermission("turn-1", "11111111-1111-4111-8111-111111111111", "codex", {
+      sessionId: "session",
+      toolCall: { toolCallId: "tool", kind: "execute", rawInput: { command: "npm test" } },
+      options: [
+        { optionId: "allow_session", name: "Allow for This Session", kind: "allow_always" },
+        { optionId: "allow_always", name: "Allow and Don't Ask Again", kind: "allow_always" }
+      ]
+    });
+    expect(permission?.view.options).toEqual([
+      { id: "option-0", decision: "allow_session", label: "Allow for This Session" },
+      { id: "option-1", decision: "allow_always", label: "Allow and Don't Ask Again" }
+    ]);
+  });
+
+  it("preserves multiple provider choices in the same ACP category", () => {
+    const permission = normalizeToolPermission("turn-1", "11111111-1111-4111-8111-111111111111", "claude", {
+      sessionId: "session",
+      toolCall: { toolCallId: "tool", kind: "execute", rawInput: { command: "apply plan" } },
+      options: [
+        { optionId: "auto", name: "Yes, and use auto mode", kind: "allow_always" },
+        { optionId: "acceptEdits", name: "Yes, and auto-accept edits", kind: "allow_always" }
+      ]
+    });
+    expect(permission?.view.options).toHaveLength(2);
+    expect(permission?.optionIds).toEqual({ "option-0": "auto", "option-1": "acceptEdits" });
   });
 
   it("marks surfaced Claude command approvals as device authority", () => {

--- a/runtime/test/pi-harness.test.ts
+++ b/runtime/test/pi-harness.test.ts
@@ -1,0 +1,271 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { createServer } from "node:http";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { createInterface } from "node:readline";
+import { afterEach, describe, expect, it } from "vitest";
+import { agentDirectory, configDirectory, discoverAgentProfiles, discoverPiProviders, existingSkillPaths, PiApprovalState, runPiQuestion } from "../src/pi-harness.js";
+import type { BrokerEvent } from "../src/types.js";
+
+const roots: string[] = [];
+afterEach(async () => Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true }))));
+
+describe("native Pi harness", () => {
+  it("separates OmaPilot config from the standard shared agents root", () => {
+    const env = { HOME: "/home/test", XDG_CONFIG_HOME: "/config" };
+    expect(configDirectory(env)).toBe("/config/omapilot");
+    expect(agentDirectory(env)).toBe("/home/test/.agents");
+    expect(configDirectory({ ...env, OMAPILOT_CONFIG_DIR: "/custom/config" })).toBe("/custom/config");
+    expect(agentDirectory({ ...env, OMAPILOT_AGENTS_DIR: "/custom/agents" })).toBe("/custom/agents");
+  });
+
+  it("keeps session grants ephemeral and durable grants as command-free fingerprints", async () => {
+    const root = await mkdtemp(join(tmpdir(), "omapilot-pi-approvals-"));
+    roots.push(root);
+    const path = join(root, "config/approvals.json");
+    const first = new PiApprovalState(path, "/workspace");
+    const sessionKey = first.key("bash", { command: "echo session" });
+    const durableKey = first.key("write", { command: "write /tmp/a", path: "/tmp/a", content: "secret" });
+    first.allowSession(sessionKey);
+    first.allowAlways(durableKey);
+    expect(first.allowed(sessionKey)).toBe(true);
+
+    const restarted = new PiApprovalState(path, "/workspace");
+    expect(restarted.allowed(sessionKey)).toBe(false);
+    expect(restarted.allowed(durableKey)).toBe(true);
+    expect(await readFile(path, "utf8")).not.toMatch(/echo session|write \/tmp|secret/u);
+    restarted.denyAlways(durableKey);
+    const denied = new PiApprovalState(path, "/workspace");
+    expect(denied.allowed(durableKey)).toBe(false);
+    expect(denied.denied(durableKey)).toBe(true);
+  });
+
+  it("discovers OpenAI API auth and groups OpenAI-compatible models", async () => {
+    const root = await mkdtemp(join(tmpdir(), "omapilot-pi-"));
+    roots.push(root);
+    const agentDir = join(root, ".config/omapilot");
+    await mkdir(agentDir, { recursive: true });
+    await writeFile(join(agentDir, "models.json"), JSON.stringify({
+      providers: {
+        local: {
+          baseUrl: "http://127.0.0.1:11434/v1",
+          api: "openai-completions",
+          apiKey: "local-only-placeholder",
+          models: [{ id: "coder", name: "Local Coder", contextWindow: 32_000 }]
+        }
+      }
+    }));
+
+    const providers = await discoverPiProviders({
+      HOME: root,
+      OMAPILOT_CONFIG_DIR: agentDir,
+      OPENAI_API_KEY: "test-openai-key"
+    });
+
+    expect(providers).toHaveLength(1);
+    expect(providers[0]?.id).toBe("builtin");
+    expect(providers[0]?.models).toContainEqual(
+      expect.objectContaining({ id: expect.stringMatching(/^openai::/u) })
+    );
+    expect(providers[0]?.models).toContainEqual(
+      expect.objectContaining({ id: "local::coder", name: "Local Coder (local)" })
+    );
+    expect(providers.every((provider) => provider.kind === "pi" && provider.agentDir === agentDir)).toBe(true);
+  });
+
+  it("loads bounded named agents and all supported shared skill roots", async () => {
+    const root = await mkdtemp(join(tmpdir(), "omapilot-pi-resources-"));
+    roots.push(root);
+    const agentDir = join(root, ".agents");
+    const project = join(root, "project");
+    const userSkills = join(agentDir, "skills");
+    const projectSkills = join(project, ".agents/skills");
+    const piProjectSkills = join(project, ".pi/skills");
+    await Promise.all([
+      mkdir(join(agentDir, "agents"), { recursive: true }),
+      mkdir(userSkills, { recursive: true }),
+      mkdir(projectSkills, { recursive: true }),
+      mkdir(piProjectSkills, { recursive: true })
+    ]);
+    await writeFile(join(agentDir, "agents/reviewer.md"), [
+      "---", "name: reviewer", "description: Reviews changes", "tools: [read, grep, write, unknown]", "model: openai/test", "---",
+      "Review carefully."
+    ].join("\n"));
+    await writeFile(join(agentDir, "agents/invalid.md"), "---\nname: BAD NAME\ndescription: no\n---\nIgnore");
+
+    expect(discoverAgentProfiles(agentDir, project)).toEqual([expect.objectContaining({
+      name: "reviewer",
+      description: "Reviews changes",
+      tools: ["read", "grep", "write"],
+      model: "openai/test",
+      systemPrompt: "Review carefully."
+    })]);
+    expect(existingSkillPaths(agentDir, project)).toEqual([userSkills, projectSkills, piProjectSkills]);
+  });
+
+  it("runs and streams a complete turn through an OpenAI-compatible endpoint", async () => {
+    const root = await mkdtemp(join(tmpdir(), "omapilot-pi-run-"));
+    roots.push(root);
+    const server = createServer((_request, response) => {
+      response.writeHead(200, { "content-type": "text/event-stream" });
+      response.write(`data: ${JSON.stringify({
+        id: "chatcmpl-test", object: "chat.completion.chunk", created: 1, model: "coder",
+        choices: [{ index: 0, delta: { role: "assistant", content: "Hello " }, finish_reason: null }]
+      })}\n\n`);
+      response.write(`data: ${JSON.stringify({
+        id: "chatcmpl-test", object: "chat.completion.chunk", created: 1, model: "coder",
+        choices: [{ index: 0, delta: { content: "from Pi." }, finish_reason: null }]
+      })}\n\n`);
+      response.write(`data: ${JSON.stringify({
+        id: "chatcmpl-test", object: "chat.completion.chunk", created: 1, model: "coder",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+        usage: { prompt_tokens: 10, completion_tokens: 3, total_tokens: 13 }
+      })}\n\ndata: [DONE]\n\n`);
+      response.end();
+    });
+    await new Promise<void>((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+    try {
+      const address = server.address();
+      if (address === null || typeof address === "string") throw new Error("test server did not bind");
+      const agentDir = join(root, ".config/omapilot");
+      await mkdir(agentDir, { recursive: true });
+      await writeFile(join(agentDir, "models.json"), JSON.stringify({ providers: { local: {
+        baseUrl: `http://127.0.0.1:${String(address.port)}/v1`, api: "openai-completions", apiKey: "test",
+        compat: { supportsUsageInStreaming: true }, models: [{ id: "coder", name: "Coder" }]
+      } } }));
+      const [provider] = await discoverPiProviders({ HOME: root, OMAPILOT_CONFIG_DIR: agentDir });
+      if (provider === undefined) throw new Error("compatible provider was not discovered");
+      const events: BrokerEvent[] = [];
+      const run = runPiQuestion(provider, "pi-turn", "Say hello", "local::coder", (event) => events.push(event), 5_000);
+      await expect(run.result).resolves.toMatchObject({ answer: "Hello from Pi.", resumable: false });
+      expect(events.filter((event) => event.type === "content")).toEqual([
+        { type: "content", id: "pi-turn", delta: "Hello " },
+        { type: "content", id: "pi-turn", delta: "from Pi." }
+      ]);
+    } finally {
+      await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
+    }
+  });
+
+  it("blocks a Pi write until the broker permission handler allows it", async () => {
+    const root = await mkdtemp(join(tmpdir(), "omapilot-pi-permission-"));
+    roots.push(root);
+    const target = join(root, "should-not-exist.txt");
+    let requests = 0;
+    const server = createServer((request, response) => {
+      request.resume();
+      requests += 1;
+      response.writeHead(200, { "content-type": "text/event-stream" });
+      const chunk = requests === 1
+        ? {
+            id: "chatcmpl-tool", object: "chat.completion.chunk", created: 1, model: "coder",
+            choices: [{ index: 0, delta: {
+              role: "assistant",
+              tool_calls: [{ index: 0, id: "call-write", type: "function", function: {
+                name: "write", arguments: JSON.stringify({ path: target, content: "blocked" })
+              } }]
+            }, finish_reason: "tool_calls" }]
+          }
+        : {
+            id: "chatcmpl-tool", object: "chat.completion.chunk", created: 1, model: "coder",
+            choices: [{ index: 0, delta: { role: "assistant", content: "Denied safely." }, finish_reason: "stop" }],
+            usage: { prompt_tokens: 20, completion_tokens: 3, total_tokens: 23 }
+          };
+      response.end(`data: ${JSON.stringify(chunk)}\n\ndata: [DONE]\n\n`);
+    });
+    await new Promise<void>((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+    try {
+      const address = server.address();
+      if (address === null || typeof address === "string") throw new Error("test server did not bind");
+      const agentDir = join(root, ".config/omapilot");
+      await mkdir(agentDir, { recursive: true });
+      await writeFile(join(agentDir, "models.json"), JSON.stringify({ providers: { local: {
+        baseUrl: `http://127.0.0.1:${String(address.port)}/v1`, api: "openai-completions", apiKey: "test",
+        models: [{ id: "coder", name: "Coder" }]
+      } } }));
+      const [provider] = await discoverPiProviders({ HOME: root, OMAPILOT_CONFIG_DIR: agentDir });
+      if (provider === undefined) throw new Error("compatible provider was not discovered");
+      const permissions: Array<{ command?: unknown; path?: unknown; content?: unknown }> = [];
+      const run = runPiQuestion(provider, "pi-tool-turn", "Write a file", "local::coder", () => undefined, 5_000,
+        (request) => {
+          permissions.push(request.toolCall.rawInput ?? {});
+          return Promise.resolve(request.options.find((option) => option.kind === "reject_once")?.optionId);
+        });
+      await expect(run.result).resolves.toMatchObject({ answer: "Denied safely." });
+      expect(permissions).toEqual([{ command: `write ${target}`, path: target, content: "blocked" }]);
+      expect(existsSync(target)).toBe(false);
+      expect(requests).toBe(2);
+    } finally {
+      await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
+    }
+  });
+
+  it("ships the Pi harness in the self-contained broker bundle", async () => {
+    const root = await mkdtemp(join(tmpdir(), "omapilot-pi-bundle-"));
+    roots.push(root);
+    const server = createServer((request, response) => {
+      request.resume();
+      response.writeHead(200, { "content-type": "text/event-stream" });
+      response.end(`data: ${JSON.stringify({
+        id: "chatcmpl-bundle", object: "chat.completion.chunk", created: 1, model: "coder",
+        choices: [{ index: 0, delta: { role: "assistant", content: "Bundled Pi works." }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 10, completion_tokens: 3, total_tokens: 13 }
+      })}\n\ndata: [DONE]\n\n`);
+    });
+    await new Promise<void>((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+    let child: ChildProcessWithoutNullStreams | undefined;
+    try {
+      const address = server.address();
+      if (address === null || typeof address === "string") throw new Error("test server did not bind");
+      const agentDir = join(root, ".config/omapilot");
+      await mkdir(agentDir, { recursive: true });
+      await writeFile(join(agentDir, "models.json"), JSON.stringify({ providers: { local: {
+        baseUrl: `http://127.0.0.1:${String(address.port)}/v1`, api: "openai-completions", apiKey: "test",
+        models: [{ id: "coder", name: "Coder" }]
+      } } }));
+      const running = spawn(resolve("runtime/bin/quickchat-broker"), [], {
+        env: {
+          ...process.env,
+          HOME: root,
+          OMAPILOT_CONFIG_DIR: agentDir,
+          QUICKCHAT_DEBUG_PI: "1",
+          XDG_STATE_HOME: join(root, "state"),
+          XDG_CACHE_HOME: join(root, "cache"),
+          XDG_RUNTIME_DIR: join(root, "run")
+        },
+        stdio: ["pipe", "pipe", "pipe"]
+      });
+      child = running;
+      const events: Array<Record<string, unknown>> = [];
+      let stderr = "";
+      running.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString("utf8"); });
+      createInterface({ input: running.stdout }).on("line", (line) => {
+        const parsed: unknown = JSON.parse(line);
+        if (typeof parsed === "object" && parsed !== null) events.push(parsed as Record<string, unknown>);
+      });
+      running.stdin.write('{"type":"initialize","protocolVersion":2,"harness":"builtin"}\n');
+      await until(() => events.some((event) => event.type === "ready"), 10_000);
+      const ready = events.find((event) => event.type === "ready");
+      expect(JSON.stringify(ready), stderr).toContain('"id":"builtin"');
+      running.stdin.write('{"type":"submit","id":"bundle-turn","question":"hello","provider":"builtin","model":"local::coder"}\n');
+      await until(() => events.some((event) => event.type === "complete"), 10_000);
+      expect(events).toContainEqual({ type: "content", id: "bundle-turn", delta: "Bundled Pi works." });
+      running.stdin.end('{"type":"shutdown"}\n');
+      await new Promise<void>((resolveExit) => running.once("close", () => resolveExit()));
+      child = undefined;
+    } finally {
+      child?.kill("SIGTERM");
+      await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
+    }
+  }, 25_000);
+});
+
+async function until(predicate: () => boolean, timeoutMs: number): Promise<void> {
+  const started = Date.now();
+  while (!predicate()) {
+    if (Date.now() - started > timeoutMs) throw new Error("Timed out waiting for broker event");
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 20));
+  }
+}

--- a/runtime/test/policy.test.ts
+++ b/runtime/test/policy.test.ts
@@ -332,17 +332,22 @@ describe("provider security profiles", () => {
       ...process.env,
       PATH: `${resolve("runtime/test/fixtures/bin-unsafe")}:${process.env.PATH ?? ""}`,
       QUICKCHAT_CODEX_ACP: resolve("runtime/test/fake-acp-agent.mjs")
-    });
+    }, "codex");
     expect(providers.some((provider) => provider.id === "codex")).toBe(false);
   });
 
-  it("discovers automatic providers without public capability metadata", async () => {
-    const providers = await discoverProviders({
+  it("discovers only the selected ACP harness without public capability metadata", async () => {
+    const env = {
       ...process.env,
       PATH: `${resolve("runtime/test/fixtures/claude-auth")}:${resolve("runtime/test/fixtures/bin")}:${process.env.PATH ?? ""}`,
       QUICKCHAT_CODEX_ACP: resolve("runtime/test/fake-acp-agent.mjs"),
       QUICKCHAT_CLAUDE_ACP: resolve("runtime/test/fake-acp-agent.mjs")
-    });
+    };
+    const providers = (await Promise.all([
+      discoverProviders(env, "codex"),
+      discoverProviders(env, "claude"),
+      discoverProviders(env, "opencode")
+    ])).flat();
     expect(providers.map((provider) => provider.id)).toEqual(["codex", "claude", "opencode"]);
     expect(providers.every((provider) => !("capabilities" in provider))).toBe(true);
     expect(providers.map(({ id, policy }) => ({ id, policy }))).toEqual([
@@ -354,6 +359,16 @@ describe("provider security profiles", () => {
     expect(opencode).toBeDefined();
     const config = JSON.parse(opencode?.agent.env.OPENCODE_CONFIG_CONTENT ?? "{}");
     expect(config).toMatchObject({ default_agent: "build", skills: { urls: [] }, mcp: { "fixture-user-mcp": false } });
+  });
+
+  it("never substitutes ACP when the selected built-in harness is disabled", async () => {
+    const providers = await discoverProviders({
+      ...process.env,
+      QUICKCHAT_DISABLE_PI: "1",
+      PATH: `${resolve("runtime/test/fixtures/bin")}:${process.env.PATH ?? ""}`,
+      QUICKCHAT_CODEX_ACP: resolve("runtime/test/fake-acp-agent.mjs")
+    }, "builtin");
+    expect(providers).toEqual([]);
   });
 });
 

--- a/runtime/test/protocol.test.ts
+++ b/runtime/test/protocol.test.ts
@@ -50,6 +50,7 @@ describe("NDJSON protocol", () => {
   it("rejects malformed commands", () => {
     expect(commandSchema.safeParse({ type: "submit", id: "one", question: "", provider: "codex" }).success).toBe(false);
     expect(commandSchema.safeParse({ type: "permission_response", id: "one", permissionId: "not-a-uuid", decision: "allow_always" }).success).toBe(false);
+    expect(commandSchema.safeParse({ type: "permission_response", id: "one", permissionId: "11111111-1111-4111-8111-111111111111", choiceId: "option-1", decision: "allow_session" }).success).toBe(true);
     expect(commandSchema.safeParse({ type: "browser_companion_status" }).success).toBe(true);
     expect(commandSchema.safeParse({ type: "browser_companion_install" }).success).toBe(true);
     expect(commandSchema.safeParse({ type: "browser_companion_uninstall" }).success).toBe(true);
@@ -62,7 +63,7 @@ describe("NDJSON protocol", () => {
     const child = spawn(brokerExecutable(), [], { stdio: ["pipe", "pipe", "pipe"] });
     const events: Record<string, unknown>[] = [];
     createInterface({ input: child.stdout }).on("line", (line) => events.push(parseObject(line)));
-    child.stdin.write('{"type":"initialize","protocolVersion":1}\n');
+    child.stdin.write('{"type":"initialize","protocolVersion":1,"harness":"codex"}\n');
     await until(() => events.some((event) => event.code === "unsupported_protocol"));
     expect(events.some((event) => event.type === "ready")).toBe(false);
     expect(events.find((event) => event.code === "unsupported_protocol")?.message).toBe("Quickchat supports broker protocol version 2");
@@ -99,15 +100,14 @@ describe("NDJSON protocol", () => {
     const events: Record<string, unknown>[] = [];
     const lines = createInterface({ input: child.stdout });
     lines.on("line", (line) => events.push(parseObject(line)));
-    child.stdin.write(`${JSON.stringify({ type: "initialize", protocolVersion: 2, client: "test" })}\n`);
+    child.stdin.write(`${JSON.stringify({ type: "initialize", protocolVersion: 2, harness: "codex", client: "test" })}\n`);
     await until(() => events.some((event) => event.type === "ready"));
     const ready = readySchema.parse(events.find((event) => event.type === "ready"));
     expect(ready.protocolVersion).toBe(2);
     expect(ready.features).toEqual(["desktop-context", "context-attachments"]);
     expect(ready.providers.find((provider) => provider.id === "codex")?.models).toContainEqual({ id: "test/default", name: "Default" });
     expect(ready.providers.map(({ id, policy }) => ({ id, policy }))).toEqual([
-      { id: "codex", policy: { tools: "device-approval", web: "approved-command", hostReads: true } },
-      { id: "opencode", policy: { tools: "device-approval", web: "search", hostReads: false } }
+      { id: "codex", policy: { tools: "device-approval", web: "approved-command", hostReads: true } }
     ]);
     expect(JSON.stringify(events.find((event) => event.type === "ready"))).not.toContain('"capabilities"');
     child.stdin.write(`${JSON.stringify({
@@ -136,7 +136,7 @@ describe("NDJSON protocol", () => {
     expect(promptBlocks[0]?.text).toContain("Context-only browser title");
     expect(promptBlocks[1]?.text).toBe("Say hello");
     child.stdin.write(`${JSON.stringify({ type: "history_delete", chatId: complete.chat.id })}\n`);
-    await until(async () => (await readFile(audit, "utf8")).trim() === "delete:fake-1");
+    await until(async () => (await readFile(audit, "utf8").catch(() => "")).trim() === "delete:fake-1");
     child.stdin.end(`${JSON.stringify({ type: "shutdown" })}\n`);
     await new Promise((resolveExit) => child.once("close", resolveExit));
   }, 25_000);
@@ -156,7 +156,7 @@ describe("NDJSON protocol", () => {
     });
     const events: Record<string, unknown>[] = [];
     createInterface({ input: child.stdout }).on("line", (line) => events.push(parseObject(line)));
-    child.stdin.write('{"type":"initialize","protocolVersion":2}\n');
+    child.stdin.write('{"type":"initialize","protocolVersion":2,"harness":"codex"}\n');
     await until(() => events.some((event) => event.type === "ready"));
     child.stdin.write('{"type":"submit","id":"short-stream","question":"Keep it short","provider":"codex"}\n');
     await until(() => events.some((event) => event.type === "content"));
@@ -186,7 +186,7 @@ describe("NDJSON protocol", () => {
     });
     const events: Record<string, unknown>[] = [];
     createInterface({ input: child.stdout }).on("line", (line) => events.push(parseObject(line)));
-    child.stdin.write('{"type":"initialize","protocolVersion":2}\n');
+    child.stdin.write('{"type":"initialize","protocolVersion":2,"harness":"codex"}\n');
     await until(() => events.some((event) => event.type === "ready"));
     child.stdin.write(`${JSON.stringify({
       type: "context_begin", id: "clip-1",
@@ -239,7 +239,7 @@ describe("NDJSON protocol", () => {
     });
     const events: Record<string, unknown>[] = [];
     createInterface({ input: child.stdout }).on("line", (line) => events.push(parseObject(line)));
-    child.stdin.write('{"type":"initialize","protocolVersion":2}\n');
+    child.stdin.write('{"type":"initialize","protocolVersion":2,"harness":"codex"}\n');
     await until(() => events.some((event) => event.type === "ready"));
     const ready = readySchema.parse(events.find((event) => event.type === "ready"));
     expect(ready.providers.find((provider) => provider.id === "codex")?.models).toContainEqual({ id: "test/default", name: "Default" });
@@ -266,7 +266,7 @@ describe("NDJSON protocol", () => {
     });
     const events: Record<string, unknown>[] = [];
     createInterface({ input: child.stdout }).on("line", (line) => events.push(parseObject(line)));
-    child.stdin.write('{"type":"initialize","protocolVersion":2}\n');
+    child.stdin.write('{"type":"initialize","protocolVersion":2,"harness":"codex"}\n');
     await until(() => events.some((event) => event.type === "ready"));
     child.stdin.write('{"type":"submit","id":"action-shaped","question":"open zoom","provider":"codex"}\n');
     await until(() => events.some((event) => event.type === "complete"));
@@ -305,17 +305,19 @@ describe("NDJSON protocol", () => {
     });
     const events: Record<string, unknown>[] = [];
     createInterface({ input: child.stdout }).on("line", (line) => events.push(parseObject(line)));
-    child.stdin.write('{"type":"initialize","protocolVersion":2}\n');
+    child.stdin.write(`${JSON.stringify({ type: "initialize", protocolVersion: 2, harness: provider })}\n`);
     await until(() => events.some((event) => event.type === "ready"));
     child.stdin.write(`${JSON.stringify({ type: "submit", id: "tool-turn", question: "Run uname", provider })}\n`);
     await until(() => events.some((event) => event.type === "permission"));
     const permission = z.object({
       type: z.literal("permission"),
-      permission: z.object({ id: z.string().uuid(), requestId: z.literal("tool-turn"), kind: z.literal("execute"), detail: z.string(), allowOnce: z.literal(true) })
+      permission: z.object({ id: z.string().uuid(), requestId: z.literal("tool-turn"), kind: z.literal("execute"), detail: z.string(), options: z.array(z.object({ id: z.string(), decision: z.string(), label: z.string() })) })
     }).parse(events.find((event) => event.type === "permission"));
     expect(permission.permission.detail).toBe('{\n  "command": "uname -s"\n}');
     expect(JSON.stringify(permission)).not.toContain("provider-allow");
-    child.stdin.write(`${JSON.stringify({ type: "permission_response", id: "tool-turn", permissionId: permission.permission.id, decision: "allow_once" })}\n`);
+    const allowChoice = permission.permission.options.find((option) => option.decision === "allow_once");
+    if (allowChoice === undefined) throw new Error("allow-once choice missing");
+    child.stdin.write(`${JSON.stringify({ type: "permission_response", id: "tool-turn", permissionId: permission.permission.id, choiceId: allowChoice.id, decision: "allow_once" })}\n`);
     await until(() => events.some((event) => event.type === "complete"));
     expect(events).toContainEqual({ type: "permission_closed", id: "tool-turn", permissionId: permission.permission.id, reason: "decided" });
     expect(events.some((event) => event.type === "error")).toBe(false);
@@ -360,13 +362,15 @@ describe("NDJSON protocol", () => {
     });
     const events: Record<string, unknown>[] = [];
     createInterface({ input: child.stdout }).on("line", (line) => events.push(parseObject(line)));
-    child.stdin.write('{"type":"initialize","protocolVersion":2}\n');
+    child.stdin.write('{"type":"initialize","protocolVersion":2,"harness":"claude"}\n');
     await until(() => events.some((event) => event.type === "ready"));
     child.stdin.write('{"type":"submit","id":"deny-turn","question":"Do not run it","provider":"claude"}\n');
     await until(() => events.some((event) => event.type === "permission"));
-    const permission = z.object({ type: z.literal("permission"), permission: z.object({ id: z.string().uuid() }) })
+    const permission = z.object({ type: z.literal("permission"), permission: z.object({ id: z.string().uuid(), options: z.array(z.object({ id: z.string(), decision: z.string() })) }) })
       .parse(events.find((event) => event.type === "permission"));
-    child.stdin.write(`${JSON.stringify({ type: "permission_response", id: "deny-turn", permissionId: permission.permission.id, decision: "reject_once" })}\n`);
+    const denyChoice = permission.permission.options.find((option) => option.decision === "reject_once");
+    if (denyChoice === undefined) throw new Error("deny choice missing");
+    child.stdin.write(`${JSON.stringify({ type: "permission_response", id: "deny-turn", permissionId: permission.permission.id, choiceId: denyChoice.id, decision: "reject_once" })}\n`);
     await until(() => events.some((event) => event.type === "complete"));
     expect(events).toContainEqual({ type: "permission_closed", id: "deny-turn", permissionId: permission.permission.id, reason: "decided" });
     expect(events.some((event) => event.type === "error")).toBe(false);
@@ -393,7 +397,7 @@ describe("NDJSON protocol", () => {
     });
     const events: Record<string, unknown>[] = [];
     createInterface({ input: child.stdout }).on("line", (line) => events.push(parseObject(line)));
-    child.stdin.write('{"type":"initialize","protocolVersion":2}\n');
+    child.stdin.write('{"type":"initialize","protocolVersion":2,"harness":"codex"}\n');
     await until(() => events.some((event) => event.type === "ready"));
     child.stdin.write('{"type":"submit","id":"fail","question":"fail","provider":"codex"}\n');
     await until(() => events.some((event) => event.type === "error"));
@@ -421,7 +425,7 @@ describe("NDJSON protocol", () => {
     });
     const events: Record<string, unknown>[] = [];
     createInterface({ input: child.stdout }).on("line", (line) => events.push(parseObject(line)));
-    child.stdin.write('{"type":"initialize","protocolVersion":2}\n');
+    child.stdin.write('{"type":"initialize","protocolVersion":2,"harness":"codex"}\n');
     await until(() => events.some((event) => event.type === "ready"));
     child.stdin.write('{"type":"submit","id":"cancel-me","question":"wait","provider":"codex"}\n');
     await until(() => events.some((event) => event.type === "state" && event.state === "streaming"));
@@ -485,7 +489,7 @@ async function forbiddenAttempt(provider: "codex" | "opencode", extraEnv: NodeJS
   });
   const events: Record<string, unknown>[] = [];
   createInterface({ input: child.stdout }).on("line", (line) => events.push(parseObject(line)));
-  child.stdin.write('{"type":"initialize","protocolVersion":2}\n');
+  child.stdin.write(`${JSON.stringify({ type: "initialize", protocolVersion: 2, harness: provider })}\n`);
   await until(() => events.some((event) => event.type === "ready"));
   child.stdin.write(`${JSON.stringify({ type: "submit", id: "forbidden", question: "Run a device command", provider })}\n`);
   await until(() => events.some((event) => event.type === "error"));
@@ -515,7 +519,7 @@ async function autoApproveAttempt(
   });
   const events: Record<string, unknown>[] = [];
   createInterface({ input: child.stdout }).on("line", (line) => events.push(parseObject(line)));
-  child.stdin.write('{"type":"initialize","protocolVersion":2}\n');
+  child.stdin.write(`${JSON.stringify({ type: "initialize", protocolVersion: 2, harness: provider })}\n`);
   await until(() => events.some((event) => event.type === "ready"));
   child.stdin.write(`${JSON.stringify({
     type: "submit", id: "auto-turn", question: "Run uname", provider,

--- a/scripts/check-manifest.sh
+++ b/scripts/check-manifest.sh
@@ -28,7 +28,8 @@ jq -e '
   and .barWidget.allowMultiple == false
   and .barWidget.defaultSection == "right"
   and .barWidget.defaults == {
-    "provider":"codex",
+    "provider":"builtin",
+    "builtinModel":"",
     "codexModel":"",
     "claudeModel":"",
     "opencodeModel":"",
@@ -36,13 +37,13 @@ jq -e '
     "desktopContext":"On",
     "dangerousAutoApprove":false
   }
-  and ([.barWidget.schema[].key] | sort) == (["claudeModel", "codexModel", "dangerousAutoApprove", "desktopContext", "opencodeModel", "provider"] | sort)
+  and ([.barWidget.schema[].key] | sort) == (["builtinModel", "claudeModel", "codexModel", "dangerousAutoApprove", "desktopContext", "opencodeModel", "provider"] | sort)
   and (.barWidget.schema[] | select(.key == "dangerousAutoApprove")) == {
     "key":"dangerousAutoApprove",
     "type":"boolean",
     "label":"Dangerous auto-approve",
     "defaultValue":false,
-    "description":"Automatically select each exact ACP request\u0027s Allow once option instead of prompting."
+    "description":"Automatically select each exact tool request\u0027s Allow once option instead of prompting."
   }
 ' "$manifest" >/dev/null || fail "manifest contract drifted from the Quickchat v0.1 schema"
 

--- a/scripts/package-runtime.sh
+++ b/scripts/package-runtime.sh
@@ -41,6 +41,7 @@ required=(
   package.json
   package-lock.json
   runtime/dist/quickchat-broker.js
+  runtime/dist/quickchat-broker.js.LEGAL.txt
   runtime/dist/adapters/codex-acp.js
   runtime/dist/adapters/claude-agent-acp.js
   runtime/dist/adapters/claude-agent-acp.js.LEGAL.txt
@@ -108,6 +109,7 @@ mkdir -p "$stage/runtime/dist/adapters" "$stage/runtime/bin" "$stage/runtime/pol
 
 cp "$repo_root/package.json" "$repo_root/package-lock.json" "$stage/"
 cp "$repo_root/runtime/dist/quickchat-broker.js" "$stage/runtime/dist/"
+cp "$repo_root/runtime/dist/quickchat-broker.js.LEGAL.txt" "$stage/runtime/dist/"
 cp "$repo_root/runtime/dist/adapters/codex-acp.js" "$stage/runtime/dist/adapters/"
 cp "$repo_root/runtime/dist/adapters/claude-agent-acp.js" "$stage/runtime/dist/adapters/"
 cp "$repo_root/runtime/dist/adapters/claude-agent-acp.js.LEGAL.txt" "$stage/runtime/dist/adapters/"

--- a/tests/check-ui-contract.sh
+++ b/tests/check-ui-contract.sh
@@ -48,6 +48,9 @@ grep -Fq 'property string configuredProvider: "builtin"' \
 grep -Fq 'harness: provider' "$repo_dir/components/QuickchatStore.qml"
 grep -Fq 'readonly property var modeProviders: Protocol.harnessOptions()' \
   "$repo_dir/components/SettingsView.qml"
+grep -Fq 'text: "Authenticate Built-in"' "$repo_dir/components/SettingsView.qml"
+grep -Fq '"PI_CODING_AGENT_DIR=" + builtinAuthDirectory, "pi"' \
+  "$repo_dir/components/QuickchatStore.qml"
 if grep -Fq 'backendSelection' "$repo_dir/components/QuickchatStore.qml"; then
   printf 'Harness selection must not be split into backend and provider settings\n' >&2
   exit 1
@@ -364,7 +367,7 @@ if grep -Eq "visual preview failed|Failed to load|Type .* unavailable|Cannot ass
   exit 1
 fi
 
-for preview_state in actions-settings waiting streaming error error-details context; do
+for preview_state in auth-settings actions-settings waiting streaming error error-details context; do
   preview_output="$repo_dir/screenshots/implementation-omapilot-$preview_state.png"
   OMAPILOT_PREVIEW_STATE="$preview_state" OMAPILOT_PREVIEW_PATH="$preview_output" \
     QT_QPA_PLATFORM=offscreen timeout 5s quickshell --no-duplicate \

--- a/tests/check-ui-contract.sh
+++ b/tests/check-ui-contract.sh
@@ -43,8 +43,15 @@ grep -Fq 'Qt.resolvedUrl("../runtime/bin/quickchat-broker")' \
   "$repo_dir/components/QuickchatStore.qml"
 grep -Fq 'Quickshell.env("QUICKCHAT_BROKER_PATH") || bundledBrokerPath' \
   "$repo_dir/components/QuickchatStore.qml"
-grep -Fq 'property string configuredProvider: "codex"' \
+grep -Fq 'property string configuredProvider: "builtin"' \
   "$repo_dir/components/QuickchatStore.qml"
+grep -Fq 'harness: provider' "$repo_dir/components/QuickchatStore.qml"
+grep -Fq 'readonly property var modeProviders: Protocol.harnessOptions()' \
+  "$repo_dir/components/SettingsView.qml"
+if grep -Fq 'backendSelection' "$repo_dir/components/QuickchatStore.qml"; then
+  printf 'Harness selection must not be split into backend and provider settings\n' >&2
+  exit 1
+fi
 grep -Fq 'property bool desktopContextEnabled: true' \
   "$repo_dir/components/QuickchatStore.qml"
 grep -Fq 'DesktopContext.snapshot()' "$repo_dir/components/QuickchatStore.qml"
@@ -100,7 +107,7 @@ if grep -Eq 'sandboxed|Device commands stay blocked|sandbox limits stay active' 
   printf 'QML permission copy must not retain unreachable legacy policy branches\n' >&2
   exit 1
 fi
-grep -Fq 'Allow once may read or change device data and access the network' \
+grep -Fq 'Review the exact request and choose how long this agent may retain the approval.' \
   "$repo_dir/Panel.qml"
 grep -Fq 'readonly property bool popupOpen:' "$repo_dir/components/Composer.qml"
 grep -Fq 'var action = Presentation.escapeAction(root.viewMode, composer.popupOpen,' "$repo_dir/Panel.qml"

--- a/tests/tst_protocol.qml
+++ b/tests/tst_protocol.qml
@@ -147,14 +147,26 @@ TestCase {
     verify(Protocol.providerPolicyDescription("claude", { tools: "device-approval", web: "blocked", hostReads: false }).indexOf("web search") < 0)
   }
 
+  function test_harnessOptionsAreExplicitAndBuiltInFirst() {
+    var options = Protocol.harnessOptions()
+    compare(options.length, 4)
+    compare(options[0].value, "builtin")
+    compare(options[0].label, "Built-in (OmaPilot)")
+    compare(options[1].value, "codex")
+    compare(options[2].value, "claude")
+    compare(options[3].value, "opencode")
+  }
+
   function test_toolPermissionIsBoundToCurrentTurn() {
     var permission = Protocol.normalizedPermission({
       id: "permission-1", requestId: "turn-1", title: "Run uname",
-      kind: "execute", authority: "device", detail: "uname -s", allowOnce: true
+      kind: "execute", authority: "device", detail: "uname -s",
+      options: [{ id: "option-0", decision: "allow_once", label: "Allow once" }, { id: "option-1", decision: "allow_session", label: "Allow for session" }]
     }, "turn-1")
     compare(permission.detail, "uname -s")
     compare(permission.authority, "device")
-    verify(permission.allowOnce)
+    compare(permission.options.length, 2)
+    compare(permission.options[1].decision, "allow_session")
     compare(Protocol.normalizedPermission({ id: "permission-1", requestId: "other", kind: "execute" }, "turn-1"), null)
     compare(Protocol.normalizedPermission({ id: "permission-1", requestId: "turn-1", kind: "edit" }, "turn-1"), null)
     compare(Protocol.normalizedPermission({ id: "permission-1", requestId: "turn-1", kind: "local_action" }, "turn-1"), null)

--- a/tests/visual-preview.qml
+++ b/tests/visual-preview.qml
@@ -28,8 +28,8 @@ ShellRoot {
       : (root.previewState === "streaming" ? "streaming"
         : (root.previewState === "error" || root.previewState === "error-details"
           ? "error" : "composing"))
-    property string provider: "codex"
-    property string model: "gpt-5.4"
+    property string provider: "builtin"
+    property string model: "openai-codex::gpt-5.4"
     property string transcript: ""
     property string statusMessage: root.previewState === "waiting" ? "Preparing Codex…"
       : (root.previewState === "error" || root.previewState === "error-details"
@@ -47,11 +47,9 @@ ShellRoot {
     })
     property var pendingPermission: null
     property var providers: [
-      { value: "codex", label: "Codex", policy: { tools: "device-approval" } },
-      { value: "claude", label: "Claude", policy: { tools: "device-approval" } },
-      { value: "opencode", label: "OpenCode", policy: { tools: "device-approval" } }
+      { value: "builtin", label: "Built-in (OmaPilot)", policy: { tools: "device-approval" } }
     ]
-    property var modelOptions: [{ value: "gpt-5.4", label: "gpt-5.4" }]
+    property var modelOptions: [{ value: "openai-codex::gpt-5.4", label: "GPT-5.4 (openai-codex)" }]
     property var providerPolicy: ({ tools: "device-approval", web: "approved-command", hostReads: true })
     property var contextAttachments: root.previewState === "context" ? [{
       id: "11111111-1111-4111-8111-111111111111",

--- a/tests/visual-preview.qml
+++ b/tests/visual-preview.qml
@@ -18,16 +18,17 @@ ShellRoot {
 
   QtObject {
     id: backend
-    property bool initialized: true
+    property bool initialized: root.previewState !== "auth-settings"
     property bool busy: false
     property bool canSubmit: true
-    property bool canRetry: false
+    property bool canRetry: root.previewState === "auth-settings"
     property bool contextCaptureAvailable: true
     property bool desktopContextActive: false
-    property string state: root.previewState === "waiting" ? "preparing"
+    property string state: root.previewState === "auth-settings" ? "unavailable"
+      : (root.previewState === "waiting" ? "preparing"
       : (root.previewState === "streaming" ? "streaming"
         : (root.previewState === "error" || root.previewState === "error-details"
-          ? "error" : "composing"))
+          ? "error" : "composing")))
     property string provider: "builtin"
     property string model: "openai-codex::gpt-5.4"
     property string transcript: ""
@@ -46,10 +47,11 @@ ShellRoot {
       retryable: true
     })
     property var pendingPermission: null
-    property var providers: [
+    property var providers: root.previewState === "auth-settings" ? [] : [
       { value: "builtin", label: "Built-in (OmaPilot)", policy: { tools: "device-approval" } }
     ]
-    property var modelOptions: [{ value: "openai-codex::gpt-5.4", label: "GPT-5.4 (openai-codex)" }]
+    property var modelOptions: root.previewState === "auth-settings" ? []
+      : [{ value: "openai-codex::gpt-5.4", label: "GPT-5.4 (openai-codex)" }]
     property var providerPolicy: ({ tools: "device-approval", web: "approved-command", hostReads: true })
     property var contextAttachments: root.previewState === "context" ? [{
       id: "11111111-1111-4111-8111-111111111111",
@@ -71,6 +73,7 @@ ShellRoot {
     function stopDictation() {}
     function cancel() {}
     function retryBroker() {}
+    function authenticateBuiltIn() {}
     function copyText(text) {}
     function beginContextCapture() {}
     function setContextRepresentation(id, mode) {
@@ -82,7 +85,8 @@ ShellRoot {
   Window {
     id: previewWindow
     width: 860
-    height: root.previewState === "settings" || root.previewState === "dangerous-settings"
+    height: root.previewState === "settings" || root.previewState === "auth-settings"
+      || root.previewState === "dangerous-settings"
       || root.previewState === "actions-settings" ? 760
       : (root.previewState === "error-details" ? 520 : (root.previewState === "context" ? 430 : 320))
     visible: true
@@ -141,6 +145,7 @@ ShellRoot {
       OmaPilot.SettingsView {
         id: settingsView
         visible: root.previewState === "settings"
+          || root.previewState === "auth-settings"
           || root.previewState === "dangerous-settings"
           || root.previewState === "actions-settings"
         anchors.fill: parent
@@ -276,6 +281,7 @@ ShellRoot {
         && (header.implicitHeight <= 0 || composer.implicitHeight <= 0
           || actions.implicitHeight <= 0)
       var invalidSettings = (root.previewState === "settings"
+          || root.previewState === "auth-settings"
           || root.previewState === "dangerous-settings"
           || root.previewState === "actions-settings")
         && settingsView.implicitHeight <= 0

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "verbatimModuleSyntax": true,
-    "skipLibCheck": false,
+    "skipLibCheck": true,
     "outDir": "runtime/dist"
   },
   "include": ["runtime/src/**/*.ts", "runtime/test/**/*.ts", "runtime/scripts/**/*.mjs"]


### PR DESCRIPTION
## Summary

- add a bundled native Pi coding-agent harness with Codex subscription, OpenAI API, Claude, and OpenAI-compatible model support
- load standard ~/.agents skills and named agents while keeping executable extensions disabled
- support reviewed allow-once, session, durable, deny-once, and durable-deny decisions
- make Harness one explicit selector: Built-in (OmaPilot), Codex ACP, Claude ACP, or OpenCode ACP
- never fall back or substitute when the selected harness is unavailable
- guide unauthenticated Built-in users through Pi login in the OmaPilot config directory and offer Retry

## Validation

- repository validation: 167 passed, 12 opt-in live tests skipped
- QML/UI contract: 45 passed, plus Wayland/offscreen smoke and visual settings render
- packaged Built-in Codex OAuth turn: passed with the existing Codex subscription session
- packaged OpenAI-compatible API-key turn: passed against the isolated test endpoint
- selected Built-in with Pi disabled: verified no ACP substitution even with authenticated ACP fixtures present
- npm audit --omit=dev: 0 vulnerabilities

## Live auth note

The locally installed Claude CLI reports logged in, but its real request currently returns an expired OAuth token error. The selected Claude ACP path fails with the sanitized OmaPilot error and does not switch to another harness. A fresh Claude login is needed before rerunning the opt-in real Claude behavior test.