### PR TITLE
Embed built-in authentication flow

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -763,6 +763,7 @@ Panel {
         background: root.surface
         accent: root.accent
         fontFamily: root.fontFamily
+        onAuthenticationRequested: root.openSettings()
         onDismissed: root.showChat()
       }
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ coding tools behind OmaPilot's approval broker. See [Native Pi harness configura
 The Harness setting explicitly selects **Built-in (OmaPilot)**, **Codex**,
 **Claude**, or **OpenCode**. The latter three are ACP harnesses and must already
 be installed and signed in. OmaPilot never substitutes one harness for another.
+When Built-in has no configured credential, its settings card offers
+subscription and API-key sign-in methods. OmaPilot runs Pi's typed login flow
+inside the broker, opens the provider's browser page for OAuth when needed, and
+renders provider choices, device codes, manual-code fallbacks, progress, and
+errors in Settings. It never opens the Pi terminal.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ be installed and signed in. OmaPilot never substitutes one harness for another.
 When Built-in has no configured credential, its settings card offers
 subscription and API-key sign-in methods. OmaPilot runs Pi's typed login flow
 inside the broker, opens the provider's browser page for OAuth when needed, and
-renders provider choices, device codes, manual-code fallbacks, progress, and
-errors in Settings. It never opens the Pi terminal.
+renders provider choices, device codes, progress, and errors in Settings.
+Browser OAuth completes through a broker-owned localhost callback; callback
+URLs are never user input. It never opens the Pi terminal.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ The compact composer expands from the right side of the bar. Its result panel
 supports selectable Markdown, code blocks, tables, safe clickable links,
 bounded images, Copy, New chat, History, and Continue in Herdr. The in-panel
 settings pane can add, edit, remove, and reorder up to five quick actions.
+Built-in follow-ups resume the same durable Pi conversation until **New chat**
+is selected, including after the shell restarts. **Continue in Herdr** opens
+that same Pi session with OmaPilot's private auth and session directories.
 Waiting and streaming use one theme-native perimeter runner around the response
 surface. One GPU-blurred accent form replaces the old route glyph without a
 separate hard stroke or fake progress; phase changes never restart the runner,
@@ -211,7 +214,7 @@ invalid entries, and caps it at five.
 
 | Path | Purpose |
 | --- | --- |
-| `${XDG_STATE_HOME:-~/.local/state}/quickchat/` | Atomic local history and resumable session metadata |
+| `${XDG_STATE_HOME:-~/.local/state}/quickchat/` | Atomic local history and durable Pi conversation sessions |
 | `${XDG_CACHE_HOME:-~/.cache}/quickchat/` | Bounded, validated image cache |
 | `${XDG_RUNTIME_DIR}/quickchat/` | Per-login sockets, temporary dictation, and in-flight data |
 

--- a/components/ErrorDetailsView.qml
+++ b/components/ErrorDetailsView.qml
@@ -17,6 +17,7 @@ Item {
     backend ? backend.statusMessage : "OmaPilot could not complete that request.")
 
   signal dismissed()
+  signal authenticationRequested()
 
   implicitHeight: content.implicitHeight
 
@@ -184,6 +185,19 @@ Item {
             }
 
             Item { Layout.fillWidth: true }
+
+            Button {
+              visible: root.backend && root.backend.provider === "builtin"
+                && root.backend.providers.length === 0
+              text: "Open authentication"
+              foreground: root.foreground
+              background: root.background
+              accent: root.accent
+              active: true
+              bordered: true
+              focusable: true
+              onClicked: root.authenticationRequested()
+            }
 
             Button {
               visible: root.backend && root.backend.canRetry

--- a/components/Protocol.js
+++ b/components/Protocol.js
@@ -10,6 +10,13 @@ var validStates = [
   "complete", "canceled", "error", "unavailable", "history"
 ]
 
+function providerReadyState(currentState, providerCount) {
+  var current = String(currentState || "")
+  if (Number(providerCount || 0) > 0 && ["preparing", "unavailable"].indexOf(current) >= 0)
+    return "composing"
+  return current
+}
+
 function command(type, values) {
   var result = { type: String(type || "") }
   var source = values || {}

--- a/components/Protocol.js
+++ b/components/Protocol.js
@@ -17,6 +17,62 @@ function command(type, values) {
   return result
 }
 
+function normalizedAuthMethods(raw) {
+  var source = Array.isArray(raw) ? raw : []
+  var result = []
+  for (var i = 0; i < source.length && result.length < 32; i++) {
+    var method = source[i] && typeof source[i] === "object" ? source[i] : {}
+    var id = String(method.id || "")
+    var providerId = String(method.providerId || "")
+    var authType = String(method.authType || "")
+    if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}::(?:api_key|oauth)$/.test(id)
+        || !/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/.test(providerId)
+        || ["api_key", "oauth"].indexOf(authType) < 0) continue
+    result.push({
+      value: id,
+      label: safeContextText(method.label, 120) || providerId,
+      description: safeContextText(method.description, 240),
+      providerId: providerId,
+      authType: authType
+    })
+  }
+  return result
+}
+
+function normalizedAuthEvent(raw) {
+  var source = raw && typeof raw === "object" ? raw : {}
+  var phase = String(source.phase || "")
+  if (["starting", "prompt", "info", "browser", "device_code", "complete", "cancelled", "error"].indexOf(phase) < 0) return null
+  var result = {
+    phase: phase,
+    flowId: String(source.flowId || ""),
+    methodId: String(source.methodId || ""),
+    message: safeContextText(source.message || source.instructions, 500),
+    url: isSafeExternalUrl(source.url) ? String(source.url) : "",
+    verificationUri: isSafeExternalUrl(source.verificationUri) ? String(source.verificationUri) : "",
+    userCode: safeContextText(source.userCode, 120),
+    prompt: null
+  }
+  var prompt = source.prompt && typeof source.prompt === "object" ? source.prompt : null
+  if (prompt !== null) {
+    var kind = String(prompt.kind || "")
+    if (["text", "secret", "select", "manual_code"].indexOf(kind) >= 0) {
+      var options = []
+      var rawOptions = Array.isArray(prompt.options) ? prompt.options : []
+      for (var i = 0; i < rawOptions.length && options.length < 32; i++) {
+        var option = rawOptions[i] && typeof rawOptions[i] === "object" ? rawOptions[i] : {}
+        var optionId = safeContextText(option.id, 160)
+        if (!optionId) continue
+        options.push({ value: optionId, label: safeContextText(option.label, 120) || optionId,
+          description: safeContextText(option.description, 240) })
+      }
+      result.prompt = { id: String(prompt.id || ""), kind: kind,
+        message: safeContextText(prompt.message, 500), placeholder: safeContextText(prompt.placeholder, 500), options: options }
+    }
+  }
+  return result
+}
+
 function submitCommand(id, question, provider, model, desktopContext, dangerousAutoApprove, contextAttachments) {
   var payload = command("submit", {
     id: String(id || ""),

--- a/components/Protocol.js
+++ b/components/Protocol.js
@@ -80,12 +80,15 @@ function normalizedAuthEvent(raw) {
   return result
 }
 
-function submitCommand(id, question, provider, model, desktopContext, dangerousAutoApprove, contextAttachments) {
+function submitCommand(id, question, provider, model, desktopContext, dangerousAutoApprove, contextAttachments, resumeChatId) {
   var payload = command("submit", {
     id: String(id || ""),
     question: String(question || ""),
     provider: normalizedProvider(provider) || "builtin"
   })
+  var previousChat = String(resumeChatId || "")
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(previousChat))
+    payload.resumeChatId = previousChat
   var selectedModel = String(model || "").trim()
   if (selectedModel !== "") payload.model = selectedModel
   var context = normalizedDesktopContext(desktopContext)

--- a/components/Protocol.js
+++ b/components/Protocol.js
@@ -56,7 +56,7 @@ function normalizedAuthEvent(raw) {
   var prompt = source.prompt && typeof source.prompt === "object" ? source.prompt : null
   if (prompt !== null) {
     var kind = String(prompt.kind || "")
-    if (["text", "secret", "select", "manual_code"].indexOf(kind) >= 0) {
+    if (["text", "secret", "select"].indexOf(kind) >= 0) {
       var options = []
       var rawOptions = Array.isArray(prompt.options) ? prompt.options : []
       for (var i = 0; i < rawOptions.length && options.length < 32; i++) {

--- a/components/QuickchatStore.qml
+++ b/components/QuickchatStore.qml
@@ -499,6 +499,12 @@ Scope {
     }
     provider = configuredProvider
     selectProvider(configuredProvider)
+    var readyState = Protocol.providerReadyState(state, providers.length)
+    if (readyState !== state) {
+      state = readyState
+      statusMessage = ""
+      errorDetails = null
+    }
   }
 
   function prependHistory(chat) {
@@ -531,11 +537,6 @@ Scope {
       brokerContextAttachmentsSupported = Protocol.hasFeature(event.features, "context-attachments")
       applyProviders(event.providers || [])
       history = Protocol.normalizedHistory(event.history || [])
-      if (providers.length > 0 && (state === "preparing" || state === "unavailable")) {
-        state = "composing"
-        statusMessage = ""
-        errorDetails = null
-      }
       return
     }
     if (type === "providers") {

--- a/components/QuickchatStore.qml
+++ b/components/QuickchatStore.qml
@@ -21,7 +21,6 @@ Scope {
     return url
   }
   readonly property string brokerPath: Quickshell.env("QUICKCHAT_BROKER_PATH") || bundledBrokerPath
-
   property string state: "preparing"
   property string statusMessage: "Starting OmaPilot…"
   property string currentId: ""
@@ -31,6 +30,9 @@ Scope {
   property var errorDetails: null
   property var images: []
   property var providers: []
+  property var builtinAuthMethods: []
+  property var builtinAuth: ({ phase: "idle", flowId: "", methodId: "", message: "", url: "",
+    verificationUri: "", userCode: "", prompt: null })
   property var history: []
   property string provider: "builtin"
   property string model: ""
@@ -73,6 +75,8 @@ Scope {
     || browserCompanionStatus.firefoxConnected === true
   readonly property bool browserCompanionBusy: browserCompanionStatus.phase === "installing"
     || browserCompanionStatus.phase === "removing"
+  readonly property bool builtinAuthBusy: ["starting", "prompt", "info", "browser", "device_code"]
+    .indexOf(String(builtinAuth.phase || "")) >= 0
 
   signal answerChanged()
   signal focusComposerRequested()
@@ -407,6 +411,34 @@ Scope {
     } else broker.running = true
   }
 
+  function authenticateBuiltIn(methodId) {
+    if (provider !== "builtin" || builtinAuthBusy) return
+    var selected = String(methodId || "")
+    if (selected === "" && builtinAuthMethods.length > 0) selected = String(builtinAuthMethods[0].value || "")
+    if (selected === "") return
+    builtinAuth = ({ phase: "starting", flowId: "", methodId: selected,
+      message: "Starting secure authentication…", url: "", verificationUri: "", userCode: "", prompt: null })
+    sendCommand(Protocol.command("auth_begin", { methodId: selected }))
+  }
+
+  function respondBuiltInAuth(value) {
+    var prompt = builtinAuth.prompt
+    if (!prompt || !builtinAuth.flowId) return
+    sendCommand(Protocol.command("auth_response", {
+      flowId: String(builtinAuth.flowId), promptId: String(prompt.id || ""), value: String(value || "")
+    }))
+    var next = {}
+    for (var key in builtinAuth) next[key] = builtinAuth[key]
+    next.prompt = null
+    next.phase = "info"
+    next.message = "Continuing authentication…"
+    builtinAuth = next
+  }
+
+  function cancelBuiltInAuth() {
+    if (!builtinAuth.flowId) return
+    sendCommand(Protocol.command("auth_cancel", { flowId: String(builtinAuth.flowId) }))
+  }
   function activateLink(url) {
     var value = String(url || "")
     if (Protocol.isImageLink(value)) {
@@ -451,12 +483,11 @@ Scope {
     providers = Protocol.exactHarnessProviders(raw, configuredProvider)
     if (providers.length === 0) {
       state = "unavailable"
-      var configHome = Quickshell.env("XDG_CONFIG_HOME") || (Quickshell.env("HOME") + "/.config")
       var mismatched = discovered.length > 0
       statusMessage = mismatched
         ? "OmaPilot refused an unexpected harness response. Restart the selected harness and try again."
         : configuredProvider === "builtin"
-          ? "Built-in (OmaPilot) needs authentication. In a terminal run PI_CODING_AGENT_DIR=\"" + configHome + "/omapilot\" pi, choose /login, then Retry."
+          ? "Built-in (OmaPilot) needs authentication. Finish the secure setup in Settings."
           : Protocol.providerLabel(configuredProvider) + " is unavailable. Install and sign in to it, then retry or choose another harness in Settings."
       errorDetails = Protocol.normalizedError({
         unavailable: true,
@@ -509,6 +540,32 @@ Scope {
     }
     if (type === "providers") {
       applyProviders(event.providers || [])
+      return
+    }
+    if (type === "auth_methods") {
+      builtinAuthMethods = Protocol.normalizedAuthMethods(event.methods || [])
+      return
+    }
+    if (type === "auth") {
+      var authEvent = Protocol.normalizedAuthEvent(event)
+      if (!authEvent) return
+      if (authEvent.phase !== "starting" && builtinAuth.flowId
+          && authEvent.flowId !== String(builtinAuth.flowId)) return
+      if (!builtinAuth.flowId && authEvent.phase !== "starting" && builtinAuth.methodId
+          && authEvent.methodId !== String(builtinAuth.methodId)) return
+      var merged = {}
+      for (var authKey in builtinAuth) merged[authKey] = builtinAuth[authKey]
+      for (var eventKey in authEvent) {
+        if (eventKey === "prompt" && authEvent.prompt === null && authEvent.phase !== "complete"
+            && authEvent.phase !== "cancelled" && authEvent.phase !== "error") continue
+        if ((eventKey === "url" || eventKey === "verificationUri" || eventKey === "userCode")
+            && String(authEvent[eventKey] || "") === "") continue
+        merged[eventKey] = authEvent[eventKey]
+      }
+      builtinAuth = merged
+      if (authEvent.phase === "browser" && authEvent.url) activateLink(authEvent.url)
+      else if (authEvent.phase === "device_code" && authEvent.verificationUri) activateLink(authEvent.verificationUri)
+      if (authEvent.phase === "complete") toastRequested("Built-in authentication complete")
       return
     }
     if (type === "state") {

--- a/components/QuickchatStore.qml
+++ b/components/QuickchatStore.qml
@@ -210,6 +210,7 @@ Scope {
   function submit(text) {
     var prompt = String(text || "").trim()
     if (!prompt || !canSubmit) return false
+    var resumeChatId = currentChatId
     currentId = "qml-" + Date.now() + "-" + Math.floor(Math.random() * 100000)
     currentChatId = ""
     question = prompt
@@ -228,7 +229,7 @@ Scope {
     }
     var autoApprove = configuredDangerousAutoApprove
     sendCommand(Protocol.submitCommand(
-      currentId, prompt, provider, model, context, autoApprove, attachmentSelections))
+      currentId, prompt, provider, model, context, autoApprove, attachmentSelections, resumeChatId))
     contextAttachments = []
     answerChanged()
     return true

--- a/components/SettingsView.qml
+++ b/components/SettingsView.qml
@@ -25,7 +25,10 @@ Item {
   readonly property bool browserCompanionBusy: backend ? backend.browserCompanionBusy === true : false
   property bool browserRemoveConfirmation: false
   property bool browserSetupExpanded: false
+  property string selectedAuthMethod: ""
+  property string authPromptSelection: ""
   readonly property bool popupOpen: providerPicker.popupOpen || modelPicker.popupOpen
+    || authMethodPicker.popupOpen || authPromptPicker.popupOpen
   readonly property bool modalInteractionActive: popupOpen
     || browserRemoveConfirmation
     || browserCompanionBusy
@@ -48,6 +51,8 @@ Item {
   function closePopups(restoreFocus) {
     providerPicker.close()
     modelPicker.close()
+    authMethodPicker.close()
+    authPromptPicker.close()
     if (restoreFocus !== false)
       Qt.callLater(function() { backButton.forceActiveFocus() })
   }
@@ -487,6 +492,193 @@ Item {
             onChanged: function(value) { root.providerChanged(value) }
           }
 
+          BorderSurface {
+            Layout.fillWidth: true
+            visible: root.backend && root.backend.provider === "builtin"
+              && root.backend.state === "unavailable" && root.backend.providers.length === 0
+            implicitHeight: authContent.implicitHeight + contentTopInset + contentBottomInset
+              + Style.spacing.xl * 2
+            color: Style.normalFillFor(root.accent, root.accent)
+            borderSpec: Border.controlSpec("normal", root.accent, root.accent)
+            radius: Style.cornerRadius
+
+            ColumnLayout {
+              id: authContent
+              anchors.left: parent.left
+              anchors.right: parent.right
+              anchors.top: parent.top
+              anchors.leftMargin: parent.contentLeftInset + Style.spacing.xl
+              anchors.rightMargin: parent.contentRightInset + Style.spacing.xl
+              anchors.topMargin: parent.contentTopInset + Style.spacing.xl
+              spacing: Style.spacing.md
+
+              Text {
+                Layout.fillWidth: true
+                text: "Authentication required"
+                color: root.foreground
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.body
+                font.bold: true
+              }
+
+              Text {
+                Layout.fillWidth: true
+                text: "Sign in here with a subscription or API key. OmaPilot runs the provider flow in the background and stores credentials only in its private configuration."
+                color: Qt.darker(root.foreground, 1.35)
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.caption
+                wrapMode: Text.Wrap
+                Accessible.role: Accessible.StaticText
+                Accessible.name: text
+              }
+
+              Dropdown {
+                id: authMethodPicker
+                Layout.fillWidth: true
+                visible: root.backend && !root.backend.builtinAuthBusy
+                  && String(root.backend.builtinAuth.phase || "") !== "complete"
+                showLabel: false
+                options: root.backend ? root.backend.builtinAuthMethods : []
+                value: root.selectedAuthMethod || (options.length > 0 ? String(options[0].value || "") : "")
+                enabled: options.length > 0
+                foreground: root.foreground
+                background: root.background
+                Accessible.name: "Built-in authentication method"
+                onChanged: function(value) { root.selectedAuthMethod = value }
+              }
+
+              Text {
+                Layout.fillWidth: true
+                visible: root.backend && String(root.backend.builtinAuth.message || "") !== ""
+                text: root.backend ? String(root.backend.builtinAuth.message || "") : ""
+                color: root.backend && String(root.backend.builtinAuth.phase || "") === "error"
+                  ? Color.urgent : Qt.darker(root.foreground, 1.35)
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.caption
+                wrapMode: Text.Wrap
+              }
+
+              RowLayout {
+                Layout.fillWidth: true
+                visible: root.backend && (String(root.backend.builtinAuth.url || "") !== ""
+                  || String(root.backend.builtinAuth.verificationUri || "") !== "")
+                spacing: Style.spacing.md
+
+                Button {
+                  text: "Open sign-in page"
+                  iconText: "󰖟"
+                  foreground: root.foreground
+                  background: root.background
+                  accent: root.accent
+                  active: true
+                  bordered: true
+                  focusable: true
+                  onClicked: root.backend.activateLink(String(root.backend.builtinAuth.url
+                    || root.backend.builtinAuth.verificationUri || ""))
+                }
+
+                Button {
+                  visible: root.backend && String(root.backend.builtinAuth.userCode || "") !== ""
+                  text: "Copy " + (root.backend ? String(root.backend.builtinAuth.userCode || "") : "")
+                  foreground: root.foreground
+                  background: root.background
+                  bordered: true
+                  focusable: true
+                  onClicked: root.backend.copyText(String(root.backend.builtinAuth.userCode || ""))
+                }
+
+                Item { Layout.fillWidth: true }
+              }
+
+              Text {
+                Layout.fillWidth: true
+                visible: root.backend && root.backend.builtinAuth.prompt
+                text: visible ? String(root.backend.builtinAuth.prompt.message || "") : ""
+                color: root.foreground
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.caption
+                wrapMode: Text.Wrap
+              }
+
+              Dropdown {
+                id: authPromptPicker
+                Layout.fillWidth: true
+                visible: root.backend && root.backend.builtinAuth.prompt
+                  && root.backend.builtinAuth.prompt.kind === "select"
+                showLabel: false
+                options: visible ? root.backend.builtinAuth.prompt.options : []
+                value: root.authPromptSelection || (options.length > 0 ? String(options[0].value || "") : "")
+                foreground: root.foreground
+                background: root.background
+                Accessible.name: visible ? String(root.backend.builtinAuth.prompt.message || "Authentication choice") : "Authentication choice"
+                onChanged: function(value) { root.authPromptSelection = value }
+              }
+
+              TextField {
+                id: authPromptInput
+                Layout.fillWidth: true
+                visible: root.backend && root.backend.builtinAuth.prompt
+                  && root.backend.builtinAuth.prompt.kind !== "select"
+                password: visible && root.backend.builtinAuth.prompt.kind === "secret"
+                placeholderText: visible ? String(root.backend.builtinAuth.prompt.placeholder
+                  || root.backend.builtinAuth.prompt.message || "") : ""
+                maximumLength: 32768
+                foreground: root.foreground
+                accent: root.accent
+                Accessible.name: visible ? String(root.backend.builtinAuth.prompt.message || "Authentication value") : "Authentication value"
+                onVisibleChanged: if (visible) { text = ""; forceActiveFocus() }
+                onAccepted: if (visible) root.backend.respondBuiltInAuth(text)
+              }
+
+              RowLayout {
+                Layout.fillWidth: true
+                spacing: Style.spacing.md
+
+                Button {
+                  visible: root.backend && !root.backend.builtinAuthBusy
+                    && String(root.backend.builtinAuth.phase || "") !== "complete"
+                  text: String(root.backend && root.backend.builtinAuth.phase || "") === "error" ? "Try again" : "Continue"
+                  iconText: "󰌾"
+                  foreground: root.foreground
+                  background: root.background
+                  accent: root.accent
+                  active: true
+                  bordered: true
+                  focusable: true
+                  enabled: authMethodPicker.options.length > 0
+                  onClicked: root.backend.authenticateBuiltIn(authMethodPicker.value)
+                }
+
+                Button {
+                  visible: root.backend && root.backend.builtinAuth.prompt
+                  text: "Continue"
+                  foreground: root.foreground
+                  background: root.background
+                  accent: root.accent
+                  active: true
+                  bordered: true
+                  focusable: true
+                  enabled: root.backend && root.backend.builtinAuth.prompt
+                    ? (root.backend.builtinAuth.prompt.kind === "select"
+                      ? authPromptPicker.value !== "" : authPromptInput.text !== "") : false
+                  onClicked: root.backend.respondBuiltInAuth(root.backend.builtinAuth.prompt.kind === "select"
+                    ? authPromptPicker.value : authPromptInput.text)
+                }
+
+                Button {
+                  visible: root.backend && root.backend.builtinAuthBusy
+                  text: "Cancel"
+                  foreground: root.foreground
+                  background: root.background
+                  bordered: true
+                  focusable: true
+                  onClicked: root.backend.cancelBuiltInAuth()
+                }
+
+                Item { Layout.fillWidth: true }
+              }
+            }
+          }
           Text {
             Layout.fillWidth: true
             text: "Model"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,8 @@ The broker emits events whose `type` is one of `ready`, `providers`, `state`, `c
 The broker's internal run contract is the normalization boundary, not the policy
 boundary. Initialization selects exactly one harness: the embedded Pi runtime
 or one ACP harness. Discovery failure never switches harnesses. The submit
-command contains provider/model/question plus an optional versioned desktop
+command contains provider/model/question, an optional prior chat identity for
+same-harness continuation, plus an optional versioned desktop
 snapshot and up to four opaque context-attachment selections. QML latches the active app and
 its capture rectangle immediately before the panel takes focus
 and synchronously reads the current app/workspace/media inventory from
@@ -44,9 +45,11 @@ Quickshell's public Hyprland and MPRIS objects at submit time; it does not poll
 field counts, lengths, and control characters, then frames the snapshot as
 untrusted observational JSON before the authoritative user request. It sends
 the combined prompt to the selected ACP session but stores only the original
-question in Quickchat history. Provider-native session retention still applies.
-Native Herdr resume therefore inherits provider-retained context, while the
-transcript fallback contains only the stored question and answer.
+question in Quickchat history. The Built-in runtime stores Pi sessions beneath
+the Quickchat XDG state root and resolves continuation only through a validated
+saved chat and session identity. Native Herdr resume therefore inherits the Pi
+conversation and uses a pane-scoped OmaPilot configuration environment; the
+transcript fallback remains available when a native harness cannot resume.
 
 ## Explicit context clips
 

--- a/docs/native-harness.md
+++ b/docs/native-harness.md
@@ -35,6 +35,17 @@ from `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `auth.json`:
 }
 ```
 
+Completed Built-in turns are written to durable Pi JSONL sessions under
+`${XDG_STATE_HOME:-$HOME/.local/state}/quickchat/pi-sessions/`. A follow-up from
+the main screen or Recent chats resumes that exact session; **New chat** creates
+a new one. Session-scoped approvals remain active for the conversation while
+the broker is running, while persistent approvals remain in `approvals.json`.
+
+**Continue in Herdr** starts Herdr's native `pi` agent with the saved session.
+Before launch, OmaPilot scopes that pane to its private configuration and
+session directories, so the interactive Pi process uses the same credential
+and conversation without copying tokens into command arguments.
+
 Codex subscription and Claude subscription OAuth entries use the
 `openai-codex` and `anthropic` keys respectively. Normally, configure these from
 the authentication card under OmaPilot Settings. The broker invokes Pi's native

--- a/docs/native-harness.md
+++ b/docs/native-harness.md
@@ -40,7 +40,9 @@ Codex subscription and Claude subscription OAuth entries use the
 the authentication card under OmaPilot Settings. The broker invokes Pi's native
 typed login APIs in the background: secrets are entered in a password field,
 OAuth continues in the system browser, and provider prompts, device codes,
-progress, cancellation, and failures remain visible in OmaPilot. No Pi terminal
+progress, cancellation, and failures remain visible in OmaPilot. Codex browser
+OAuth returns to the broker's fixed `http://localhost:1455/auth/callback`
+listener; OmaPilot never asks the user to paste a callback URL. No Pi terminal
 or `/login` handoff is involved.
 
 ## OpenAI-compatible providers

--- a/docs/native-harness.md
+++ b/docs/native-harness.md
@@ -36,16 +36,12 @@ from `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `auth.json`:
 ```
 
 Codex subscription and Claude subscription OAuth entries use the
-`openai-codex` and `anthropic` keys respectively. A Pi CLI can initialize them
-in the same directory:
-
-```bash
-PI_CODING_AGENT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/omapilot" pi
-```
-
-Use Pi's `/login` command, exit Pi, then choose **Retry** in OmaPilot so provider
-discovery sees the new credential. OmaPilot never downloads or launches the Pi
-CLI; this is an explicit user-owned setup action.
+`openai-codex` and `anthropic` keys respectively. Normally, configure these from
+the authentication card under OmaPilot Settings. The broker invokes Pi's native
+typed login APIs in the background: secrets are entered in a password field,
+OAuth continues in the system browser, and provider prompts, device codes,
+progress, cancellation, and failures remain visible in OmaPilot. No Pi terminal
+or `/login` handoff is involved.
 
 ## OpenAI-compatible providers
 

--- a/runtime/src/broker.ts
+++ b/runtime/src/broker.ts
@@ -288,6 +288,16 @@ export class QuickchatBroker {
       this.#error("provider_unavailable", "The selected harness is not installed and authenticated", false, command.id);
       return;
     }
+    let resumeSessionId: string | undefined;
+    if (isPiProvider(provider) && command.resumeChatId !== undefined) {
+      const previous = await this.#history.get(command.resumeChatId);
+      if (previous?.provider !== provider.id || !previous.session.resumable || previous.session.acpId === undefined) {
+        await this.#contextAttachments.discardMany((command.contextAttachments ?? []).map((value) => value.id));
+        this.#error("session_unavailable", "The saved Pi conversation is unavailable", false, command.id);
+        return;
+      }
+      resumeSessionId = previous.session.acpId;
+    }
     const dangerousAutoApprove = command.dangerousAutoApprove === true
       && provider.policy.tools === "device-approval";
     this.#emit({ type: "state", id: command.id, state: "preparing", message: `Preparing ${provider.name}…` });
@@ -311,7 +321,7 @@ export class QuickchatBroker {
     const run = isPiProvider(provider)
       ? (await import("./pi-harness.js")).runPiQuestion(
         provider, command.id, prompt, command.model, this.#emit, 180_000, permission,
-        () => this.#cancelPermissions(command.id))
+        () => this.#cancelPermissions(command.id), resumeSessionId)
       : runAcpQuestion(provider, command.id, prompt, command.model,
         this.#emit, 180_000, this.#images, permission,
         () => this.#cancelPermissions(command.id));

--- a/runtime/src/broker.ts
+++ b/runtime/src/broker.ts
@@ -13,6 +13,7 @@ import { discoverProviders, fallbackModels, isPiProvider, type DiscoveredProvide
 import { resolveExecutable, runCommand } from "./process.js";
 import type { BrokerCommand, BrokerEvent, ChatRecord, ProviderId, ProviderInfo } from "./types.js";
 import type { RequestPermissionRequest } from "@agentclientprotocol/sdk";
+import type { AuthEvent, AuthPrompt } from "../../node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/auth/types.js";
 import { BrowserCompanionServer, type BrowserCapture } from "./browser-companion.js";
 import {
   browserCompanionSetupStatus,
@@ -30,6 +31,18 @@ type PermissionWaiter = PendingToolPermission & {
   resolve: (decision: PermissionDecision) => void;
   timeout: NodeJS.Timeout;
 };
+type AuthPromptWaiter = {
+  id: string;
+  resolve: (value: string) => void;
+  reject: (error: Error) => void;
+  cleanup: () => void;
+};
+type AuthFlow = {
+  id: string;
+  methodId: string;
+  controller: AbortController;
+  prompt?: AuthPromptWaiter;
+};
 
 export class QuickchatBroker {
   readonly #emit: (event: BrokerEvent) => void;
@@ -46,6 +59,7 @@ export class QuickchatBroker {
   #runs = new Map<string, AcpRun>();
   #handoffs = new Map<string, Promise<void>>();
   #permissions = new Map<string, PermissionWaiter>();
+  #authFlow: AuthFlow | undefined;
   #submissions = new Set<string>();
   #dictationGeneration = 0;
   #browserCompanionSetupBusy = false;
@@ -90,6 +104,9 @@ export class QuickchatBroker {
       case "browser_companion_install": await this.#installBrowserCompanion(); break;
       case "browser_companion_uninstall": await this.#uninstallBrowserCompanion(); break;
       case "browser_companion_open_settings": await this.#openBrowserCompanionSettings(command.family); break;
+      case "auth_begin": this.#beginAuth(command.methodId); break;
+      case "auth_response": this.#respondAuth(command); break;
+      case "auth_cancel": this.#cancelAuth(command.flowId); break;
       case "cancel": await this.#cancel(command.id); break;
       case "permission_response": this.#respondPermission(command); break;
       case "history_list": await this.#emitHistory(); break;
@@ -113,6 +130,7 @@ export class QuickchatBroker {
       case "open_link": await this.#openLink(command.url); break;
       case "copy": await this.#copy(command.text); break;
       case "shutdown": {
+        this.#cancelAuth(this.#authFlow?.id);
         await Promise.all([...this.#runs.values()].map((run) => run.cancel()));
         await this.#browserCompanion.close();
         return false;
@@ -126,7 +144,12 @@ export class QuickchatBroker {
       this.#error("unsupported_protocol", "Quickchat supports broker protocol version 2", false);
       return;
     }
-    const discovered = await discoverProviders(this.#env, command.harness);
+    const [discovered, authMethods] = await Promise.all([
+      discoverProviders(this.#env, command.harness),
+      command.harness === "builtin"
+        ? import("./pi-harness.js").then(({ discoverPiAuthMethods }) => discoverPiAuthMethods(this.#env)).catch(() => [])
+        : Promise.resolve([])
+    ]);
     await this.#browserCompanion.start().catch(() => undefined);
     await this.#emitBrowserCompanionStatus();
     await Promise.all(discovered.map(async (provider) => {
@@ -139,6 +162,109 @@ export class QuickchatBroker {
     this.#providers = new Map(discovered.map((provider) => [provider.id, provider]));
     const history = (await this.#history.list()).map((chat) => presentChat(chat));
     this.#emit({ type: "ready", protocolVersion: 2, features: ["desktop-context", "context-attachments"], providers: discovered.map(publicProvider), history });
+    if (command.harness === "builtin") this.#emit({ type: "auth_methods", methods: authMethods });
+  }
+
+  #beginAuth(methodId: string): void {
+    if (this.#authFlow !== undefined) this.#cancelAuth(this.#authFlow.id);
+    const flow: AuthFlow = { id: randomUUID(), methodId, controller: new AbortController() };
+    this.#authFlow = flow;
+    this.#emit({ type: "auth", phase: "starting", flowId: flow.id, methodId, message: "Starting secure authentication…" });
+    void this.#runAuth(flow);
+  }
+
+  async #runAuth(flow: AuthFlow): Promise<void> {
+    try {
+      const { discoverPiAuthMethods, loginPiProvider } = await import("./pi-harness.js");
+      await loginPiProvider(this.#env, flow.methodId, {
+        signal: flow.controller.signal,
+        prompt: (prompt) => this.#promptAuth(flow, prompt),
+        notify: (event) => this.#notifyAuth(flow, event)
+      });
+      if (flow.controller.signal.aborted || this.#authFlow?.id !== flow.id) return;
+      const discovered = await discoverProviders(this.#env, "builtin");
+      this.#providers = new Map(discovered.map((provider) => [provider.id, provider]));
+      this.#emit({ type: "providers", providers: discovered.map(publicProvider) });
+      this.#emit({ type: "auth_methods", methods: await discoverPiAuthMethods(this.#env) });
+      this.#emit({ type: "auth", phase: "complete", flowId: flow.id, methodId: flow.methodId, message: "Authentication complete. OmaPilot is ready." });
+    } catch (error) {
+      if (flow.controller.signal.aborted) {
+        this.#emit({ type: "auth", phase: "cancelled", flowId: flow.id, methodId: flow.methodId, message: "Authentication cancelled." });
+      } else {
+        this.#emit({ type: "auth", phase: "error", flowId: flow.id, methodId: flow.methodId,
+          message: error instanceof Error && error.message === "Authentication prompt was cancelled"
+            ? error.message : "Authentication could not be completed. Check the details and try again." });
+      }
+    } finally {
+      flow.prompt?.cleanup();
+      if (this.#authFlow?.id === flow.id) this.#authFlow = undefined;
+    }
+  }
+
+  #promptAuth(flow: AuthFlow, prompt: AuthPrompt): Promise<string> {
+    if (flow.controller.signal.aborted || this.#authFlow?.id !== flow.id)
+      return Promise.reject(new Error("Authentication prompt was cancelled"));
+    flow.prompt?.reject(new Error("Authentication prompt was cancelled"));
+    return new Promise<string>((resolve, reject) => {
+      const promptId = randomUUID();
+      const signals = [flow.controller.signal, prompt.signal].filter((signal): signal is AbortSignal => signal !== undefined);
+      const signal = signals.length === 1 ? (signals[0] ?? flow.controller.signal) : AbortSignal.any(signals);
+      const onAbort = (): void => reject(new Error("Authentication prompt was cancelled"));
+      const cleanup = (): void => signal.removeEventListener("abort", onAbort);
+      flow.prompt = {
+        id: promptId,
+        resolve: (value) => { cleanup(); resolve(value); },
+        reject: (error) => { cleanup(); reject(error); },
+        cleanup
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+      this.#emit({
+        type: "auth", phase: "prompt", flowId: flow.id, methodId: flow.methodId,
+        prompt: {
+          id: promptId,
+          kind: prompt.type,
+          message: prompt.message,
+          ...("placeholder" in prompt && prompt.placeholder !== undefined ? { placeholder: prompt.placeholder } : {}),
+          ...(prompt.type === "select" ? { options: prompt.options.map((option) => ({ ...option })) } : {})
+        }
+      });
+    });
+  }
+
+  #notifyAuth(flow: AuthFlow, event: AuthEvent): void {
+    if (this.#authFlow?.id !== flow.id || flow.controller.signal.aborted) return;
+    if (event.type === "auth_url") {
+      if (!isAllowedExternalLink(event.url)) return;
+      this.#emit({ type: "auth", phase: "browser", flowId: flow.id, methodId: flow.methodId,
+        url: event.url, ...(event.instructions === undefined ? {} : { instructions: event.instructions }) });
+      return;
+    }
+    if (event.type === "device_code") {
+      if (!isAllowedExternalLink(event.verificationUri)) return;
+      this.#emit({ type: "auth", phase: "device_code", flowId: flow.id, methodId: flow.methodId,
+        userCode: event.userCode, verificationUri: event.verificationUri,
+        ...(event.expiresInSeconds === undefined ? {} : { expiresInSeconds: event.expiresInSeconds }) });
+      return;
+    }
+    const links = event.type === "info" ? event.links?.filter((link) => isAllowedExternalLink(link.url)).map((link) => ({ ...link })) : undefined;
+    this.#emit({ type: "auth", phase: "info", flowId: flow.id, methodId: flow.methodId,
+      message: event.message, ...(links === undefined ? {} : { links }) });
+  }
+
+  #respondAuth(command: Extract<BrokerCommand, { type: "auth_response" }>): void {
+    const flow = this.#authFlow;
+    if (flow?.id !== command.flowId || flow.prompt?.id !== command.promptId) return;
+    const prompt = flow.prompt;
+    delete flow.prompt;
+    prompt.resolve(command.value);
+  }
+
+  #cancelAuth(flowId: string | undefined): void {
+    const flow = this.#authFlow;
+    if (flow === undefined || flowId === undefined || flow.id !== flowId) return;
+    this.#authFlow = undefined;
+    flow.controller.abort();
+    flow.prompt?.reject(new Error("Authentication prompt was cancelled"));
   }
 
   async #submit(command: Extract<BrokerCommand, { type: "submit" }>): Promise<void> {

--- a/runtime/src/broker.ts
+++ b/runtime/src/broker.ts
@@ -10,7 +10,7 @@ import { continueInHerdr, describeHerdrError } from "./herdr.js";
 import { ImagePolicyError, ImageStore, isAllowedExternalLink } from "./images.js";
 import { normalizeToolPermission, type PendingToolPermission } from "./permissions.js";
 import { discoverProviders, fallbackModels, isPiProvider, type DiscoveredProvider } from "./providers.js";
-import { resolveExecutable, runCommand } from "./process.js";
+import { launchDetached, resolveExecutable } from "./process.js";
 import type { BrokerCommand, BrokerEvent, ChatRecord, ProviderId, ProviderInfo } from "./types.js";
 import type { RequestPermissionRequest } from "@agentclientprotocol/sdk";
 import type { AuthEvent, AuthPrompt } from "../../node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/auth/types.js";
@@ -218,6 +218,10 @@ export class QuickchatBroker {
         cleanup
       };
       signal.addEventListener("abort", onAbort, { once: true });
+      // Browser OAuth providers already start a broker-owned localhost callback
+      // listener before issuing this compatibility fallback. Keep the promise
+      // alive for cancellation, but do not ask users to paste callback URLs.
+      if (prompt.type === "manual_code") return;
       this.#emit({
         type: "auth", phase: "prompt", flowId: flow.id, methodId: flow.methodId,
         prompt: {
@@ -586,8 +590,7 @@ export class QuickchatBroker {
     if (!isAllowedExternalLink(url)) { this.#emit({ type: "link", url, opened: false }); return; }
     const opener = await resolveExecutable("xdg-open", this.#env);
     if (opener === undefined) { this.#emit({ type: "link", url, opened: false }); return; }
-    const result = await runCommand(opener, [url], { env: this.#env, timeoutMs: 5_000, maxOutput: 8_192 });
-    this.#emit({ type: "link", url, opened: result.code === 0 });
+    this.#emit({ type: "link", url, opened: await launchDetached(opener, [url], { env: this.#env }) });
   }
 
   async #copy(text: string): Promise<void> {

--- a/runtime/src/herdr.ts
+++ b/runtime/src/herdr.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import type { ChatRecord, ProviderId } from "./types.js";
+import { quickchatPaths } from "./paths.js";
 import { resolveExecutable, runCommand } from "./process.js";
 
 type HerdrCommand = { executable: string; args: string[] };
@@ -68,12 +69,18 @@ function nestedArray(value: unknown, key: string): unknown[] | undefined {
   return Array.isArray(entry) ? entry : undefined;
 }
 
-export function nativeResumeArgs(provider: ProviderId, sessionId: string, cwd = process.cwd()): string[] | undefined {
+export function nativeResumeArgs(
+  provider: ProviderId,
+  sessionId: string,
+  cwd = process.cwd(),
+  env: NodeJS.ProcessEnv = process.env
+): string[] | undefined {
   // Continue in Herdr deliberately hands authority back to the native harness.
   // Keep Codex interactive so any command outside its read-only sandbox still
   // requires the user's approval in Herdr.
   if (provider === "codex") return ["resume", sessionId, "-C", cwd, "-s", "read-only", "-a", "on-request"];
   if (provider === "claude") return ["--resume", sessionId];
+  if (provider === "builtin") return ["--session", sessionId, "--session-dir", quickchatPaths(env).piSessions, "--approve"];
   return ["--pure", "--session", sessionId];
 }
 
@@ -145,9 +152,10 @@ export async function continueInHerdr(
     const workspaceId = target.workspaceId;
     const resume = !chat.session.resumable || chat.session.acpId === undefined
       ? undefined
-      : nativeResumeArgs(chat.provider, chat.session.acpId, cwd);
+      : nativeResumeArgs(chat.provider, chat.session.acpId, cwd, env);
     let mode: "native" | "transcript" = resume === undefined ? "transcript" : "native";
     const initialAgentName = resume === undefined ? transcriptAgentName : agentName;
+    await prepareAgentPane(commands.herdr, chat.provider, target.paneId, env, run, wait);
     let started = await startAgent(commands.herdr, chat.provider, initialAgentName, target.paneId, resume, run, wait);
 
     if (started.code !== 0) {
@@ -165,6 +173,7 @@ export async function continueInHerdr(
       mode = "transcript";
       const nativeTabId = target.tabId;
       target = await createTabTarget(commands.herdr, workspaceId, cwd, chat.title, run, createdTabs);
+      await prepareAgentPane(commands.herdr, chat.provider, target.paneId, env, run, wait);
       started = await startAgent(commands.herdr, chat.provider, transcriptAgentName, target.paneId, undefined, run, wait);
       if (started.code !== 0)
         throw new HerdrHandoffError("session", herdrCliErrorCode(started) ?? "agent_start_failed");
@@ -333,7 +342,8 @@ async function startAgent(
   run: CommandRunner,
   wait: Delay
 ): Promise<RunResult> {
-  const args = ["agent", "start", agentName, "--kind", provider, "--pane", paneId, "--timeout", "30000"];
+  const kind = provider === "builtin" ? "pi" : provider;
+  const args = ["agent", "start", agentName, "--kind", kind, "--pane", paneId, "--timeout", "30000"];
   if (resume !== undefined) args.push("--", ...resume);
   let result = await run(herdr, args);
   for (let attempt = 0; herdrCliErrorCode(result) === "agent_pane_busy" && attempt < 19; attempt += 1) {
@@ -341,6 +351,25 @@ async function startAgent(
     result = await run(herdr, args);
   }
   return result;
+}
+
+async function prepareAgentPane(
+  herdr: string,
+  provider: ProviderId,
+  paneId: string,
+  env: NodeJS.ProcessEnv,
+  run: CommandRunner,
+  wait: Delay
+): Promise<void> {
+  if (provider !== "builtin") return;
+  const paths = quickchatPaths(env);
+  const configured = await run(herdr, [
+    "pane", "run", paneId,
+    `export PI_CODING_AGENT_DIR=${shellWord(paths.config)} PI_CODING_AGENT_SESSION_DIR=${shellWord(paths.piSessions)}`
+  ]);
+  if (configured.code !== 0)
+    throw new HerdrHandoffError("session", herdrCliErrorCode(configured) ?? "pi_environment_failed");
+  await wait(100);
 }
 
 async function focusSessionAndWindow(

--- a/runtime/src/history.ts
+++ b/runtime/src/history.ts
@@ -65,6 +65,7 @@ export class HistoryStore {
       await Promise.all(chat.images.map(async (image) => {
         if (basename(image.path) === image.path) await rm(join(this.#paths.images, image.path), { force: true });
       }));
+      await this.#removeUnreferencedPiSession(chat);
     }
     return chat;
   }
@@ -73,6 +74,7 @@ export class HistoryStore {
     const chats = await this.listAll();
     await rm(this.#paths.records, { recursive: true, force: true });
     await rm(this.#paths.images, { recursive: true, force: true });
+    await rm(this.#paths.piSessions, { recursive: true, force: true });
     return chats;
   }
 
@@ -96,6 +98,17 @@ export class HistoryStore {
     }));
     return records.filter((record): record is ChatRecord => record !== undefined)
       .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  }
+
+  async #removeUnreferencedPiSession(chat: ChatRecord): Promise<void> {
+    const sessionId = chat.provider === "builtin" ? chat.session.acpId : undefined;
+    if (sessionId === undefined || !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu.test(sessionId)) return;
+    if ((await this.listAll()).some((record) => record.provider === "builtin" && record.session.acpId === sessionId)) return;
+    let names: string[];
+    try { names = await readdir(this.#paths.piSessions); } catch { return; }
+    const suffix = `_${sessionId}.jsonl`;
+    await Promise.all(names.filter((name) => name.endsWith(suffix))
+      .map((name) => rm(join(this.#paths.piSessions, name), { force: true })));
   }
 
 }

--- a/runtime/src/paths.ts
+++ b/runtime/src/paths.ts
@@ -5,6 +5,7 @@ export type QuickchatPaths = {
   config: string;
   state: string;
   records: string;
+  piSessions: string;
   cache: string;
   images: string;
   adapters: string;
@@ -26,6 +27,7 @@ export function quickchatPaths(env: NodeJS.ProcessEnv = process.env): QuickchatP
     config: join(configRoot, "omapilot"),
     state: join(stateRoot, "quickchat"),
     records: join(stateRoot, "quickchat/chats"),
+    piSessions: join(stateRoot, "quickchat/pi-sessions"),
     cache: join(cacheRoot, "quickchat"),
     images: join(cacheRoot, "quickchat/images"),
     adapters: join(cacheRoot, "quickchat/adapters"),

--- a/runtime/src/pi-harness.ts
+++ b/runtime/src/pi-harness.ts
@@ -9,6 +9,7 @@ import { SessionManager } from "../../node_modules/@earendil-works/pi-coding-age
 import { SettingsManager } from "../../node_modules/@earendil-works/pi-coding-agent/dist/core/settings-manager.js";
 import { parseFrontmatter } from "../../node_modules/@earendil-works/pi-coding-agent/dist/utils/frontmatter.js";
 import type { InlineExtension, ToolDefinition } from "../../node_modules/@earendil-works/pi-coding-agent/dist/core/extensions/types.js";
+import type { AuthInteraction, AuthType } from "../../node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/auth/types.js";
 import { registerBundledOAuthFlowLoaders } from "../../node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/auth/oauth/load.js";
 import { anthropicOAuth } from "../../node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/auth/oauth/anthropic.js";
 import { openaiCodexOAuth } from "../../node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/auth/oauth/openai-codex.js";
@@ -22,7 +23,7 @@ import type { RequestPermissionRequest } from "@agentclientprotocol/sdk";
 import type { AcpPrompt } from "./context.js";
 import type { AcpResult, AcpRun, PermissionHandler } from "./acp.js";
 import { automaticInstructions, type PiDiscoveredProvider } from "./providers.js";
-import type { BrokerEvent, ModelOption, ProviderPolicyInfo } from "./types.js";
+import type { BrokerEvent, BuiltinAuthMethod, ModelOption, ProviderPolicyInfo } from "./types.js";
 import { quickchatPaths } from "./paths.js";
 
 const PROVIDER_GROUPS = [
@@ -94,6 +95,46 @@ async function createRuntime(env: NodeJS.ProcessEnv, directory: string): Promise
     if (key?.trim()) await runtime.setRuntimeApiKey(provider, key.trim());
   }
   return runtime;
+}
+
+export async function discoverPiAuthMethods(env: NodeJS.ProcessEnv = process.env): Promise<BuiltinAuthMethod[]> {
+  const directory = configDirectory(env);
+  const runtime = await createRuntime(env, directory);
+  const configured = new Set(configuredProviderIds(directory));
+  const allowed = new Set([...BUILTIN_PROVIDER_IDS, ...configured]);
+  const methods: BuiltinAuthMethod[] = [];
+  for (const provider of runtime.getProviders()) {
+    if (!allowed.has(provider.id)) continue;
+    if (provider.auth.oauth !== undefined) methods.push({
+      id: `${provider.id}::oauth`,
+      providerId: provider.id,
+      authType: "oauth",
+      label: provider.auth.oauth.name,
+      description: provider.auth.oauth.isSubscription === true
+        ? `Use your ${provider.name} subscription in OmaPilot.`
+        : `Sign in to ${provider.name} in your browser.`
+    });
+    if (provider.auth.apiKey?.login !== undefined) methods.push({
+      id: `${provider.id}::api_key`,
+      providerId: provider.id,
+      authType: "api_key",
+      label: provider.auth.apiKey.name,
+      description: `Store this credential only in OmaPilot's private configuration.`
+    });
+  }
+  return methods;
+}
+
+export async function loginPiProvider(
+  env: NodeJS.ProcessEnv,
+  methodId: string,
+  interaction: AuthInteraction
+): Promise<void> {
+  const methods = await discoverPiAuthMethods(env);
+  const method = methods.find((candidate) => candidate.id === methodId);
+  if (method === undefined) throw new BrokerPiError("auth_method_unavailable", "That authentication method is unavailable", false);
+  const runtime = await createRuntime(env, configDirectory(env));
+  await runtime.login(method.providerId, method.authType as AuthType, interaction);
 }
 
 function optionId(providerId: string, modelId: string, grouped: boolean): string {

--- a/runtime/src/pi-harness.ts
+++ b/runtime/src/pi-harness.ts
@@ -36,6 +36,7 @@ const MUTATING_TOOLS = new Set(["bash", "edit", "write"]);
 const BASIC_TOOLS = ["read", "bash", "edit", "write", "grep", "find", "ls", "agent"];
 const SAFE_AGENT_NAME = /^[a-z0-9][a-z0-9._-]{0,63}$/u;
 const MAX_AGENT_FILE_BYTES = 128 * 1024;
+const sessionApprovals = new Map<string, PiApprovalState>();
 
 registerBundledOAuthFlowLoaders({
   anthropic: () => anthropicOAuth,
@@ -220,7 +221,8 @@ export function runPiQuestion(
   emit: (event: BrokerEvent) => void,
   timeoutMs = 180_000,
   requestPermission?: PermissionHandler,
-  cancelPermissions?: () => void
+  cancelPermissions?: () => void,
+  resumeSessionId?: string
 ): AcpRun {
   const controller = new AbortController();
   let activeSession: { abort: () => Promise<void>; dispose: () => void } | undefined;
@@ -234,8 +236,14 @@ export function runPiQuestion(
   const result = (async (): Promise<AcpResult> => {
     const model = resolveModel(provider, selectedModel);
     if (model === undefined) throw new BrokerPiError("model_unavailable", "The selected model is not available", false);
+    const sessionManager = piSessionManager(provider, resumeSessionId);
     const profiles = discoverAgentProfiles(provider.sharedAgentsDir, provider.cwd);
-    const approvals = new PiApprovalState(join(provider.agentDir, "approvals.json"), provider.cwd);
+    const approvalStateKey = `${provider.agentDir}\0${provider.cwd}\0${sessionManager.getSessionId()}`;
+    let approvals = sessionApprovals.get(approvalStateKey);
+    if (approvals === undefined) {
+      approvals = new PiApprovalState(join(provider.agentDir, "approvals.json"), provider.cwd);
+      sessionApprovals.set(approvalStateKey, approvals);
+    }
     const permissionExtension = createPermissionExtension(requestId, requestPermission, approvals);
     const loader = new DefaultResourceLoader({
       cwd: provider.cwd,
@@ -258,7 +266,7 @@ export function runPiQuestion(
       model,
       modelRuntime: provider.runtime,
       resourceLoader: loader,
-      sessionManager: SessionManager.inMemory(provider.cwd),
+      sessionManager,
       settingsManager: settings,
       tools: BASIC_TOOLS,
       customTools: [agentTool]
@@ -290,7 +298,7 @@ export function runPiQuestion(
         sessionId: session.sessionId,
         models: provider.models,
         defaultModel: optionId(model.provider, model.id, provider.id === "builtin"),
-        resumable: false
+        resumable: true
       };
     } catch (error) {
       if (error instanceof BrokerPiError) throw error;
@@ -306,6 +314,19 @@ export function runPiQuestion(
     }
   })();
   return { result, cancel };
+}
+
+function piSessionManager(provider: PiDiscoveredProvider, resumeSessionId: string | undefined): SessionManager {
+  const sessionDir = quickchatPaths(provider.agent.env).piSessions;
+  mkdirSync(sessionDir, { recursive: true, mode: 0o700 });
+  if (resumeSessionId === undefined) return SessionManager.create(provider.cwd, sessionDir);
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu.test(resumeSessionId))
+    throw new BrokerPiError("session_unavailable", "The saved Pi conversation is unavailable", false);
+  const suffix = `_${resumeSessionId}.jsonl`;
+  const file = readdirSync(sessionDir).find((name) => name.endsWith(suffix));
+  if (file === undefined)
+    throw new BrokerPiError("session_unavailable", "The saved Pi conversation is unavailable", false);
+  return SessionManager.open(join(sessionDir, file), sessionDir, provider.cwd);
 }
 
 type PiModel = ReturnType<PiDiscoveredProvider["runtime"]["getModels"]>[number];

--- a/runtime/src/process.ts
+++ b/runtime/src/process.ts
@@ -6,6 +6,32 @@ import { delimiter, isAbsolute } from "node:path";
 export type RunResult = { code: number; stdout: string; stderr: string };
 export type RunBinaryResult = { code: number; stdout: Buffer; stderr: string };
 
+export function launchDetached(
+  executable: string,
+  args: string[],
+  options: { env?: NodeJS.ProcessEnv; cwd?: string } = {}
+): Promise<boolean> {
+  return new Promise((resolveLaunch) => {
+    let settled = false;
+    const finish = (opened: boolean): void => {
+      if (settled) return;
+      settled = true;
+      resolveLaunch(opened);
+    };
+    const child = spawn(executable, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: "ignore",
+      detached: process.platform !== "win32"
+    });
+    child.once("error", () => finish(false));
+    child.once("spawn", () => {
+      child.unref();
+      finish(true);
+    });
+  });
+}
+
 export async function runCommand(
   executable: string,
   args: string[],

--- a/runtime/src/types.ts
+++ b/runtime/src/types.ts
@@ -66,6 +66,7 @@ const submitCommand = z.object({
   id: z.string().min(1).max(120),
   question: z.string().trim().min(1).max(100_000),
   provider: providerIdSchema,
+  resumeChatId: z.string().uuid().optional(),
   model: z.preprocess((value) => typeof value === "string" && value.trim() === "" ? undefined : value, z.string().min(1).max(500).optional()),
   desktopContext: desktopContextSchema.optional(),
   contextAttachments: z.array(contextAttachmentSelectionSchema).max(4).optional(),

--- a/runtime/src/types.ts
+++ b/runtime/src/types.ts
@@ -95,6 +95,17 @@ const browserCompanionOpenSettingsCommand = z.object({
   type: z.literal("browser_companion_open_settings"),
   family: z.enum(["chromium", "firefox"])
 }).strict();
+const authBeginCommand = z.object({
+  type: z.literal("auth_begin"),
+  methodId: z.string().regex(/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}::(?:api_key|oauth)$/u)
+}).strict();
+const authResponseCommand = z.object({
+  type: z.literal("auth_response"),
+  flowId: z.string().uuid(),
+  promptId: z.string().uuid(),
+  value: z.string().max(32_768)
+}).strict();
+const authCancelCommand = z.object({ type: z.literal("auth_cancel"), flowId: z.string().uuid() }).strict();
 const cancelCommand = z.object({ type: z.literal("cancel"), id: z.string().min(1).max(120) });
 const permissionResponseCommand = z.object({
   type: z.literal("permission_response"),
@@ -116,6 +127,9 @@ export const commandSchema = z.discriminatedUnion("type", [
   contextCancelCommand,
   browserCompanionCommand,
   browserCompanionOpenSettingsCommand,
+  authBeginCommand,
+  authResponseCommand,
+  authCancelCommand,
   contextDiscardCommand,
   cancelCommand,
   permissionResponseCommand,
@@ -140,6 +154,22 @@ export type ProviderInfo = {
   models: ModelOption[];
   defaultModel?: string;
   policy: ProviderPolicyInfo;
+};
+
+export type BuiltinAuthMethod = {
+  id: string;
+  providerId: string;
+  authType: "api_key" | "oauth";
+  label: string;
+  description: string;
+};
+
+export type BuiltinAuthPrompt = {
+  id: string;
+  kind: "text" | "secret" | "select" | "manual_code";
+  message: string;
+  placeholder?: string;
+  options?: Array<{ id: string; label: string; description?: string }>;
 };
 
 export type StoredImage = {
@@ -209,6 +239,13 @@ export type ChatView = Omit<ChatRecord, "images"> & { images: RenderableImage[] 
 export type BrokerEvent =
   | { type: "ready"; protocolVersion: 2; features: Array<"desktop-context" | "context-attachments">; providers: ProviderInfo[]; history: ChatView[] }
   | { type: "providers"; providers: ProviderInfo[] }
+  | { type: "auth_methods"; methods: BuiltinAuthMethod[] }
+  | { type: "auth"; phase: "starting"; flowId: string; methodId: string; message: string }
+  | { type: "auth"; phase: "prompt"; flowId: string; methodId: string; prompt: BuiltinAuthPrompt }
+  | { type: "auth"; phase: "info"; flowId: string; methodId: string; message: string; links?: Array<{ url: string; label?: string }> }
+  | { type: "auth"; phase: "browser"; flowId: string; methodId: string; url: string; instructions?: string }
+  | { type: "auth"; phase: "device_code"; flowId: string; methodId: string; userCode: string; verificationUri: string; expiresInSeconds?: number }
+  | { type: "auth"; phase: "complete" | "cancelled" | "error"; flowId: string; methodId: string; message: string }
   | { type: "state"; id?: string; state: "idle" | "preparing" | "streaming" | "stopping"; message?: string }
   | { type: "content"; id: string; delta: string }
   | { type: "permission"; permission: ToolPermission }

--- a/runtime/src/types.ts
+++ b/runtime/src/types.ts
@@ -166,7 +166,7 @@ export type BuiltinAuthMethod = {
 
 export type BuiltinAuthPrompt = {
   id: string;
-  kind: "text" | "secret" | "select" | "manual_code";
+  kind: "text" | "secret" | "select";
   message: string;
   placeholder?: string;
   options?: Array<{ id: string; label: string; description?: string }>;

--- a/runtime/test/broker-lifecycle.test.ts
+++ b/runtime/test/broker-lifecycle.test.ts
@@ -12,7 +12,10 @@ import type { DiscoveredProvider } from "../src/providers.js";
 import type { BrokerEvent, ChatRecord, ProviderId } from "../src/types.js";
 
 const roots: string[] = [];
-afterEach(async () => Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true }))));
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
 
 describe("broker lifecycle cleanup", () => {
   it("keeps local delete successful when provider session cleanup fails", async () => {
@@ -120,6 +123,43 @@ describe("embedded built-in authentication", () => {
     await vi.waitFor(() => expect(events.some((event) => event.type === "auth" && event.phase === "complete")).toBe(true));
     expect(events.some((event) => event.type === "providers" && event.providers.some((provider) => provider.id === "builtin"))).toBe(true);
     expect(await readFile(join(config, "auth.json"), "utf8")).toContain("embedded-test-key");
+    await broker.handle({ type: "shutdown" });
+  });
+
+  it("owns the Codex OAuth callback and never exposes manual callback input", async () => {
+    vi.stubEnv("PI_OAUTH_CALLBACK_HOST", "127.0.0.2");
+    const root = await mkdtemp(join(tmpdir(), "quickchat-broker-oauth-")); roots.push(root);
+    const events: BrokerEvent[] = [];
+    const broker = new QuickchatBroker(events.push.bind(events), {
+      env: {
+        ...process.env,
+        HOME: root,
+        OMAPILOT_CONFIG_DIR: join(root, ".config/omapilot"),
+        XDG_STATE_HOME: join(root, "state"),
+        XDG_CACHE_HOME: join(root, "cache"),
+        XDG_RUNTIME_DIR: join(root, "run")
+      }
+    });
+    await broker.handle({ type: "initialize", protocolVersion: 2, harness: "builtin" });
+    await broker.handle({ type: "auth_begin", methodId: "openai-codex::oauth" });
+    await vi.waitFor(() => expect(events.some((event) => event.type === "auth" && event.phase === "prompt")).toBe(true));
+    const methodPrompt = events.find((event) => event.type === "auth" && event.phase === "prompt");
+    if (methodPrompt?.type !== "auth" || methodPrompt.phase !== "prompt") throw new Error("login method prompt missing");
+    expect(methodPrompt.prompt.kind).toBe("select");
+    await broker.handle({
+      type: "auth_response",
+      flowId: methodPrompt.flowId,
+      promptId: methodPrompt.prompt.id,
+      value: "browser"
+    });
+    await vi.waitFor(() => expect(events.some((event) => event.type === "auth" && event.phase === "browser")).toBe(true));
+
+    const callback = await fetch("http://127.0.0.2:1455/auth/callback?code=test&state=wrong");
+    expect(callback.status).toBe(400);
+    expect(events.filter((event) => event.type === "auth" && event.phase === "prompt")).toHaveLength(1);
+
+    await broker.handle({ type: "auth_cancel", flowId: methodPrompt.flowId });
+    await vi.waitFor(() => expect(events.some((event) => event.type === "auth" && event.phase === "cancelled")).toBe(true));
     await broker.handle({ type: "shutdown" });
   });
 });

--- a/runtime/test/broker-lifecycle.test.ts
+++ b/runtime/test/broker-lifecycle.test.ts
@@ -93,6 +93,37 @@ describe("dictation generation guard", () => {
   });
 });
 
+describe("embedded built-in authentication", () => {
+  it("round-trips a secret prompt without launching a terminal", async () => {
+    const root = await mkdtemp(join(tmpdir(), "quickchat-broker-auth-")); roots.push(root);
+    const config = join(root, ".config/omapilot");
+    const events: BrokerEvent[] = [];
+    const broker = new QuickchatBroker(events.push.bind(events), {
+      env: {
+        ...process.env,
+        HOME: root,
+        OMAPILOT_CONFIG_DIR: config,
+        XDG_STATE_HOME: join(root, "state"),
+        XDG_CACHE_HOME: join(root, "cache"),
+        XDG_RUNTIME_DIR: join(root, "run")
+      }
+    });
+    await broker.handle({ type: "initialize", protocolVersion: 2, harness: "builtin" });
+    const methods = events.find((event) => event.type === "auth_methods");
+    expect(methods?.type === "auth_methods" ? methods.methods.map((method) => method.id) : []).toContain("openai::api_key");
+    await broker.handle({ type: "auth_begin", methodId: "openai::api_key" });
+    await vi.waitFor(() => expect(events.some((event) => event.type === "auth" && event.phase === "prompt")).toBe(true));
+    const prompt = events.find((event) => event.type === "auth" && event.phase === "prompt");
+    if (prompt?.type !== "auth" || prompt.phase !== "prompt") throw new Error("auth prompt missing");
+    expect(prompt.prompt.kind).toBe("secret");
+    await broker.handle({ type: "auth_response", flowId: prompt.flowId, promptId: prompt.prompt.id, value: "embedded-test-key" });
+    await vi.waitFor(() => expect(events.some((event) => event.type === "auth" && event.phase === "complete")).toBe(true));
+    expect(events.some((event) => event.type === "providers" && event.providers.some((provider) => provider.id === "builtin"))).toBe(true);
+    expect(await readFile(join(config, "auth.json"), "utf8")).toContain("embedded-test-key");
+    await broker.handle({ type: "shutdown" });
+  });
+});
+
 describe("tool permission lifecycle", () => {
   it("expires a pending permission with a nonce-bound closure before completing", async () => {
     const fixture = await setup();

--- a/runtime/test/herdr.test.ts
+++ b/runtime/test/herdr.test.ts
@@ -25,6 +25,9 @@ describe("Herdr handoff", () => {
     expect(nativeResumeArgs("codex", "abc", "/work")).toEqual(["resume", "abc", "-C", "/work", "-s", "read-only", "-a", "on-request"]);
     expect(nativeResumeArgs("claude", "abc")).toEqual(["--resume", "abc"]);
     expect(nativeResumeArgs("opencode", "abc")).toEqual(["--pure", "--session", "abc"]);
+    expect(nativeResumeArgs("builtin", "abc", "/work", env)).toEqual([
+      "--session", "abc", "--session-dir", "/home/test/.local/state/quickchat/pi-sessions", "--approve"
+    ]);
   });
 
   it("labels transcript fallback honestly", () => {
@@ -109,6 +112,18 @@ describe("Herdr handoff", () => {
     expect(start).toContain("--");
     expect(start.slice(start.indexOf("--") + 1)).toEqual(nativeResumeArgs(provider, "session-1", "/home/test"));
     expect(fixture.launch).not.toHaveBeenCalled();
+  });
+
+  it("starts Built-in sessions as Pi with OmaPilot-owned auth and session paths", async () => {
+    const fixture = harness();
+    await expect(continueInHerdr(chat({ provider: "builtin", resumable: true }), env, fixture))
+      .resolves.toEqual({ mode: "native", reused: false });
+    expect(callsContaining(fixture.calls, ["pane", "run"])[0]?.args[3]).toBe(
+      "export PI_CODING_AGENT_DIR='/home/test/.config/omapilot' PI_CODING_AGENT_SESSION_DIR='/home/test/.local/state/quickchat/pi-sessions'"
+    );
+    const start = callsContaining(fixture.calls, ["agent", "start"])[0]?.args ?? [];
+    expect(start).toEqual(expect.arrayContaining(["--kind", "pi"]));
+    expect(start.slice(start.indexOf("--") + 1)).toEqual(nativeResumeArgs("builtin", "session-1", "/home/test", env));
   });
 
   it("uses a fresh tab/name for transcript fallback, accepts blocked, and cleans the failed native tab", async () => {

--- a/runtime/test/history.test.ts
+++ b/runtime/test/history.test.ts
@@ -35,6 +35,23 @@ describe("history store", () => {
     expect(await store.list()).toEqual([]);
   });
 
+  it("keeps a shared Pi session until its final chat record is deleted", async () => {
+    const root = await mkdtemp(join(tmpdir(), "quickchat-history-pi-")); roots.push(root);
+    const paths = quickchatPaths({ HOME: root, XDG_STATE_HOME: join(root, "state"), XDG_CACHE_HOME: join(root, "cache"), XDG_RUNTIME_DIR: join(root, "run") });
+    const store = new HistoryStore(paths);
+    const sessionId = "11111111-1111-4111-8111-111111111111";
+    const sessionFile = `2026-08-18_${sessionId}.jsonl`;
+    await mkdir(paths.piSessions, { recursive: true });
+    await writeFile(join(paths.piSessions, sessionFile), "session\n");
+    await store.save({ ...record(1), session: { acpId: sessionId, resumable: true, resumeKind: "native" } });
+    await store.save({ ...record(2), session: { acpId: sessionId, resumable: true, resumeKind: "native" } });
+
+    await store.delete(record(1).id);
+    expect(await readdir(paths.piSessions)).toEqual([sessionFile]);
+    await store.delete(record(2).id);
+    expect(await readdir(paths.piSessions)).toEqual([]);
+  });
+
   it("loads a legacy capability field but strips it from presented history", async () => {
     const root = await mkdtemp(join(tmpdir(), "quickchat-history-legacy-")); roots.push(root);
     const paths = quickchatPaths({ HOME: root, XDG_STATE_HOME: join(root, "state"), XDG_CACHE_HOME: join(root, "cache"), XDG_RUNTIME_DIR: join(root, "run") });

--- a/runtime/test/pi-harness.test.ts
+++ b/runtime/test/pi-harness.test.ts
@@ -6,7 +6,7 @@ import { createServer } from "node:http";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { createInterface } from "node:readline";
 import { afterEach, describe, expect, it } from "vitest";
-import { agentDirectory, configDirectory, discoverAgentProfiles, discoverPiProviders, existingSkillPaths, PiApprovalState, runNestedAgentPrompt, runPiQuestion } from "../src/pi-harness.js";
+import { agentDirectory, configDirectory, discoverAgentProfiles, discoverPiAuthMethods, discoverPiProviders, existingSkillPaths, loginPiProvider, PiApprovalState, runNestedAgentPrompt, runPiQuestion } from "../src/pi-harness.js";
 import type { BrokerEvent } from "../src/types.js";
 
 const roots: string[] = [];
@@ -19,6 +19,36 @@ describe("native Pi harness", () => {
     expect(agentDirectory(env)).toBe("/home/test/.agents");
     expect(configDirectory({ ...env, OMAPILOT_CONFIG_DIR: "/custom/config" })).toBe("/custom/config");
     expect(agentDirectory({ ...env, OMAPILOT_AGENTS_DIR: "/custom/agents" })).toBe("/custom/agents");
+  });
+
+  it("offers native subscription and API-key login methods without launching Pi", async () => {
+    const root = await mkdtemp(join(tmpdir(), "omapilot-pi-auth-methods-"));
+    roots.push(root);
+    const agentDir = join(root, ".config/omapilot");
+    const methods = await discoverPiAuthMethods({ HOME: root, OMAPILOT_CONFIG_DIR: agentDir });
+    expect(methods).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "openai-codex::oauth", authType: "oauth" }),
+      expect.objectContaining({ id: "openai::api_key", authType: "api_key" }),
+      expect.objectContaining({ id: "anthropic::oauth", authType: "oauth" }),
+      expect.objectContaining({ id: "anthropic::api_key", authType: "api_key" })
+    ]));
+  });
+
+  it("persists an API key through Pi's typed background login interaction", async () => {
+    const root = await mkdtemp(join(tmpdir(), "omapilot-pi-auth-login-"));
+    roots.push(root);
+    const agentDir = join(root, ".config/omapilot");
+    const prompts: Array<{ type: string; message: string }> = [];
+    await loginPiProvider({ HOME: root, OMAPILOT_CONFIG_DIR: agentDir }, "openai::api_key", {
+      signal: new AbortController().signal,
+      prompt: (prompt) => { prompts.push({ type: prompt.type, message: prompt.message }); return Promise.resolve("test-secret-key"); },
+      notify: () => undefined
+    });
+    expect(prompts).toEqual([expect.objectContaining({ type: "secret" })]);
+    const stored: unknown = JSON.parse(await readFile(join(agentDir, "auth.json"), "utf8"));
+    expect(stored).toMatchObject({ openai: { type: "api_key", key: "test-secret-key" } });
+    const providers = await discoverPiProviders({ HOME: root, OMAPILOT_CONFIG_DIR: agentDir });
+    expect(providers[0]?.models.some((model) => model.id.startsWith("openai::"))).toBe(true);
   });
 
   it("keeps session grants ephemeral and durable grants as command-free fingerprints", async () => {

--- a/runtime/test/pi-harness.test.ts
+++ b/runtime/test/pi-harness.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -165,8 +165,14 @@ describe("native Pi harness", () => {
   it("runs and streams a complete turn through an OpenAI-compatible endpoint", async () => {
     const root = await mkdtemp(join(tmpdir(), "omapilot-pi-run-"));
     roots.push(root);
-    const server = createServer((_request, response) => {
-      response.writeHead(200, { "content-type": "text/event-stream" });
+    const requests: unknown[] = [];
+    const server = createServer((request, response) => {
+      let body = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk: string) => { body += chunk; });
+      request.on("end", () => {
+        requests.push(JSON.parse(body));
+        response.writeHead(200, { "content-type": "text/event-stream" });
       response.write(`data: ${JSON.stringify({
         id: "chatcmpl-test", object: "chat.completion.chunk", created: 1, model: "coder",
         choices: [{ index: 0, delta: { role: "assistant", content: "Hello " }, finish_reason: null }]
@@ -180,7 +186,8 @@ describe("native Pi harness", () => {
         choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
         usage: { prompt_tokens: 10, completion_tokens: 3, total_tokens: 13 }
       })}\n\ndata: [DONE]\n\n`);
-      response.end();
+        response.end();
+      });
     });
     await new Promise<void>((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
     try {
@@ -196,11 +203,26 @@ describe("native Pi harness", () => {
       if (provider === undefined) throw new Error("compatible provider was not discovered");
       const events: BrokerEvent[] = [];
       const run = runPiQuestion(provider, "pi-turn", "Say hello", "local::coder", (event) => events.push(event), 5_000);
-      await expect(run.result).resolves.toMatchObject({ answer: "Hello from Pi.", resumable: false });
+      const first = await run.result;
+      expect(first).toMatchObject({ answer: "Hello from Pi.", resumable: true });
+      const resumed = runPiQuestion(
+        provider, "pi-follow-up", "What did I ask?", "local::coder", (event) => events.push(event), 5_000,
+        undefined, undefined, first.sessionId
+      );
+      await expect(resumed.result).resolves.toMatchObject({ sessionId: first.sessionId, resumable: true });
       expect(events.filter((event) => event.type === "content")).toEqual([
         { type: "content", id: "pi-turn", delta: "Hello " },
-        { type: "content", id: "pi-turn", delta: "from Pi." }
+        { type: "content", id: "pi-turn", delta: "from Pi." },
+        { type: "content", id: "pi-follow-up", delta: "Hello " },
+        { type: "content", id: "pi-follow-up", delta: "from Pi." }
       ]);
+      expect(JSON.stringify(requests[1])).toContain("Say hello");
+      expect(JSON.stringify(requests[1])).toContain("Hello from Pi.");
+      expect(JSON.stringify(requests[1])).toContain("What did I ask?");
+      const sessionDir = join(root, ".local/state/quickchat/pi-sessions");
+      const sessionFiles = await readdir(sessionDir);
+      expect(sessionFiles).toHaveLength(1);
+      expect(await readFile(join(sessionDir, sessionFiles[0] ?? "missing"), "utf8")).toContain("What did I ask?");
     } finally {
       await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
     }
@@ -262,14 +284,20 @@ describe("native Pi harness", () => {
   it("ships the Pi harness in the self-contained broker bundle", async () => {
     const root = await mkdtemp(join(tmpdir(), "omapilot-pi-bundle-"));
     roots.push(root);
+    const requests: unknown[] = [];
     const server = createServer((request, response) => {
-      request.resume();
-      response.writeHead(200, { "content-type": "text/event-stream" });
-      response.end(`data: ${JSON.stringify({
-        id: "chatcmpl-bundle", object: "chat.completion.chunk", created: 1, model: "coder",
-        choices: [{ index: 0, delta: { role: "assistant", content: "Bundled Pi works." }, finish_reason: "stop" }],
-        usage: { prompt_tokens: 10, completion_tokens: 3, total_tokens: 13 }
-      })}\n\ndata: [DONE]\n\n`);
+      let body = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk: string) => { body += chunk; });
+      request.on("end", () => {
+        requests.push(JSON.parse(body));
+        response.writeHead(200, { "content-type": "text/event-stream" });
+        response.end(`data: ${JSON.stringify({
+          id: "chatcmpl-bundle", object: "chat.completion.chunk", created: 1, model: "coder",
+          choices: [{ index: 0, delta: { role: "assistant", content: "Bundled Pi works." }, finish_reason: "stop" }],
+          usage: { prompt_tokens: 10, completion_tokens: 3, total_tokens: 13 }
+        })}\n\ndata: [DONE]\n\n`);
+      });
     });
     await new Promise<void>((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
     let child: ChildProcessWithoutNullStreams | undefined;
@@ -309,6 +337,22 @@ describe("native Pi harness", () => {
       running.stdin.write('{"type":"submit","id":"bundle-turn","question":"hello","provider":"builtin","model":"local::coder"}\n');
       await until(() => events.some((event) => event.type === "complete"), 10_000);
       expect(events).toContainEqual({ type: "content", id: "bundle-turn", delta: "Bundled Pi works." });
+      const firstComplete = events.find((event) => event.type === "complete");
+      const firstChat = firstComplete?.chat as Record<string, unknown> | undefined;
+      const firstSession = firstChat?.session as Record<string, unknown> | undefined;
+      if (typeof firstChat?.id !== "string" || typeof firstSession?.acpId !== "string")
+        throw new Error("persisted Pi chat session missing");
+      running.stdin.write(`${JSON.stringify({
+        type: "submit", id: "bundle-follow-up", question: "what did I say?", provider: "builtin",
+        model: "local::coder", resumeChatId: firstChat.id
+      })}\n`);
+      await until(() => events.filter((event) => event.type === "complete").length === 2, 10_000);
+      const secondComplete = events.filter((event) => event.type === "complete")[1];
+      const secondSession = (secondComplete?.chat as Record<string, unknown> | undefined)?.session as Record<string, unknown> | undefined;
+      expect(secondSession?.acpId).toBe(firstSession.acpId);
+      expect(JSON.stringify(requests[1])).toContain("hello");
+      expect(JSON.stringify(requests[1])).toContain("Bundled Pi works.");
+      expect(JSON.stringify(requests[1])).toContain("what did I say?");
       running.stdin.end('{"type":"shutdown"}\n');
       await new Promise<void>((resolveExit) => running.once("close", () => resolveExit()));
       child = undefined;

--- a/runtime/test/process.test.ts
+++ b/runtime/test/process.test.ts
@@ -1,0 +1,29 @@
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { launchDetached } from "../src/process.js";
+
+const roots: string[] = [];
+afterEach(async () => Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true }))));
+
+describe("detached process launch", () => {
+  it("returns after spawn without waiting for or terminating the launched process", async () => {
+    const root = await mkdtemp(join(tmpdir(), "quickchat-detached-"));
+    roots.push(root);
+    const marker = join(root, "opened.txt");
+    const launched = await launchDetached(process.execPath, [
+      "-e",
+      "setTimeout(() => require('node:fs').writeFileSync(process.argv[1], 'opened'), 150)",
+      marker
+    ]);
+
+    expect(launched).toBe(true);
+    await expect(access(marker)).rejects.toThrow();
+    await vi.waitFor(() => expect(readFile(marker, "utf8")).resolves.toBe("opened"));
+  });
+
+  it("reports a launch failure", async () => {
+    expect(await launchDetached(join(tmpdir(), "quickchat-missing-executable"), [])).toBe(false);
+  });
+});

--- a/runtime/test/protocol.test.ts
+++ b/runtime/test/protocol.test.ts
@@ -57,6 +57,15 @@ describe("NDJSON protocol", () => {
     expect(commandSchema.safeParse({ type: "browser_companion_open_settings", family: "firefox" }).success).toBe(true);
     expect(commandSchema.safeParse({ type: "browser_companion_open_settings", family: "other" }).success).toBe(false);
     expect(commandSchema.safeParse({ type: "browser_companion_install", command: "anything" }).success).toBe(false);
+    expect(commandSchema.safeParse({ type: "auth_begin", methodId: "openai-codex::oauth" }).success).toBe(true);
+    expect(commandSchema.safeParse({ type: "auth_begin", methodId: "openai-codex::shell" }).success).toBe(false);
+    expect(commandSchema.safeParse({
+      type: "auth_response", flowId: "11111111-1111-4111-8111-111111111111",
+      promptId: "22222222-2222-4222-8222-222222222222", value: "secret"
+    }).success).toBe(true);
+    expect(commandSchema.safeParse({
+      type: "auth_cancel", flowId: "11111111-1111-4111-8111-111111111111", extra: true
+    }).success).toBe(false);
   });
 
   it("rejects incompatible protocol versions without becoming ready", async () => {

--- a/tests/check-ui-contract.sh
+++ b/tests/check-ui-contract.sh
@@ -50,6 +50,13 @@ grep -Fq 'property string configuredProvider: "builtin"' \
 grep -Fq 'harness: provider' "$repo_dir/components/QuickchatStore.qml"
 grep -Fq 'readonly property var modeProviders: Protocol.harnessOptions()' \
   "$repo_dir/components/SettingsView.qml"
+grep -Fq 'text: "Open sign-in page"' "$repo_dir/components/SettingsView.qml"
+grep -Fq 'sendCommand(Protocol.command("auth_begin", { methodId: selected }))' \
+  "$repo_dir/components/QuickchatStore.qml"
+if grep -Fq 'PI_CODING_AGENT_DIR' "$repo_dir/components/QuickchatStore.qml"; then
+  printf 'Built-in authentication must stay embedded instead of launching Pi\n' >&2
+  exit 1
+fi
 if grep -Fq 'backendSelection' "$repo_dir/components/QuickchatStore.qml"; then
   printf 'Harness selection must not be split into backend and provider settings\n' >&2
   exit 1

--- a/tests/tst_protocol.qml
+++ b/tests/tst_protocol.qml
@@ -226,6 +226,12 @@ TestCase {
     verify(payload.dangerousAutoApprove)
   }
 
+  function test_followUpSubmitCarriesOnlyAValidSavedChatId() {
+    var saved = "11111111-1111-4111-8111-111111111111"
+    compare(Protocol.submitCommand("turn", "Follow up", "builtin", "", null, false, [], saved).resumeChatId, saved)
+    verify(Protocol.submitCommand("turn", "Follow up", "builtin", "", null, false, [], "not-a-chat").resumeChatId === undefined)
+  }
+
   function test_submitIncludesOnlyBoundedSanitizedDesktopContext() {
     var windows = []
     for (var i = 0; i < 30; i++) windows.push({

--- a/tests/tst_protocol.qml
+++ b/tests/tst_protocol.qml
@@ -18,6 +18,13 @@ TestCase {
     verify(!Protocol.isCompatibleEvent({}))
   }
 
+  function test_readyProviderUpdateClearsStaleUnavailableState() {
+    compare(Protocol.providerReadyState("unavailable", 1), "composing")
+    compare(Protocol.providerReadyState("preparing", 1), "composing")
+    compare(Protocol.providerReadyState("complete", 1), "complete")
+    compare(Protocol.providerReadyState("unavailable", 0), "unavailable")
+  }
+
   function test_builtinAuthNormalizesMethodsAndProviderPrompts() {
     var methods = Protocol.normalizedAuthMethods([
       { id: "openai-codex::oauth", providerId: "openai-codex", authType: "oauth",

--- a/tests/tst_protocol.qml
+++ b/tests/tst_protocol.qml
@@ -18,6 +18,26 @@ TestCase {
     verify(!Protocol.isCompatibleEvent({}))
   }
 
+  function test_builtinAuthNormalizesMethodsAndProviderPrompts() {
+    var methods = Protocol.normalizedAuthMethods([
+      { id: "openai-codex::oauth", providerId: "openai-codex", authType: "oauth",
+        label: "ChatGPT", description: "Subscription" },
+      { id: "bad method", providerId: "bad", authType: "shell", label: "Bad" }
+    ])
+    compare(methods.length, 1)
+    compare(methods[0].value, "openai-codex::oauth")
+    var event = Protocol.normalizedAuthEvent({
+      phase: "prompt", flowId: "flow", methodId: "openai-codex::oauth",
+      prompt: { id: "prompt", kind: "select", message: "Choose sign-in method", options: [
+        { id: "browser", label: "Browser" }, { id: "device_code", label: "Device code" }
+      ] }
+    })
+    compare(event.prompt.kind, "select")
+    compare(event.prompt.options.length, 2)
+    compare(event.prompt.options[1].value, "device_code")
+    compare(Protocol.normalizedAuthEvent({ phase: "credential_dump" }), null)
+  }
+
   function test_desktopContextRequiresBrokerFeatureAdvertisement() {
     verify(Protocol.hasFeature(["desktop-context"], "desktop-context"))
     verify(!Protocol.hasFeature([], "desktop-context"))

--- a/tests/tst_protocol.qml
+++ b/tests/tst_protocol.qml
@@ -35,6 +35,10 @@ TestCase {
     compare(event.prompt.kind, "select")
     compare(event.prompt.options.length, 2)
     compare(event.prompt.options[1].value, "device_code")
+    compare(Protocol.normalizedAuthEvent({
+      phase: "prompt", flowId: "flow", methodId: "openai-codex::oauth",
+      prompt: { id: "manual", kind: "manual_code", message: "Paste callback URL" }
+    }).prompt, null)
     compare(Protocol.normalizedAuthEvent({ phase: "credential_dump" }), null)
   }
 

--- a/tests/visual-preview.qml
+++ b/tests/visual-preview.qml
@@ -51,6 +51,17 @@ ShellRoot {
     ]
     property var modelOptions: [{ value: "openai-codex::gpt-5.4", label: "GPT-5.4 (openai-codex)" }]
     property var providerPolicy: ({ tools: "device-approval", web: "approved-command", hostReads: true })
+    property var builtinAuthMethods: [
+      { value: "openai-codex::oauth", label: "OpenAI (ChatGPT Plus/Pro)",
+        description: "Use your OpenAI Codex subscription in OmaPilot." },
+      { value: "openai::api_key", label: "OpenAI API key",
+        description: "Store this credential only in OmaPilot's private configuration." },
+      { value: "anthropic::oauth", label: "Anthropic (Claude Pro/Max)",
+        description: "Use your Anthropic subscription in OmaPilot." }
+    ]
+    property var builtinAuth: ({ phase: "idle", flowId: "", methodId: "", message: "",
+      url: "", verificationUri: "", userCode: "", prompt: null })
+    property bool builtinAuthBusy: false
     property var contextAttachments: root.previewState === "context" ? [{
       id: "11111111-1111-4111-8111-111111111111",
       title: "Contextual cursor article",
@@ -71,6 +82,10 @@ ShellRoot {
     function stopDictation() {}
     function cancel() {}
     function retryBroker() {}
+    function authenticateBuiltIn(methodId) {}
+    function respondBuiltInAuth(value) {}
+    function cancelBuiltInAuth() {}
+    function activateLink(url) {}
     function copyText(text) {}
     function beginContextCapture() {}
     function setContextRepresentation(id, mode) {


### PR DESCRIPTION
## Summary
- run Pi authentication through the broker instead of opening the Pi terminal
- render OAuth links, device codes, provider prompts, API-key inputs, progress, cancellation, and errors in OmaPilot Settings
- refresh Built-in provider discovery immediately after login and preserve upstream keyboard-navigation behavior

## Validation
- `npm run check` (171 passed, 12 opt-in live tests skipped)
- `./tests/check-ui-contract.sh`
- broker-level OpenAI API-key login round trip
- visual auth-settings render