### PR TITLE
Redesign settings as tabbed lanes and restyle history

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -777,12 +777,7 @@ Panel {
             Layout.fillWidth: true
             Layout.minimumWidth: 0
             elide: Text.ElideRight
-            text: {
-              var who = Protocol.providerLabel(Quickchat.QuickchatStore.provider)
-              if (Quickchat.QuickchatStore.model !== "")
-                who += " \u00b7 " + Quickchat.QuickchatStore.model
-              return who
-            }
+            text: Protocol.providerShortLabel(Quickchat.QuickchatStore.provider)
             color: Qt.darker(root.foreground, 1.35)
             font.family: root.fontFamily
             font.pixelSize: Style.font.bodySmall
@@ -798,9 +793,9 @@ Panel {
             Layout.maximumWidth: implicitWidth
             elide: Text.ElideRight
             text: Presentation.permissionNotice(root.dangerousAutoApprove)
-            color: Color.urgent
+            color: Qt.darker(root.foreground, 1.35)
             font.family: root.fontFamily
-            font.pixelSize: Style.font.caption
+            font.pixelSize: Style.font.bodySmall
             Accessible.role: Accessible.StaticText
             Accessible.name: text
           }

--- a/Panel.qml
+++ b/Panel.qml
@@ -10,7 +10,6 @@ import "components/internal" as QuickchatInternal
 import "components/Presentation.js" as Presentation
 import "components/Protocol.js" as Protocol
 import "components/QuickActions.js" as ActionCatalog
-import "components/StateColor.js" as StateColor
 
 Panel {
   id: root
@@ -63,7 +62,6 @@ Panel {
   readonly property string statePhase: failureVisible ? "error"
     : (responseActivityActive ? "thinking"
       : (Quickchat.QuickchatStore.answerMarkdown !== "" ? "answering" : "listening"))
-  readonly property color stateColor: StateColor.forPhase(root.accent, Color.urgent, root.statePhase)
   readonly property bool responseActivityActive:
     Quickchat.QuickchatStore.state === "preparing"
     || Quickchat.QuickchatStore.state === "streaming"
@@ -285,21 +283,13 @@ Panel {
         onWorkInAppRequested: root.prepareWorkInAppDraft()
       }
 
-      // Removing the header's gear took away the only route to settings, so the
-      // lanes that lost their buttons get real keys. These are advertised in the
-      // panel's hint row; an affordance nobody can find is not a design.
+      // History remains a focused-panel shortcut. Settings already has a
+      // desktop-global route (Super+Alt+P), so do not create a second binding.
       Shortcut {
         sequences: ["Ctrl+H"]
         context: Qt.WindowShortcut
         enabled: root.opened && root.panelWindowActive && !root.modalInteractionActive
         onActivated: root.viewMode === "history" ? root.showChat() : root.openHistory()
-      }
-
-      Shortcut {
-        sequences: ["Ctrl+,"]
-        context: Qt.WindowShortcut
-        enabled: root.opened && root.panelWindowActive && !root.modalInteractionActive
-        onActivated: root.viewMode === "settings" ? root.showChat() : root.openSettings()
       }
 
       ColumnLayout {
@@ -315,14 +305,11 @@ Panel {
           id: composer
           Layout.fillWidth: true
           backend: Quickchat.QuickchatStore
-          activityActive: root.responseActivityActive && root.opened
-          activityColor: root.stateColor
           foreground: root.foreground
           background: root.surface
           accent: root.accent
           fontFamily: root.fontFamily
           onSubmitted: answerScroll.resetForNewTurn()
-          onSettingsRequested: root.viewMode === "settings" ? root.showChat() : root.openSettings()
           onHistoryRequested: root.viewMode === "history" ? root.showChat() : root.openHistory()
           onEscapeRequested: root.close()
         }
@@ -330,37 +317,36 @@ Panel {
         // runner travelling its perimeter — a window inside a window. Now it sits
         // directly on the panel under one edge-lit seam, the same seam the answer
         // curtain uses, so the typed and the spoken paths present identically.
-        // The activity signal moved to the composer's filament.
         Item {
           id: answerCard
-          Layout.fillWidth: true
-          Layout.fillHeight: true
-          Layout.minimumHeight: visible ? Style.space(120) : 0
-          Layout.preferredHeight: implicitHeight
-          implicitHeight: answerLayout.implicitHeight + Style.spacing.xl
-          visible: Quickchat.QuickchatStore.question !== ""
+          readonly property bool contentVisible: Quickchat.QuickchatStore.question !== ""
             || Quickchat.QuickchatStore.answerMarkdown !== ""
             || Quickchat.QuickchatStore.state === "error"
             || Quickchat.QuickchatStore.state === "unavailable"
+          Layout.fillWidth: true
+          Layout.minimumHeight: contentVisible ? Style.space(120) : stateLightBar.implicitHeight
+          Layout.preferredHeight: implicitHeight
+          implicitHeight: contentVisible
+            ? answerLayout.implicitHeight + Style.spacing.xl
+            : stateLightBar.implicitHeight
 
-          // Brightest at the centre, gone by the edges. A full-width rule would
-          // read as a divider; this reads as light arriving with the answer.
-          Rectangle {
+          // One persistent seam carries the entire panel's state. It remains a
+          // quiet accent while composing, gathers pace while working, and
+          // settles into the answer or error hue without becoming a progress bar.
+          Quickchat.StateLightBar {
+            id: stateLightBar
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.top: parent.top
-            height: 1
-            gradient: Gradient {
-              orientation: Gradient.Horizontal
-              GradientStop { position: 0.0; color: "transparent" }
-              GradientStop { position: 0.5; color: Qt.rgba(root.stateColor.r, root.stateColor.g, root.stateColor.b,
-                root.failureVisible ? 0.0 : 0.7) }
-              GradientStop { position: 1.0; color: "transparent" }
-            }
+            phase: root.statePhase
+            accent: root.accent
+            urgent: Color.urgent
+            motionEnabled: root.motionEnabled && root.opened
           }
 
           ColumnLayout {
             id: answerLayout
+            visible: answerCard.contentVisible
             anchors.fill: parent
             anchors.topMargin: Style.spacing.xl
             spacing: Style.spacing.lg
@@ -550,10 +536,9 @@ Panel {
             Item {
               id: responseViewport
               Layout.fillWidth: true
-              Layout.fillHeight: true
-              Layout.minimumHeight: Style.space(88)
+              Layout.minimumHeight: Style.space(48)
               Layout.preferredHeight: Presentation.responseViewportHeight(
-                answerContent.implicitHeight, Style.space(88), Style.space(420))
+                answerContent.implicitHeight, Style.space(48), Style.space(420))
 
               Flickable {
                 id: answerScroll
@@ -820,15 +805,9 @@ Panel {
             Accessible.name: text
           }
 
-          // This row is now the only place settings and history are discoverable,
-          // so it has to be readable. Caption size at darker(1.6) was too faint
-          // to notice at all. "enter send" is dropped: Enter in a text field is
-          // not the thing anyone needs told.
-          // Clickable, not just advertised. Removing the gear left settings
-          // reachable only by keystroke, and a keystroke is a single point of
-          // failure: anything upstream that swallows the key makes a whole lane
-          // unreachable with no fallback. These are the same hints, but they are
-          // also the control.
+          // Keep the global settings binding and focused-panel history binding
+          // visible and clickable. "Enter send" is omitted because text fields
+          // already establish that convention.
           // Without this the auto-approve warning butts straight against the
           // first key hint and the two read as one sentence.
           Text {
@@ -844,7 +823,7 @@ Panel {
 
             Repeater {
               model: [
-                { label: "Ctrl+, settings", lane: "settings" },
+                { label: "Super+Alt+P settings", lane: "settings" },
                 { label: "Ctrl+H history", lane: "history" }
               ]
 
@@ -866,10 +845,10 @@ Panel {
                   readonly property var laneData: parent.modelData
                   text: laneData.label
                   color: hint.hovered ? root.accent : Qt.darker(root.foreground, 1.2)
-                font.family: root.fontFamily
-                font.pixelSize: Style.font.bodySmall
-                font.underline: hint.hovered
-                Accessible.role: Accessible.Button
+                  font.family: root.fontFamily
+                  font.pixelSize: Style.font.bodySmall
+                  font.underline: hint.hovered
+                  Accessible.role: Accessible.Button
                   Accessible.name: "Open " + hintLabel.laneData.lane
 
                 Behavior on color {

--- a/Panel.qml
+++ b/Panel.qml
@@ -48,10 +48,9 @@ Panel {
   readonly property real comfortableCardHeight: popup.availableCardHeight > 0
     ? Math.min(Style.space(720), Math.max(Style.space(320), popup.availableCardHeight * 0.82))
     : Style.space(720)
-  readonly property real activeNaturalHeight: viewMode === "settings" ? settingsView.implicitHeight
-    : (viewMode === "history"
-      ? Math.max(minimumContentHeight, comfortableCardHeight - popup.verticalContentInset)
-      : (viewMode === "error" ? errorView.implicitHeight : chatView.implicitHeight))
+  readonly property real activeNaturalHeight: viewMode === "settings" || viewMode === "history"
+    ? Math.max(minimumContentHeight, comfortableCardHeight - popup.verticalContentInset)
+    : (viewMode === "error" ? errorView.implicitHeight : chatView.implicitHeight)
   readonly property var responsePhase: Presentation.responsePhase(
     Quickchat.QuickchatStore.state,
     Quickchat.QuickchatStore.answerMarkdown !== "" || Quickchat.QuickchatStore.images.length > 0)
@@ -903,13 +902,19 @@ Panel {
         visible: root.viewMode === "settings"
         backend: Quickchat.QuickchatStore
         dangerousAutoApprove: root.dangerousAutoApprove
+        desktopContextEnabled: settings
+          && String(settings.desktopContext || "On") !== "Off"
         quickActions: root.quickActionItems
+        motionEnabled: root.motionEnabled
         foreground: root.foreground
         background: root.surface
         accent: root.accent
         fontFamily: root.fontFamily
         onDangerousAutoApproveRequested: function(enabled) {
           root.persistSettings({ dangerousAutoApprove: enabled === true })
+        }
+        onDesktopContextRequested: function(enabled) {
+          root.persistSettings({ desktopContext: enabled === true ? "On" : "Off" })
         }
         onProviderChanged: function(provider) { root.selectProvider(provider) }
         onModelChanged: function(provider, model) {
@@ -933,7 +938,6 @@ Panel {
         onCustomProviderRemoveRequested: function(id) {
           Quickchat.QuickchatStore.removeCustomProvider(id)
         }
-        onRecentChatsRequested: root.openHistory()
         onDismissed: root.showChat()
       }
 
@@ -956,6 +960,7 @@ Panel {
         anchors.fill: parent
         visible: root.viewMode === "history"
         history: Quickchat.QuickchatStore.history
+        motionEnabled: root.motionEnabled
         foreground: root.foreground
         background: root.surface
         accent: root.accent

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ families. Its rules are:
 
 Native messaging requires registration outside the plugin directory, so it is
 enabled only with the user's explicit consent. The primary setup path does not
-require a terminal: open **OmaPilot settings → Browser context** and choose
+require a terminal: open **OmaPilot settings → Desktop** and choose
 **Enable browser context**. OmaPilot registers the user-local relay and adds the
 bundled unpacked extension to detected Omarchy Chromium-family browser flags.
 Restart the browser afterward, pin the OmaPilot extension, then choose **Enable

--- a/components/Composer.qml
+++ b/components/Composer.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import Quickshell.Io
 import qs.Commons
 import qs.Ui
 import "Protocol.js" as Protocol
@@ -29,7 +30,15 @@ Item {
 
   readonly property bool inputActive: inlineMode ? inlineInput.activeFocus : promptInput.activeFocus
   property bool attachmentPopupOpen: false
+  property string hostName: ""
   readonly property bool popupOpen: inlineProvider.popupOpen || attachmentPopupOpen
+
+  FileView {
+    path: "/etc/hostname"
+    watchChanges: false
+    printErrors: false
+    onLoaded: root.hostName = String(text() || "").trim().split(/\s+/)[0]
+  }
 
   implicitWidth: inlineMode ? Style.space(360) : Style.space(520)
   implicitHeight: inlineMode ? Style.bar.sizeHorizontal : panelComposer.implicitHeight
@@ -192,14 +201,14 @@ Item {
 
     Text {
       Layout.fillWidth: true
-      visible: root.backend && root.backend.desktopContextActive
-      text: "󰍹  Active window, open apps, workspaces, and playing media are attached on send."
+      visible: root.backend && root.backend.desktopContextActive && root.hostName !== ""
+      text: root.hostName
       color: Qt.darker(root.foreground, 1.45)
       font.family: root.fontFamily
       font.pixelSize: Style.font.caption
-      wrapMode: Text.Wrap
+      elide: Text.ElideRight
       Accessible.role: Accessible.StaticText
-      Accessible.name: "Desktop context is attached on send"
+      Accessible.name: "Desktop context attached from " + root.hostName
     }
 
     // The hero: one borderless prompt line, not a boxed text area with a
@@ -265,7 +274,7 @@ Item {
         spacing: Style.spacing.xs
 
         PanelActionButton {
-          iconText: "\uf0c5"
+          iconText: "󰹑"
           tooltipText: "Clip context from the desktop"
           foreground: root.foreground
           focusable: true
@@ -275,7 +284,8 @@ Item {
         }
 
         PanelActionButton {
-          iconText: root.backend && root.backend.busy ? "\udb80\ude9b" : "\udb80\udd6c"
+          iconText: root.backend && (root.backend.busy || root.backend.state === "dictating")
+            ? "󰓛" : "󰍬"
           tooltipText: root.backend && root.backend.busy ? "Stop response" : "Dictate with Voxtype"
           foreground: root.backend && root.backend.state === "dictating" ? root.accent : root.foreground
           focusable: true

--- a/components/Composer.qml
+++ b/components/Composer.qml
@@ -25,16 +25,10 @@ Item {
   // window activation — which Qt.WindowShortcut depends on — is not dependable.
   // Key events reach the focused editor regardless, which is why Enter and
   // Escape below have always worked.
-  signal settingsRequested()
   signal historyRequested()
 
   readonly property bool inputActive: inlineMode ? inlineInput.activeFocus : promptInput.activeFocus
   property bool attachmentPopupOpen: false
-  // Set by the owner. Motion must not run while the panel is closed, so the
-  // filament is gated on visibility rather than on backend state alone.
-  property bool activityActive: false
-  // Supplied by the owner so the filament shows the current state, not just accent.
-  property color activityColor: accent
   readonly property bool popupOpen: inlineProvider.popupOpen || attachmentPopupOpen
 
   implicitWidth: inlineMode ? Style.space(360) : Style.space(520)
@@ -209,35 +203,19 @@ Item {
     }
 
     // The hero: one borderless prompt line, not a boxed text area with a
-    // toolbar. The old surface framed OmaPilot as an app embedded in the
-    // desktop; a bare caret and a filament read as the desktop itself asking.
-    // The visible container is gone, so the input needs no border states.
+    // toolbar. Keep its text on the same left edge as context and responses;
+    // a decorative prompt glyph only indented the user's words.
     Item {
       id: promptRow
       Layout.fillWidth: true
       Layout.preferredHeight: Math.max(Style.space(34), promptInput.implicitHeight + Style.spacing.md)
       visible: !root.backend || root.backend.pendingPermission === null
 
-      HoverHandler { id: promptHover }
-
-      Text {
-        id: caret
-        anchors.left: parent.left
-        anchors.top: parent.top
-        anchors.topMargin: Style.spacing.xs
-        text: "\u203a"
-        color: root.accent
-        font.family: root.fontFamily
-        font.pixelSize: Style.font.heading
-        opacity: promptInput.activeFocus ? 1 : 0.55
-        Behavior on opacity { NumberAnimation { duration: 140 } }
-      }
-
       TextArea {
         id: promptInput
         anchors {
-          left: caret.right; right: promptTools.left; top: parent.top; bottom: parent.bottom
-          leftMargin: Style.spacing.md; rightMargin: Style.spacing.md
+          left: parent.left; right: promptTools.left; top: parent.top; bottom: parent.bottom
+          rightMargin: Style.spacing.md
         }
         enabled: root.backend && !root.backend.continuationBlocked
           && root.backend.state !== "streaming" && root.backend.state !== "preparing"
@@ -265,9 +243,6 @@ Item {
           if ((event.key === Qt.Key_Return || event.key === Qt.Key_Enter)
               && !(event.modifiers & Qt.ShiftModifier)) {
             root.submit()
-            event.accepted = true
-          } else if (event.key === Qt.Key_Comma && (event.modifiers & Qt.ControlModifier)) {
-            root.settingsRequested()
             event.accepted = true
           } else if (event.key === Qt.Key_H && (event.modifiers & Qt.ControlModifier)) {
             root.historyRequested()
@@ -313,18 +288,6 @@ Item {
           }
         }
       }
-    }
-
-    // The filament: the composer's only edge. Dim at rest, accent on focus,
-    // and it carries the activity sweep so motion lives on the same line the
-    // user is typing on rather than around a card.
-    ActivityFilament {
-      Layout.fillWidth: true
-      visible: !root.backend || root.backend.pendingPermission === null
-      accent: root.activityColor
-      foreground: root.foreground
-      focused: promptInput.activeFocus || promptHover.hovered
-      active: root.activityActive
     }
 
     RowLayout {

--- a/components/Composer.qml
+++ b/components/Composer.qml
@@ -202,7 +202,7 @@ Item {
     Text {
       Layout.fillWidth: true
       visible: root.backend && root.backend.desktopContextActive && root.hostName !== ""
-      text: root.hostName
+      text: "󰍹  " + root.hostName
       color: Qt.darker(root.foreground, 1.45)
       font.family: root.fontFamily
       font.pixelSize: Style.font.caption

--- a/components/HistoryView.qml
+++ b/components/HistoryView.qml
@@ -229,8 +229,13 @@ Item {
               tooltipText: "Delete chat"
               foreground: root.foreground
               hoverColor: Color.urgent
-              focusable: true
-              opacity: row.hot || activeFocus ? 1 : 0.0
+              // Opacity 0 still receives taps, so non-current rows would delete
+              // from empty space on pointers that never hover. Disable the
+              // control until the row is current, hovered, or this button is
+              // focused. List Delete remains the keyboard path.
+              enabled: row.hot || activeFocus
+              focusable: enabled
+              opacity: enabled ? 1 : 0
               Accessible.name: tooltipText
               onClicked: root.deleteRequested(String(modelData.id))
               Behavior on opacity {

--- a/components/HistoryView.qml
+++ b/components/HistoryView.qml
@@ -13,6 +13,7 @@ Item {
   property color background: Color.popups.background
   property color accent: Color.accent
   property string fontFamily: Style.font.family
+  property bool motionEnabled: true
   property bool confirmingClear: false
   readonly property bool modalInteractionActive: confirmingClear
 
@@ -28,35 +29,11 @@ Item {
 
   ColumnLayout {
     anchors.fill: parent
-    spacing: Style.spacing.lg
+    spacing: Style.spacing.md
 
     RowLayout {
       Layout.fillWidth: true
-
-      Text {
-        Layout.fillWidth: true
-        text: "Recent chats"
-        color: root.foreground
-        font.family: root.fontFamily
-        font.pixelSize: Style.font.heading
-        font.bold: true
-      }
-
-      Button {
-        id: clearHistory
-        text: root.confirmingClear ? "Confirm clear" : "Clear all"
-        visible: root.history.length > 0
-        foreground: root.confirmingClear ? Color.urgent : root.foreground
-        background: root.background
-        bordered: true
-        focusable: true
-        onClicked: {
-          if (root.confirmingClear) {
-            root.clearRequested()
-            root.confirmingClear = false
-          } else root.confirmingClear = true
-        }
-      }
+      spacing: Style.spacing.md
 
       PanelActionButton {
         id: closeHistory
@@ -67,6 +44,64 @@ Item {
         Accessible.name: tooltipText
         onClicked: root.closeRequested()
       }
+
+      Text {
+        text: "History"
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.bodySmall
+        font.bold: true
+        Accessible.role: Accessible.StaticText
+        Accessible.name: "Recent chats"
+      }
+
+      Item { Layout.fillWidth: true }
+
+      Text {
+        id: clearHistory
+        visible: root.history.length > 0
+        text: root.confirmingClear ? "Clear all?" : "Clear"
+        color: root.confirmingClear
+          ? Color.urgent
+          : (activeFocus || clearHover.hovered ? root.foreground : Qt.darker(root.foreground, 1.35))
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.bodySmall
+        font.underline: clearHover.hovered || root.confirmingClear || activeFocus
+        activeFocusOnTab: visible
+        Accessible.role: Accessible.Button
+        Accessible.name: root.confirmingClear ? "Confirm clear all chats" : "Clear all chats"
+
+        Behavior on color {
+          enabled: root.motionEnabled
+          ColorAnimation { duration: 120 }
+        }
+
+        HoverHandler {
+          id: clearHover
+          cursorShape: Qt.PointingHandCursor
+        }
+
+        TapHandler { onTapped: clearHistory.activate() }
+        Keys.onReturnPressed: clearHistory.activate()
+        Keys.onEnterPressed: clearHistory.activate()
+        Keys.onSpacePressed: clearHistory.activate()
+
+        function activate() {
+          if (root.confirmingClear) {
+            root.clearRequested()
+            root.confirmingClear = false
+          } else root.confirmingClear = true
+        }
+      }
+    }
+
+    ActivityFilament {
+      Layout.fillWidth: true
+      foreground: root.foreground
+      accent: root.accent
+      focused: list.activeFocus || closeHistory.activeFocus
+      active: false
+      motionEnabled: root.motionEnabled
     }
 
     Item {
@@ -77,10 +112,10 @@ Item {
         visible: root.history.length === 0
         anchors.centerIn: parent
         width: parent.width - Style.spacing.xxl * 2
-        text: "No saved chats yet\nYour latest 30 completed answers appear here."
-        color: Qt.darker(root.foreground, 1.45)
+        text: "No saved chats yet.\nThe latest 30 completed answers appear here."
+        color: Qt.darker(root.foreground, 1.55)
         font.family: root.fontFamily
-        font.pixelSize: Style.font.body
+        font.pixelSize: Style.font.caption
         horizontalAlignment: Text.AlignHCenter
         wrapMode: Text.Wrap
       }
@@ -90,7 +125,7 @@ Item {
         visible: root.history.length > 0
         anchors.fill: parent
         model: root.history
-        spacing: Style.spacing.sm
+        spacing: 0
         clip: true
         boundsBehavior: Flickable.StopAtBounds
         activeFocusOnTab: true
@@ -112,28 +147,56 @@ Item {
           }
         }
 
-        delegate: BorderSurface {
+        delegate: Item {
           id: row
           required property var modelData
           required property int index
           width: list.width
-          height: Style.space(62)
-          color: index === list.currentIndex || rowHover.hovered
-            ? Style.hoverFillFor(root.foreground, root.accent)
-            : Style.normalFillFor(root.foreground, root.accent)
-          borderSpec: Border.controlSpec(index === list.currentIndex ? "hover-cursor" : "normal", root.foreground, root.accent)
-          radius: Style.cornerRadius
+          height: rowContent.implicitHeight + Style.spacing.lg * 2
+          Accessible.role: Accessible.ListItem
+          Accessible.name: String(modelData.title || "Chat")
 
-          HoverHandler { id: rowHover; onHoveredChanged: if (hovered) list.currentIndex = index }
+          readonly property bool current: index === list.currentIndex
+          readonly property bool hot: current || rowHover.hovered
+
+          Rectangle {
+            anchors.fill: parent
+            color: Style.hoverFillFor(root.foreground, root.accent)
+            opacity: row.hot ? 1 : 0
+            Behavior on opacity {
+              enabled: root.motionEnabled
+              NumberAnimation { duration: 120 }
+            }
+          }
+
+          Rectangle {
+            anchors.left: parent.left
+            anchors.verticalCenter: parent.verticalCenter
+            width: 2
+            height: Math.max(Style.space(18), parent.height * 0.42)
+            radius: 1
+            color: root.accent
+            opacity: row.current ? 0.95 : 0
+            Behavior on opacity {
+              enabled: root.motionEnabled
+              NumberAnimation { duration: 140 }
+            }
+          }
+
+          HoverHandler {
+            id: rowHover
+            onHoveredChanged: if (hovered) list.currentIndex = index
+          }
           TapHandler { onTapped: root.chatSelected(modelData) }
 
           RowLayout {
-            anchors.fill: parent
-            anchors.leftMargin: row.contentLeftInset + Style.spacing.lg
-            anchors.rightMargin: row.contentRightInset + Style.spacing.sm
-            anchors.topMargin: row.contentTopInset + Style.spacing.md
-            anchors.bottomMargin: row.contentBottomInset + Style.spacing.md
-            spacing: Style.spacing.lg
+            id: rowContent
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.leftMargin: Style.spacing.lg
+            anchors.rightMargin: Style.spacing.xs
+            spacing: Style.spacing.md
 
             ColumnLayout {
               Layout.fillWidth: true
@@ -145,7 +208,6 @@ Item {
                 color: root.foreground
                 font.family: root.fontFamily
                 font.pixelSize: Style.font.body
-                font.bold: true
                 elide: Text.ElideRight
               }
 
@@ -154,7 +216,7 @@ Item {
                 text: Protocol.providerLabel(modelData.provider)
                   + (modelData.model ? " · " + modelData.model : "")
                   + (modelData.timestamp ? " · " + modelData.timestamp : "")
-                color: Qt.darker(root.foreground, 1.45)
+                color: Qt.darker(root.foreground, 1.5)
                 font.family: root.fontFamily
                 font.pixelSize: Style.font.caption
                 elide: Text.ElideRight
@@ -168,8 +230,13 @@ Item {
               foreground: root.foreground
               hoverColor: Color.urgent
               focusable: true
+              opacity: row.hot || activeFocus ? 1 : 0.0
               Accessible.name: tooltipText
               onClicked: root.deleteRequested(String(modelData.id))
+              Behavior on opacity {
+                enabled: root.motionEnabled
+                NumberAnimation { duration: 120 }
+              }
             }
           }
         }

--- a/components/Presentation.js
+++ b/components/Presentation.js
@@ -66,3 +66,30 @@ function escapeAction(viewMode, composerPopupOpen, settingsPopupOpen,
   if (busy) return "cancel"
   return "close-panel"
 }
+
+function settingsTabs() {
+  return [
+    { id: "agent", label: "Agent" },
+    { id: "servers", label: "Servers" },
+    { id: "desktop", label: "Desktop" },
+    { id: "actions", label: "Actions" }
+  ]
+}
+
+function settingsTabIds() {
+  return settingsTabs().map(function(tab) { return tab.id })
+}
+
+function normalizedSettingsTab(value) {
+  var id = String(value || "")
+  return settingsTabIds().indexOf(id) >= 0 ? id : "agent"
+}
+
+function adjacentSettingsTab(current, delta) {
+  var ids = settingsTabIds()
+  var index = ids.indexOf(normalizedSettingsTab(current))
+  var next = index + finiteNumber(delta, 0)
+  if (next < 0) next = 0
+  if (next >= ids.length) next = ids.length - 1
+  return ids[next]
+}

--- a/components/Protocol.js
+++ b/components/Protocol.js
@@ -531,6 +531,14 @@ function providerLabel(value) {
   return String(value || "")
 }
 
+function providerShortLabel(value) {
+  var provider = normalizedProvider(value)
+  if (provider === "builtin") return "OmaPilot"
+  if (provider === "codex") return "Codex"
+  if (provider === "opencode") return "OpenCode"
+  return providerLabel(value)
+}
+
 function normalizeProviders(input) {
   var source = Array.isArray(input) ? input : []
   var result = []

--- a/components/QuickActionEditor.qml
+++ b/components/QuickActionEditor.qml
@@ -20,7 +20,7 @@ ColumnLayout {
 
   signal actionsEdited(var actions)
 
-  spacing: Style.spacing.md
+  spacing: Style.spacing.lg
 
   function beginAdding() {
     if (atLimit) return
@@ -50,17 +50,13 @@ ColumnLayout {
   Repeater {
     model: root.actions
 
-    delegate: BorderSurface {
+    delegate: ColumnLayout {
       id: actionCard
       required property int index
       required property var modelData
 
       Layout.fillWidth: true
-      implicitHeight: actionFields.implicitHeight + contentTopInset + contentBottomInset
-        + Style.spacing.xl * 2
-      color: Style.normalFillFor(root.foreground, root.accent)
-      borderSpec: Border.controlSpec("normal", root.foreground, root.accent)
-      radius: Style.cornerRadius
+      spacing: Style.spacing.sm
 
       function commitFields() {
         if (String(actionLabel.text || "").trim() === ""
@@ -73,165 +69,147 @@ ColumnLayout {
           root.actions, actionCard.index, actionLabel.text, actionPrompt.text))
       }
 
-      ColumnLayout {
-        id: actionFields
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.top: parent.top
-        anchors.leftMargin: parent.contentLeftInset + Style.spacing.xl
-        anchors.rightMargin: parent.contentRightInset + Style.spacing.xl
-        anchors.topMargin: parent.contentTopInset + Style.spacing.xl
+      RowLayout {
+        Layout.fillWidth: true
         spacing: Style.spacing.sm
 
-        RowLayout {
-          Layout.fillWidth: true
-          spacing: Style.spacing.sm
-
-          Text {
-            Layout.fillWidth: true
-            text: "Action " + String(actionCard.index + 1)
-            color: Qt.darker(root.foreground, 1.45)
-            font.family: root.fontFamily
-            font.pixelSize: Style.font.caption
-            font.bold: true
-          }
-
-          PanelActionButton {
-            iconText: "󰁝"
-            tooltipText: "Move action up"
-            foreground: root.foreground
-            focusable: true
-            enabled: actionCard.index > 0
-            Accessible.name: tooltipText
-            onClicked: root.actionsEdited(
-              ActionCatalog.moveAction(root.actions, actionCard.index, -1))
-          }
-
-          PanelActionButton {
-            iconText: "󰁅"
-            tooltipText: "Move action down"
-            foreground: root.foreground
-            focusable: true
-            enabled: actionCard.index < root.actions.length - 1
-            Accessible.name: tooltipText
-            onClicked: root.actionsEdited(
-              ActionCatalog.moveAction(root.actions, actionCard.index, 1))
-          }
-
-          PanelActionButton {
-            iconText: "󰆴"
-            tooltipText: "Remove action"
-            foreground: root.foreground
-            hoverColor: Color.urgent
-            focusable: true
-            Accessible.name: tooltipText
-            onClicked: root.actionsEdited(
-              ActionCatalog.removeAction(root.actions, actionCard.index))
-          }
+        Rectangle {
+          Layout.preferredWidth: 2
+          Layout.preferredHeight: Style.space(16)
+          radius: 1
+          color: root.accent
+          opacity: 0.7
         }
 
-        TextField {
-          id: actionLabel
+        Text {
           Layout.fillWidth: true
-          text: String(actionCard.modelData.label || "")
-          placeholderText: "Button label"
-          maximumLength: 48
+          text: "Action " + String(actionCard.index + 1)
+          color: Qt.darker(root.foreground, 1.45)
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+          font.bold: true
+        }
+
+        PanelActionButton {
+          iconText: "󰁝"
+          tooltipText: "Move action up"
           foreground: root.foreground
-          accent: root.accent
-          Accessible.name: "Quick action label"
-          onEditingFinished: actionCard.commitFields()
+          focusable: true
+          enabled: actionCard.index > 0
+          Accessible.name: tooltipText
+          onClicked: root.actionsEdited(
+            ActionCatalog.moveAction(root.actions, actionCard.index, -1))
         }
 
-        TextField {
-          id: actionPrompt
-          Layout.fillWidth: true
-          text: String(actionCard.modelData.prompt || "")
-          placeholderText: "Prompt inserted into the composer"
-          maximumLength: 1200
+        PanelActionButton {
+          iconText: "󰁅"
+          tooltipText: "Move action down"
           foreground: root.foreground
-          accent: root.accent
-          Accessible.name: "Quick action prompt"
-          onEditingFinished: actionCard.commitFields()
+          focusable: true
+          enabled: actionCard.index < root.actions.length - 1
+          Accessible.name: tooltipText
+          onClicked: root.actionsEdited(
+            ActionCatalog.moveAction(root.actions, actionCard.index, 1))
         }
-      }
-    }
-  }
 
-  BorderSurface {
-    Layout.fillWidth: true
-    visible: root.adding
-    implicitHeight: newActionFields.implicitHeight + contentTopInset + contentBottomInset
-      + Style.spacing.xl * 2
-    color: Style.focusFillFor(root.foreground, root.accent)
-    borderSpec: Border.controlSpec("focus", root.foreground, root.accent)
-    radius: Style.cornerRadius
-
-    ColumnLayout {
-      id: newActionFields
-      anchors.left: parent.left
-      anchors.right: parent.right
-      anchors.top: parent.top
-      anchors.leftMargin: parent.contentLeftInset + Style.spacing.xl
-      anchors.rightMargin: parent.contentRightInset + Style.spacing.xl
-      anchors.topMargin: parent.contentTopInset + Style.spacing.xl
-      spacing: Style.spacing.sm
-
-      Text {
-        Layout.fillWidth: true
-        text: "New quick action"
-        color: root.foreground
-        font.family: root.fontFamily
-        font.pixelSize: Style.font.body
-        font.bold: true
+        PanelActionButton {
+          iconText: "󰆴"
+          tooltipText: "Remove action"
+          foreground: root.foreground
+          hoverColor: Color.urgent
+          focusable: true
+          Accessible.name: tooltipText
+          onClicked: root.actionsEdited(
+            ActionCatalog.removeAction(root.actions, actionCard.index))
+        }
       }
 
       TextField {
-        id: newLabel
+        id: actionLabel
         Layout.fillWidth: true
+        text: String(actionCard.modelData.label || "")
         placeholderText: "Button label"
         maximumLength: 48
         foreground: root.foreground
         accent: root.accent
-        Accessible.name: "New quick action label"
+        Accessible.name: "Quick action label"
+        onEditingFinished: actionCard.commitFields()
       }
 
       TextField {
-        id: newPrompt
+        id: actionPrompt
         Layout.fillWidth: true
+        text: String(actionCard.modelData.prompt || "")
         placeholderText: "Prompt inserted into the composer"
         maximumLength: 1200
         foreground: root.foreground
         accent: root.accent
-        Accessible.name: "New quick action prompt"
-        Keys.onReturnPressed: root.saveNew()
+        Accessible.name: "Quick action prompt"
+        onEditingFinished: actionCard.commitFields()
+      }
+    }
+  }
+
+  ColumnLayout {
+    Layout.fillWidth: true
+    visible: root.adding
+    spacing: Style.spacing.sm
+
+    Text {
+      Layout.fillWidth: true
+      text: "New quick action"
+      color: root.foreground
+      font.family: root.fontFamily
+      font.pixelSize: Style.font.bodySmall
+      font.bold: true
+    }
+
+    TextField {
+      id: newLabel
+      Layout.fillWidth: true
+      placeholderText: "Button label"
+      maximumLength: 48
+      foreground: root.foreground
+      accent: root.accent
+      Accessible.name: "New quick action label"
+    }
+
+    TextField {
+      id: newPrompt
+      Layout.fillWidth: true
+      placeholderText: "Prompt inserted into the composer"
+      maximumLength: 1200
+      foreground: root.foreground
+      accent: root.accent
+      Accessible.name: "New quick action prompt"
+      Keys.onReturnPressed: root.saveNew()
+    }
+
+    RowLayout {
+      Layout.fillWidth: true
+      spacing: Style.spacing.md
+
+      Item { Layout.fillWidth: true }
+
+      Button {
+        text: "Cancel"
+        foreground: root.foreground
+        background: root.background
+        bordered: true
+        focusable: true
+        onClicked: root.cancelAdding()
       }
 
-      RowLayout {
-        Layout.fillWidth: true
-        spacing: Style.spacing.md
-
-        Item { Layout.fillWidth: true }
-
-        Button {
-          text: "Cancel"
-          foreground: root.foreground
-          background: root.background
-          bordered: true
-          focusable: true
-          onClicked: root.cancelAdding()
-        }
-
-        Button {
-          text: "Add"
-          foreground: root.foreground
-          background: root.background
-          accent: root.accent
-          active: true
-          bordered: true
-          focusable: true
-          enabled: root.canSaveNew && !root.atLimit
-          onClicked: root.saveNew()
-        }
+      Button {
+        text: "Add"
+        foreground: root.foreground
+        background: root.background
+        accent: root.accent
+        active: true
+        bordered: true
+        focusable: true
+        enabled: root.canSaveNew && !root.atLimit
+        onClicked: root.saveNew()
       }
     }
   }

--- a/components/SettingsTabs.qml
+++ b/components/SettingsTabs.qml
@@ -1,0 +1,178 @@
+import QtQuick
+import QtQuick.Effects
+import qs.Commons
+import "Presentation.js" as Presentation
+
+// Quiet text tabs with the same filament language as the composer.
+// A faint full-width rail, plus a short accent glow that sits under the
+// current label. The group is one Tab stop; h / l / Left / Right move
+// between tabs without walking every label.
+Item {
+  id: root
+
+  property string current: "agent"
+  property var tabs: Presentation.settingsTabs()
+  property color foreground: Color.popups.text
+  property color accent: Color.accent
+  property string fontFamily: Style.font.family
+  property bool motionEnabled: true
+  readonly property int currentIndex: {
+    var ids = Presentation.settingsTabIds()
+    var index = ids.indexOf(Presentation.normalizedSettingsTab(root.current))
+    return index < 0 ? 0 : index
+  }
+
+  signal selected(string id)
+
+  implicitHeight: tabRow.implicitHeight + Style.spacing.sm + rail.height
+  implicitWidth: tabRow.implicitWidth
+  activeFocusOnTab: true
+  Accessible.role: Accessible.PageTabList
+  Accessible.name: "Settings sections"
+  Accessible.focusable: true
+
+  function selectByDelta(delta) {
+    root.selected(Presentation.adjacentSettingsTab(root.current, delta))
+  }
+
+  Keys.onPressed: function(event) {
+    var unmodified = event.modifiers === Qt.NoModifier
+      || event.modifiers === Qt.KeypadModifier
+    if (!unmodified) return
+    if (event.key === Qt.Key_Left || event.key === Qt.Key_H) {
+      root.selectByDelta(-1)
+      event.accepted = true
+    } else if (event.key === Qt.Key_Right || event.key === Qt.Key_L) {
+      root.selectByDelta(1)
+      event.accepted = true
+    } else if (event.key === Qt.Key_Home) {
+      root.selected(Presentation.settingsTabIds()[0])
+      event.accepted = true
+    } else if (event.key === Qt.Key_End) {
+      var ids = Presentation.settingsTabIds()
+      root.selected(ids[ids.length - 1])
+      event.accepted = true
+    }
+  }
+
+  Row {
+    id: tabRow
+    spacing: Style.spacing.xl
+
+    Repeater {
+      id: tabRepeater
+      model: root.tabs
+
+      delegate: Text {
+        id: tabLabel
+        required property var modelData
+        required property int index
+        readonly property string tabId: String(modelData.id || "")
+        readonly property bool currentTab: tabId === Presentation.normalizedSettingsTab(root.current)
+
+        text: String(modelData.label || "")
+        color: tabLabel.currentTab || tabHover.hovered || (root.activeFocus && index === root.currentIndex)
+          ? root.foreground : Qt.darker(root.foreground, 1.45)
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.bodySmall
+        font.bold: tabLabel.currentTab
+        opacity: tabLabel.currentTab ? 1 : 0.86
+        Accessible.role: Accessible.PageTab
+        Accessible.name: text
+        Accessible.checkable: true
+        Accessible.checked: tabLabel.currentTab
+
+        Behavior on color {
+          enabled: root.motionEnabled
+          ColorAnimation { duration: 140 }
+        }
+
+        HoverHandler {
+          id: tabHover
+          cursorShape: Qt.PointingHandCursor
+        }
+
+        TapHandler {
+          onTapped: root.selected(tabLabel.tabId)
+        }
+      }
+    }
+  }
+
+  Item {
+    id: rail
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.bottom: parent.bottom
+    height: 1
+
+    Rectangle {
+      anchors.fill: parent
+      color: root.activeFocus ? root.accent : Qt.darker(root.foreground, 1.9)
+      opacity: root.activeFocus ? 0.55 : 0.28
+      Behavior on opacity {
+        enabled: root.motionEnabled
+        NumberAnimation { duration: 160; easing.type: Easing.OutCubic }
+      }
+      Behavior on color {
+        enabled: root.motionEnabled
+        ColorAnimation { duration: 160 }
+      }
+    }
+
+    Item {
+      id: glowSource
+      anchors.fill: parent
+      visible: false
+
+      Rectangle {
+        id: glowSegment
+        height: parent.height
+        width: Math.max(Style.space(24), activeTabWidth)
+        x: activeTabX
+        color: root.accent
+
+        readonly property real activeTabX: {
+          var _w = tabRow.width + tabRepeater.count
+          var item = tabRepeater.itemAt(root.currentIndex)
+          return item ? item.x : _w * 0
+        }
+        readonly property real activeTabWidth: {
+          var _w = tabRow.width + tabRepeater.count
+          var item = tabRepeater.itemAt(root.currentIndex)
+          return item ? item.width : Math.max(Style.space(24), _w * 0 + Style.space(36))
+        }
+
+        Behavior on x {
+          enabled: root.motionEnabled
+          NumberAnimation { duration: 180; easing.type: Easing.OutCubic }
+        }
+        Behavior on width {
+          enabled: root.motionEnabled
+          NumberAnimation { duration: 180; easing.type: Easing.OutCubic }
+        }
+      }
+    }
+
+    MultiEffect {
+      anchors.fill: glowSource
+      source: glowSource
+      autoPaddingEnabled: true
+      blurEnabled: true
+      blur: 1
+      blurMax: 16
+      blurMultiplier: 0.8
+      brightness: 0.45
+      colorization: 1
+      colorizationColor: root.accent
+    }
+
+    Rectangle {
+      height: parent.height
+      width: glowSegment.width
+      x: glowSegment.x
+      color: root.accent
+      opacity: 0.9
+    }
+  }
+}

--- a/components/SettingsView.qml
+++ b/components/SettingsView.qml
@@ -71,10 +71,10 @@ Item {
   readonly property bool popupOpen: providerPicker.popupOpen || modelPicker.popupOpen
     || authMethodPicker.popupOpen || authPromptPicker.popupOpen
   readonly property bool modalInteractionActive: popupOpen
-    || browserRemoveConfirmation
     || browserCompanionBusy
-    || quickActionEditor.interactionActive
-    || serverRemoveConfirmId !== ""
+    || (selectedTab === "desktop" && browserRemoveConfirmation)
+    || (selectedTab === "actions" && quickActionEditor.interactionActive)
+    || (selectedTab === "servers" && serverRemoveConfirmId !== "")
   implicitHeight: Style.space(560)
   readonly property color mutedForeground: Qt.darker(foreground, 1.45)
   Accessible.name: "OmaPilot settings"
@@ -137,6 +137,12 @@ Item {
     var next = Presentation.normalizedSettingsTab(id)
     if (next === selectedTab) return
     closePopups(false)
+    // Confirmations and the add-action editor are tab-local. Leaving them
+    // armed keeps modalInteractionActive true while their controls are gone,
+    // which swallows Ctrl+H / Ctrl+, and panel navigation.
+    if (next !== "servers") serverRemoveConfirmId = ""
+    if (next !== "desktop") browserRemoveConfirmation = false
+    if (next !== "actions" && quickActionEditor.adding) quickActionEditor.cancelAdding()
     selectedTab = next
   }
 

--- a/components/SettingsView.qml
+++ b/components/SettingsView.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Layouts
 import qs.Commons
 import qs.Ui
+import "Presentation.js" as Presentation
 import "Protocol.js" as Protocol
 
 Item {
@@ -9,7 +10,10 @@ Item {
 
   required property var backend
   property bool dangerousAutoApprove: false
+  property bool desktopContextEnabled: true
   property var quickActions: []
+  property string selectedTab: "agent"
+  property bool motionEnabled: true
   property color foreground: Color.popups.text
   property color background: Color.popups.background
   property color accent: Color.accent
@@ -70,8 +74,13 @@ Item {
     || browserRemoveConfirmation
     || browserCompanionBusy
     || quickActionEditor.interactionActive
+    || serverRemoveConfirmId !== ""
+  implicitHeight: Style.space(560)
+  readonly property color mutedForeground: Qt.darker(foreground, 1.45)
+  Accessible.name: "OmaPilot settings"
 
   signal dangerousAutoApproveRequested(bool enabled)
+  signal desktopContextRequested(bool enabled)
   signal providerChanged(string provider)
   signal modelChanged(string provider, string model)
   signal quickActionsEdited(var actions)
@@ -84,6 +93,7 @@ Item {
   signal customProviderTestRequested(string baseUrl, string apiKey)
   signal customProviderRemoveRequested(string id)
   signal voxtypeOsdRequested(bool enabled)
+  signal dismissed()
 
   function resetServerForm() {
     serverFormError = ""
@@ -121,6 +131,13 @@ Item {
       return
     }
     invalidateServerTest()
+  }
+
+  function selectTab(id) {
+    var next = Presentation.normalizedSettingsTab(id)
+    if (next === selectedTab) return
+    closePopups(false)
+    selectedTab = next
   }
 
   Connections {
@@ -191,11 +208,8 @@ Item {
     serverDraftResponses = String(server.api || "") !== "openai-completions"
     serverRemoveConfirmId = ""
     serverFormExpanded = true
+    selectTab("servers")
   }
-  signal recentChatsRequested()
-  signal dismissed()
-
-  implicitHeight: settingsContent.implicitHeight
 
   function closePopups(restoreFocus) {
     providerPicker.close()
@@ -203,295 +217,119 @@ Item {
     authMethodPicker.close()
     authPromptPicker.close()
     if (restoreFocus !== false)
-      Qt.callLater(function() { backButton.forceActiveFocus() })
+      Qt.callLater(function() { tabBar.forceActiveFocus() })
   }
 
   function forceInitialFocus() {
-    backButton.forceActiveFocus()
+    if (root.authenticationRequired) selectTab("agent")
+    tabBar.forceActiveFocus()
   }
 
-  Flickable {
-    id: settingsScroll
+  ColumnLayout {
     anchors.fill: parent
-    contentWidth: width
-    contentHeight: settingsContent.implicitHeight
-    clip: true
-    boundsBehavior: Flickable.StopAtBounds
-    interactive: contentHeight > height
+    spacing: Style.spacing.md
 
-    ColumnLayout {
-      id: settingsContent
-      width: settingsScroll.width
-      spacing: Style.spacing.xxl
+    RowLayout {
+      Layout.fillWidth: true
+      spacing: Style.spacing.md
 
-      RowLayout {
+      PanelActionButton {
+        id: backButton
+        Layout.alignment: Qt.AlignTop
+        iconText: "󰁍"
+        tooltipText: "Back to conversation"
+        foreground: root.foreground
+        focusable: true
+        Accessible.name: tooltipText
+        onClicked: root.dismissed()
+      }
+
+      SettingsTabs {
+        id: tabBar
         Layout.fillWidth: true
-        spacing: Style.spacing.md
+        Layout.alignment: Qt.AlignTop
+        current: root.selectedTab
+        foreground: root.foreground
+        accent: root.accent
+        fontFamily: root.fontFamily
+        motionEnabled: root.motionEnabled
+        onSelected: function(id) { root.selectTab(id) }
+      }
+    }
 
-        PanelActionButton {
-          id: backButton
-          iconText: "󰁍"
-          tooltipText: "Back to conversation"
-          foreground: root.foreground
-          focusable: true
-          Accessible.name: tooltipText
-          onClicked: root.dismissed()
-        }
+    Item {
+      Layout.fillWidth: true
+      Layout.fillHeight: true
+
+      Flickable {
+        id: agentScroll
+        anchors.fill: parent
+        visible: root.selectedTab === "agent"
+        contentWidth: width
+        contentHeight: agentContent.implicitHeight
+        clip: true
+        boundsBehavior: Flickable.StopAtBounds
+        interactive: contentHeight > height
 
         ColumnLayout {
-          Layout.fillWidth: true
-          spacing: 0
+          id: agentContent
+          width: agentScroll.width
+          spacing: Style.spacing.lg
 
           Text {
-            text: "OmaPilot settings"
-            color: root.foreground
+            Layout.fillWidth: true
+            text: "Harness"
+            color: root.mutedForeground
             font.family: root.fontFamily
-            font.pixelSize: Style.font.heading
+            font.pixelSize: Style.font.caption
             font.bold: true
           }
 
+          Dropdown {
+            id: providerPicker
+            Layout.fillWidth: true
+            showLabel: false
+            options: root.modeProviders
+            value: root.backend ? root.backend.provider : ""
+            enabled: root.backend && !root.backend.busy
+            foreground: root.foreground
+            background: root.background
+            Accessible.name: "Agent harness"
+            onChanged: function(value) { root.providerChanged(value) }
+          }
+
           Text {
-            text: "Harness, browser context, permissions, and quick actions"
-            color: Qt.darker(root.foreground, 1.45)
+            Layout.fillWidth: true
+            text: "Model"
+            color: root.mutedForeground
             font.family: root.fontFamily
             font.pixelSize: Style.font.caption
+            font.bold: true
           }
-        }
-      }
 
-      BorderSurface {
-        Layout.fillWidth: true
-        implicitHeight: settingsFields.implicitHeight + contentTopInset + contentBottomInset + Style.spacing.xxl * 2
-        color: Style.normalFillFor(root.foreground, root.accent)
-        borderSpec: Border.controlSpec("normal", root.foreground, root.accent)
-        radius: Style.cornerRadius
-
-        ColumnLayout {
-          id: settingsFields
-          anchors.left: parent.left
-          anchors.right: parent.right
-          anchors.top: parent.top
-          anchors.leftMargin: parent.contentLeftInset + Style.spacing.xxl
-          anchors.rightMargin: parent.contentRightInset + Style.spacing.xxl
-          anchors.topMargin: parent.contentTopInset + Style.spacing.xxl
-          spacing: Style.spacing.lg
-
-          // Accounts first. Signing in is the one thing a new install must do,
-          // and it was previously the last block in a scrolling panel — below
-          // permissions, servers, browser setup, and the harness picker — which
-          // is indistinguishable from missing.
-          BorderSurface {
+          Dropdown {
+            id: modelPicker
             Layout.fillWidth: true
-            // Was first-run only: `state === "unavailable" && providers.length === 0`.
-            // That hid the whole sign-in flow the moment ONE provider was
-            // authenticated, so a second account — Grok, or a registered
-            // OpenAI-compatible server — could never be added. It is now always
-            // available for the built-in harness and only *looks* urgent while
-            // nothing is authenticated.
-            visible: root.backend && root.backend.provider === "builtin"
-            implicitHeight: authContent.implicitHeight + contentTopInset + contentBottomInset
-              + Style.spacing.xl * 2
-            color: root.authenticationRequired
-              ? Style.normalFillFor(root.accent, root.accent)
-              : Style.normalFillFor(root.foreground, root.accent)
-            borderSpec: Border.controlSpec("normal",
-              root.authenticationRequired ? root.accent : root.foreground, root.accent)
-            radius: Style.cornerRadius
-
-            ColumnLayout {
-              id: authContent
-              anchors.left: parent.left
-              anchors.right: parent.right
-              anchors.top: parent.top
-              anchors.leftMargin: parent.contentLeftInset + Style.spacing.xl
-              anchors.rightMargin: parent.contentRightInset + Style.spacing.xl
-              anchors.topMargin: parent.contentTopInset + Style.spacing.xl
-              spacing: Style.spacing.md
-
-              Text {
-                Layout.fillWidth: true
-                text: root.authenticationRequired ? "Authentication required" : "Accounts"
-                color: root.foreground
-                font.family: root.fontFamily
-                font.pixelSize: Style.font.body
-                font.bold: true
-              }
-
-              Text {
-                Layout.fillWidth: true
-                text: root.authenticationRequired
-                  ? "Sign in here with a subscription or API key. OmaPilot runs the provider flow in the background and stores credentials only in its private configuration."
-                  : "Add another account — Codex, OpenAI, Grok, or a server you registered above. Signing in adds its models to the list below; it does not replace the accounts you already have."
-                color: Qt.darker(root.foreground, 1.35)
-                font.family: root.fontFamily
-                font.pixelSize: Style.font.caption
-                wrapMode: Text.Wrap
-                Accessible.role: Accessible.StaticText
-                Accessible.name: text
-              }
-
-              Dropdown {
-                id: authMethodPicker
-                Layout.fillWidth: true
-                visible: root.backend && !root.backend.builtinAuthBusy
-                showLabel: false
-                options: root.backend ? root.backend.builtinAuthMethods : []
-                value: root.selectedAuthMethod || (options.length > 0 ? String(options[0].value || "") : "")
-                enabled: options.length > 0
-                foreground: root.foreground
-                background: root.background
-                Accessible.name: "Built-in authentication method"
-                onChanged: function(value) { root.selectedAuthMethod = value }
-              }
-
-              Text {
-                Layout.fillWidth: true
-                visible: root.backend && String(root.backend.builtinAuth.message || "") !== ""
-                text: root.backend ? String(root.backend.builtinAuth.message || "") : ""
-                color: root.backend && String(root.backend.builtinAuth.phase || "") === "error"
-                  ? Color.urgent : Qt.darker(root.foreground, 1.35)
-                font.family: root.fontFamily
-                font.pixelSize: Style.font.caption
-                wrapMode: Text.Wrap
-              }
-
-              RowLayout {
-                Layout.fillWidth: true
-                visible: root.backend && (String(root.backend.builtinAuth.url || "") !== ""
-                  || String(root.backend.builtinAuth.verificationUri || "") !== "")
-                spacing: Style.spacing.md
-
-                Button {
-                  text: "Open sign-in page"
-                  iconText: "󰖟"
-                  foreground: root.foreground
-                  background: root.background
-                  accent: root.accent
-                  active: true
-                  bordered: true
-                  focusable: true
-                  onClicked: root.backend.activateLink(String(root.backend.builtinAuth.url
-                    || root.backend.builtinAuth.verificationUri || ""))
-                }
-
-                Button {
-                  visible: root.backend && String(root.backend.builtinAuth.userCode || "") !== ""
-                  text: "Copy " + (root.backend ? String(root.backend.builtinAuth.userCode || "") : "")
-                  foreground: root.foreground
-                  background: root.background
-                  bordered: true
-                  focusable: true
-                  onClicked: root.backend.copyText(String(root.backend.builtinAuth.userCode || ""))
-                }
-
-                Item { Layout.fillWidth: true }
-              }
-
-              Text {
-                Layout.fillWidth: true
-                visible: root.backend && root.backend.builtinAuth.prompt
-                text: visible ? String(root.backend.builtinAuth.prompt.message || "") : ""
-                color: root.foreground
-                font.family: root.fontFamily
-                font.pixelSize: Style.font.caption
-                wrapMode: Text.Wrap
-              }
-
-              Dropdown {
-                id: authPromptPicker
-                Layout.fillWidth: true
-                visible: root.backend && root.backend.builtinAuth.prompt
-                  && root.backend.builtinAuth.prompt.kind === "select"
-                showLabel: false
-                options: visible ? root.backend.builtinAuth.prompt.options : []
-                value: root.authPromptSelection || (options.length > 0 ? String(options[0].value || "") : "")
-                foreground: root.foreground
-                background: root.background
-                Accessible.name: visible ? String(root.backend.builtinAuth.prompt.message || "Authentication choice") : "Authentication choice"
-                onChanged: function(value) { root.authPromptSelection = value }
-              }
-
-              TextField {
-                id: authPromptInput
-                Layout.fillWidth: true
-                visible: root.backend && root.backend.builtinAuth.prompt
-                  && root.backend.builtinAuth.prompt.kind !== "select"
-                password: visible && root.backend.builtinAuth.prompt.kind === "secret"
-                placeholderText: visible ? String(root.backend.builtinAuth.prompt.placeholder
-                  || root.backend.builtinAuth.prompt.message || "") : ""
-                maximumLength: 32768
-                foreground: root.foreground
-                accent: root.accent
-                Accessible.name: visible ? String(root.backend.builtinAuth.prompt.message || "Authentication value") : "Authentication value"
-                onVisibleChanged: if (visible) { text = ""; forceActiveFocus() }
-                onAccepted: if (visible) root.backend.respondBuiltInAuth(text)
-              }
-
-              RowLayout {
-                Layout.fillWidth: true
-                spacing: Style.spacing.md
-
-                Button {
-                  visible: root.backend && !root.backend.builtinAuthBusy
-                  text: String(root.backend && root.backend.builtinAuth.phase || "") === "error" ? "Try again"
-                    : (root.authenticationRequired ? "Continue" : "Sign in")
-                  iconText: "󰌾"
-                  foreground: root.foreground
-                  background: root.background
-                  accent: root.accent
-                  active: true
-                  bordered: true
-                  focusable: true
-                  enabled: authMethodPicker.options.length > 0
-                  onClicked: root.backend.authenticateBuiltIn(authMethodPicker.value)
-                }
-
-                Button {
-                  visible: root.backend && root.backend.builtinAuth.prompt
-                  text: "Continue"
-                  foreground: root.foreground
-                  background: root.background
-                  accent: root.accent
-                  active: true
-                  bordered: true
-                  focusable: true
-                  enabled: root.backend && root.backend.builtinAuth.prompt
-                    ? (root.backend.builtinAuth.prompt.kind === "select"
-                      ? authPromptPicker.value !== "" : authPromptInput.text !== "") : false
-                  onClicked: root.backend.respondBuiltInAuth(root.backend.builtinAuth.prompt.kind === "select"
-                    ? authPromptPicker.value : authPromptInput.text)
-                }
-
-                Button {
-                  visible: root.backend && root.backend.builtinAuthBusy
-                  text: "Cancel"
-                  foreground: root.foreground
-                  background: root.background
-                  bordered: true
-                  focusable: true
-                  onClicked: root.backend.cancelBuiltInAuth()
-                }
-
-                Item { Layout.fillWidth: true }
-              }
+            showLabel: false
+            options: root.backend && root.backend.modelOptions.length > 0
+              ? root.backend.modelOptions
+              : [{ value: "", label: "Harness default" }]
+            value: root.backend ? root.backend.model : ""
+            enabled: root.backend && !root.backend.busy
+            foreground: root.foreground
+            background: root.background
+            Accessible.name: "AI model"
+            onChanged: function(value) {
+              root.backend.model = value
+              root.modelChanged(root.backend.provider, value)
             }
           }
 
           Text {
             Layout.fillWidth: true
-            text: "Permissions"
-            color: root.foreground
-            font.family: root.fontFamily
-            font.pixelSize: Style.font.subtitle
-            font.bold: true
-          }
-
-          Text {
-            Layout.fillWidth: true
-            text: root.dangerousAutoApprove
-              ? "OmaPilot auto-approves each exact, inspectable device request."
-              : "Device changes stay behind an exact, inspectable approval."
-            color: Qt.darker(root.foreground, 1.45)
+            visible: root.backend
+            text: !root.backend ? "" : Protocol.providerPolicyDescription(root.backend.provider, root.backend.providerPolicy)
+            color: root.mutedForeground
             font.family: root.fontFamily
             font.pixelSize: Style.font.caption
             wrapMode: Text.Wrap
@@ -499,24 +337,11 @@ Item {
             Accessible.name: text
           }
 
-          Toggle {
-            Layout.fillWidth: true
-            label: "Dangerous auto-approve"
-            description: "Approve each exact device action automatically instead of prompting."
-            checked: root.dangerousAutoApprove
-            enabled: root.backend && !root.backend.busy
-            foreground: root.foreground
-            accent: checked ? Color.urgent : root.accent
-            fontFamily: root.fontFamily
-            Accessible.name: label
-            onClicked: root.dangerousAutoApproveRequested(!root.dangerousAutoApprove)
-          }
-
           Text {
             Layout.fillWidth: true
-            visible: root.dangerousAutoApprove
-            text: "Approval prompts are skipped. Commands may read, change, or delete device data and use the network."
-            color: Color.urgent
+            visible: root.backend && root.backend.modelOptions.length === 0
+            text: "Using the harness default. This harness did not expose a model catalog."
+            color: root.mutedForeground
             font.family: root.fontFamily
             font.pixelSize: Style.font.caption
             wrapMode: Text.Wrap
@@ -524,91 +349,208 @@ Item {
             Accessible.name: text
           }
 
-          PanelSeparator {
+          ColumnLayout {
             Layout.fillWidth: true
-            Layout.topMargin: Style.spacing.md
-            foreground: root.foreground
-          }
+            visible: root.backend && root.backend.provider === "builtin"
+            spacing: Style.spacing.md
 
-          PanelSeparator {
-            Layout.fillWidth: true
-            Layout.topMargin: Style.spacing.md
-            foreground: root.foreground
-          }
+            Text {
+              Layout.fillWidth: true
+              text: root.authenticationRequired ? "Authentication required" : "Accounts"
+              color: root.foreground
+              font.family: root.fontFamily
+              font.pixelSize: root.authenticationRequired ? Style.font.body : Style.font.caption
+              font.bold: true
+            }
 
-          Text {
-            Layout.fillWidth: true
-            text: "Voice indicator"
-            color: root.foreground
-            font.family: root.fontFamily
-            font.pixelSize: Style.font.subtitle
-            font.bold: true
+            Text {
+              Layout.fillWidth: true
+              text: root.authenticationRequired
+                ? "Sign in with a subscription or API key. Credentials stay in OmaPilot's private configuration."
+                : "Add Codex, OpenAI, Grok, or a server from the Servers tab."
+              color: root.mutedForeground
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.caption
+              wrapMode: Text.Wrap
+              Accessible.role: Accessible.StaticText
+              Accessible.name: text
+            }
+
+            Dropdown {
+              id: authMethodPicker
+              Layout.fillWidth: true
+              visible: root.backend && !root.backend.builtinAuthBusy
+              showLabel: false
+              options: root.backend ? root.backend.builtinAuthMethods : []
+              value: root.selectedAuthMethod || (options.length > 0 ? String(options[0].value || "") : "")
+              enabled: options.length > 0
+              foreground: root.foreground
+              background: root.background
+              Accessible.name: "Built-in authentication method"
+              onChanged: function(value) { root.selectedAuthMethod = value }
+            }
+
+            Text {
+              Layout.fillWidth: true
+              visible: root.backend && String(root.backend.builtinAuth.message || "") !== ""
+              text: root.backend ? String(root.backend.builtinAuth.message || "") : ""
+              color: root.backend && String(root.backend.builtinAuth.phase || "") === "error"
+                ? Color.urgent : root.mutedForeground
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.caption
+              wrapMode: Text.Wrap
+            }
+
+            RowLayout {
+              Layout.fillWidth: true
+              visible: root.backend && (String(root.backend.builtinAuth.url || "") !== ""
+                || String(root.backend.builtinAuth.verificationUri || "") !== "")
+              spacing: Style.spacing.md
+
+              Button {
+                text: "Open sign-in page"
+                iconText: "󰖟"
+                foreground: root.foreground
+                background: root.background
+                accent: root.accent
+                active: true
+                bordered: true
+                focusable: true
+                onClicked: root.backend.activateLink(String(root.backend.builtinAuth.url
+                  || root.backend.builtinAuth.verificationUri || ""))
+              }
+
+              Button {
+                visible: root.backend && String(root.backend.builtinAuth.userCode || "") !== ""
+                text: "Copy " + (root.backend ? String(root.backend.builtinAuth.userCode || "") : "")
+                foreground: root.foreground
+                background: root.background
+                bordered: true
+                focusable: true
+                onClicked: root.backend.copyText(String(root.backend.builtinAuth.userCode || ""))
+              }
+
+              Item { Layout.fillWidth: true }
+            }
+
+            Text {
+              Layout.fillWidth: true
+              visible: root.backend && root.backend.builtinAuth.prompt
+              text: visible ? String(root.backend.builtinAuth.prompt.message || "") : ""
+              color: root.foreground
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.caption
+              wrapMode: Text.Wrap
+            }
+
+            Dropdown {
+              id: authPromptPicker
+              Layout.fillWidth: true
+              visible: root.backend && root.backend.builtinAuth.prompt
+                && root.backend.builtinAuth.prompt.kind === "select"
+              showLabel: false
+              options: visible ? root.backend.builtinAuth.prompt.options : []
+              value: root.authPromptSelection || (options.length > 0 ? String(options[0].value || "") : "")
+              foreground: root.foreground
+              background: root.background
+              Accessible.name: visible ? String(root.backend.builtinAuth.prompt.message || "Authentication choice") : "Authentication choice"
+              onChanged: function(value) { root.authPromptSelection = value }
+            }
+
+            TextField {
+              id: authPromptInput
+              Layout.fillWidth: true
+              visible: root.backend && root.backend.builtinAuth.prompt
+                && root.backend.builtinAuth.prompt.kind !== "select"
+              password: visible && root.backend.builtinAuth.prompt.kind === "secret"
+              placeholderText: visible ? String(root.backend.builtinAuth.prompt.placeholder
+                || root.backend.builtinAuth.prompt.message || "") : ""
+              maximumLength: 32768
+              foreground: root.foreground
+              accent: root.accent
+              Accessible.name: visible ? String(root.backend.builtinAuth.prompt.message || "Authentication value") : "Authentication value"
+              onVisibleChanged: if (visible) { text = ""; forceActiveFocus() }
+              onAccepted: if (visible) root.backend.respondBuiltInAuth(text)
+            }
+
+            RowLayout {
+              Layout.fillWidth: true
+              spacing: Style.spacing.md
+
+              Button {
+                visible: root.backend && !root.backend.builtinAuthBusy
+                text: String(root.backend && root.backend.builtinAuth.phase || "") === "error" ? "Try again"
+                  : (root.authenticationRequired ? "Continue" : "Sign in")
+                iconText: "󰌾"
+                foreground: root.foreground
+                background: root.background
+                accent: root.accent
+                active: true
+                bordered: true
+                focusable: true
+                enabled: authMethodPicker.options.length > 0
+                onClicked: root.backend.authenticateBuiltIn(authMethodPicker.value)
+              }
+
+              Button {
+                visible: root.backend && root.backend.builtinAuth.prompt
+                text: "Continue"
+                foreground: root.foreground
+                background: root.background
+                accent: root.accent
+                active: true
+                bordered: true
+                focusable: true
+                enabled: root.backend && root.backend.builtinAuth.prompt
+                  ? (root.backend.builtinAuth.prompt.kind === "select"
+                    ? authPromptPicker.value !== "" : authPromptInput.text !== "") : false
+                onClicked: root.backend.respondBuiltInAuth(root.backend.builtinAuth.prompt.kind === "select"
+                  ? authPromptPicker.value : authPromptInput.text)
+              }
+
+              Button {
+                visible: root.backend && root.backend.builtinAuthBusy
+                text: "Cancel"
+                foreground: root.foreground
+                background: root.background
+                bordered: true
+                focusable: true
+                onClicked: root.backend.cancelBuiltInAuth()
+              }
+
+              Item { Layout.fillWidth: true }
+            }
           }
+        }
+      }
+
+      Flickable {
+        id: serversScroll
+        anchors.fill: parent
+        visible: root.selectedTab === "servers"
+        contentWidth: width
+        contentHeight: serversContent.implicitHeight
+        clip: true
+        boundsBehavior: Flickable.StopAtBounds
+        interactive: contentHeight > height
+
+        ColumnLayout {
+          id: serversContent
+          width: serversScroll.width
+          spacing: Style.spacing.lg
 
           Text {
             Layout.fillWidth: true
             wrapMode: Text.Wrap
-            text: root.voxtypeOsd.available
-              ? "Voxtype draws its own waveform at the bottom of the screen, in the same place as OmaPilot's voice glow. Turning it off leaves one indicator instead of two."
-              : "Voxtype's configuration was not found, so its on-screen display cannot be switched from here."
-            color: Qt.darker(root.foreground, 1.45)
+            text: "Register an OpenAI-compatible /responses or /chat/completions endpoint. Test /models before saving. Keys go to auth.json, never into the definition."
+            color: root.mutedForeground
             font.family: root.fontFamily
             font.pixelSize: Style.font.caption
           }
 
-          Toggle {
-            Layout.fillWidth: true
-            visible: root.voxtypeOsd.available
-            label: "Voxtype on-screen display"
-            description: "Off leaves OmaPilot's glow as the only recording indicator. Restarts the Voxtype daemon."
-            checked: root.voxtypeOsd.enabled
-            foreground: root.foreground
-            accent: root.accent
-            fontFamily: root.fontFamily
-            Accessible.name: label
-            onClicked: root.voxtypeOsdRequested(!root.voxtypeOsd.enabled)
-          }
-
           Text {
             Layout.fillWidth: true
-            wrapMode: Text.Wrap
-            visible: String(root.voxtypeOsd.message || "") !== ""
-            text: String(root.voxtypeOsd.message || "")
-            color: Color.urgent
-            font.family: root.fontFamily
-            font.pixelSize: Style.font.caption
-          }
-
-          PanelSeparator {
-            Layout.fillWidth: true
-            Layout.topMargin: Style.spacing.md
-            foreground: root.foreground
-          }
-
-          Text {
-            Layout.fillWidth: true
-            text: "OpenAI-compatible servers"
-            color: root.foreground
-            font.family: root.fontFamily
-            font.pixelSize: Style.font.subtitle
-            font.bold: true
-          }
-
-          Text {
-            Layout.fillWidth: true
-            wrapMode: Text.Wrap
-            text: "Register any endpoint that speaks the OpenAI /responses or /chat/completions API. Test /models first; those discovered models join the built-in harness when you save. API keys are optional and go to auth.json, never into the definition."
-            color: Qt.darker(root.foreground, 1.45)
-            font.family: root.fontFamily
-            font.pixelSize: Style.font.caption
-          }
-
-          // Saved servers were invisible when the list was empty, so adding one
-          // looked like nothing had happened. An explicit empty state, and a
-          // per-server sign-in line, make the actual state legible.
-          Text {
-            Layout.fillWidth: true
-            visible: root.savedServers.length === 0
+            visible: root.savedServers.length === 0 && !root.serverFormExpanded
             text: "No servers added yet."
             color: Qt.darker(root.foreground, 1.55)
             font.family: root.fontFamily
@@ -618,67 +560,79 @@ Item {
           Repeater {
             model: root.savedServers
 
-            RowLayout {
+            ColumnLayout {
               required property var modelData
               readonly property int liveModels: root.backend && root.backend.modelOptions
                 ? Protocol.customProviderModelCount(root.backend.modelOptions, modelData.id) : 0
               Layout.fillWidth: true
-              spacing: Style.spacing.md
+              spacing: Style.spacing.sm
 
-              ColumnLayout {
+              RowLayout {
                 Layout.fillWidth: true
-                spacing: 0
-                Text {
-                  Layout.fillWidth: true
-                  text: modelData.name + "  \u00b7  " + modelData.apiLabel
-                  color: root.foreground
-                  font.family: root.fontFamily
-                  font.pixelSize: Style.font.bodySmall
-                  elide: Text.ElideRight
-                }
-                Text {
-                  Layout.fillWidth: true
-                  text: modelData.baseUrl + "  \u00b7  " + modelData.models.length
-                    + (modelData.models.length === 1 ? " model" : " models")
-                  color: Qt.darker(root.foreground, 1.5)
-                  font.family: root.fontFamily
-                  font.pixelSize: Style.font.caption
-                  elide: Text.ElideMiddle
-                }
-                Text {
-                  Layout.fillWidth: true
-                  text: liveModels > 0
-                    ? "Connected \u00b7 " + liveModels + (liveModels === 1 ? " model available" : " models available")
-                    : (modelData.requiresAuth
-                      ? "Not signed in \u2014 edit this server and enter its API key"
-                      : "No API key required \u00b7 refreshing models")
-                  color: liveModels > 0 ? Qt.darker(root.foreground, 1.5) : root.accent
-                  font.family: root.fontFamily
-                  font.pixelSize: Style.font.caption
-                  elide: Text.ElideRight
-                }
-              }
+                spacing: Style.spacing.md
 
-              Button {
-                text: "Edit"
-                foreground: Qt.darker(root.foreground, 1.3)
-                background: root.background
-                bordered: true
-                focusable: true
-                onClicked: root.editServer(modelData)
-              }
+                Rectangle {
+                  Layout.preferredWidth: 2
+                  Layout.preferredHeight: Style.space(28)
+                  radius: 1
+                  color: liveModels > 0 ? root.accent : Qt.darker(root.foreground, 1.8)
+                }
 
-              Button {
-                text: root.serverRemoveConfirmId === modelData.id ? "Confirm removal" : "Remove"
-                foreground: root.serverRemoveConfirmId === modelData.id ? Color.urgent : Qt.darker(root.foreground, 1.3)
-                background: root.background
-                bordered: true
-                focusable: true
-                onClicked: {
-                  if (root.serverRemoveConfirmId === modelData.id) {
-                    root.customProviderRemoveRequested(modelData.id)
-                    root.serverRemoveConfirmId = ""
-                  } else root.serverRemoveConfirmId = modelData.id
+                ColumnLayout {
+                  Layout.fillWidth: true
+                  spacing: 0
+                  Text {
+                    Layout.fillWidth: true
+                    text: modelData.name + "  \u00b7  " + modelData.apiLabel
+                    color: root.foreground
+                    font.family: root.fontFamily
+                    font.pixelSize: Style.font.bodySmall
+                    elide: Text.ElideRight
+                  }
+                  Text {
+                    Layout.fillWidth: true
+                    text: modelData.baseUrl + "  \u00b7  " + modelData.models.length
+                      + (modelData.models.length === 1 ? " model" : " models")
+                    color: Qt.darker(root.foreground, 1.5)
+                    font.family: root.fontFamily
+                    font.pixelSize: Style.font.caption
+                    elide: Text.ElideMiddle
+                  }
+                  Text {
+                    Layout.fillWidth: true
+                    text: liveModels > 0
+                      ? "Connected \u00b7 " + liveModels + (liveModels === 1 ? " model available" : " models available")
+                      : (modelData.requiresAuth
+                        ? "Not signed in \u2014 edit this server and enter its API key"
+                        : "No API key required \u00b7 refreshing models")
+                    color: liveModels > 0 ? Qt.darker(root.foreground, 1.5) : root.accent
+                    font.family: root.fontFamily
+                    font.pixelSize: Style.font.caption
+                    elide: Text.ElideRight
+                  }
+                }
+
+                Button {
+                  text: "Edit"
+                  foreground: Qt.darker(root.foreground, 1.3)
+                  background: root.background
+                  bordered: true
+                  focusable: true
+                  onClicked: root.editServer(modelData)
+                }
+
+                Button {
+                  text: root.serverRemoveConfirmId === modelData.id ? "Confirm removal" : "Remove"
+                  foreground: root.serverRemoveConfirmId === modelData.id ? Color.urgent : Qt.darker(root.foreground, 1.3)
+                  background: root.background
+                  bordered: true
+                  focusable: true
+                  onClicked: {
+                    if (root.serverRemoveConfirmId === modelData.id) {
+                      root.customProviderRemoveRequested(modelData.id)
+                      root.serverRemoveConfirmId = ""
+                    } else root.serverRemoveConfirmId = modelData.id
+                  }
                 }
               }
             }
@@ -757,10 +711,6 @@ Item {
               }
             }
 
-            // Signing in used to be a separate trip through Accounts, which left
-            // a freshly added server contributing no models and looking broken.
-            // The key is sent straight to the harness login and stored in
-            // auth.json; it is never written to models.json.
             TextField {
               Layout.fillWidth: true
               placeholderText: root.serverEditingId === ""
@@ -814,21 +764,16 @@ Item {
               wrapMode: Text.Wrap
             }
 
-            RowLayout {
-              Layout.fillWidth: true
-              spacing: Style.spacing.md
-
-              Toggle {
-                enabled: !root.serverSavePending
-                checked: root.serverDraftResponses
-                label: "Use the /responses API"
-                description: "Turn off for servers that only implement /chat/completions."
-                foreground: root.foreground
-                accent: root.accent
-                fontFamily: root.fontFamily
-                Accessible.name: label
-                onClicked: root.serverDraftResponses = !root.serverDraftResponses
-              }
+            Toggle {
+              enabled: !root.serverSavePending
+              checked: root.serverDraftResponses
+              label: "Use the /responses API"
+              description: "Turn off for servers that only implement /chat/completions."
+              foreground: root.foreground
+              accent: root.accent
+              fontFamily: root.fontFamily
+              Accessible.name: label
+              onClicked: root.serverDraftResponses = !root.serverDraftResponses
             }
 
             Text {
@@ -851,8 +796,6 @@ Item {
               active: true
               bordered: true
               focusable: true
-              // Deliberately always clickable. Disabling it hid the reason a save
-              // could not proceed, which read as the button being broken.
               onClicked: {
                 var missing = []
                 if (root.serverDraftId.trim() === "") missing.push("an id")
@@ -876,25 +819,101 @@ Item {
               }
             }
           }
+        }
+      }
 
-          Text {
+      Flickable {
+        id: desktopScroll
+        anchors.fill: parent
+        visible: root.selectedTab === "desktop"
+        contentWidth: width
+        contentHeight: desktopContent.implicitHeight
+        clip: true
+        boundsBehavior: Flickable.StopAtBounds
+        interactive: contentHeight > height
+
+        ColumnLayout {
+          id: desktopContent
+          width: desktopScroll.width
+          spacing: Style.spacing.lg
+
+          Toggle {
             Layout.fillWidth: true
-            text: "Browser context"
-            color: root.foreground
-            font.family: root.fontFamily
-            font.pixelSize: Style.font.subtitle
-            font.bold: true
+            label: "Dangerous auto-approve"
+            description: "Approve each exact device action automatically instead of prompting."
+            checked: root.dangerousAutoApprove
+            enabled: root.backend && !root.backend.busy
+            foreground: root.foreground
+            accent: checked ? Color.urgent : root.accent
+            fontFamily: root.fontFamily
+            Accessible.name: label
+            onClicked: root.dangerousAutoApproveRequested(!root.dangerousAutoApprove)
           }
 
           Text {
             Layout.fillWidth: true
-            text: "Select semantic page elements and choose Element, Text, or Screenshot before sharing context. OmaPilot handles setup from here—no terminal command is required."
-            color: Qt.darker(root.foreground, 1.45)
+            visible: root.dangerousAutoApprove
+            text: "Approval prompts are skipped. Commands may read, change, or delete device data and use the network."
+            color: Color.urgent
             font.family: root.fontFamily
             font.pixelSize: Style.font.caption
             wrapMode: Text.Wrap
             Accessible.role: Accessible.StaticText
             Accessible.name: text
+          }
+
+          Toggle {
+            Layout.fillWidth: true
+            label: "Desktop context"
+            description: "Attach the active window, open apps, workspaces, and playing media on send."
+            checked: root.desktopContextEnabled
+            foreground: root.foreground
+            accent: root.accent
+            fontFamily: root.fontFamily
+            Accessible.name: label
+            onClicked: root.desktopContextRequested(!root.desktopContextEnabled)
+          }
+
+          Toggle {
+            Layout.fillWidth: true
+            visible: root.voxtypeOsd.available
+            label: "Voxtype on-screen display"
+            description: "Off leaves OmaPilot's glow as the only recording indicator. Restarts the Voxtype daemon."
+            checked: root.voxtypeOsd.enabled
+            foreground: root.foreground
+            accent: root.accent
+            fontFamily: root.fontFamily
+            Accessible.name: label
+            onClicked: root.voxtypeOsdRequested(!root.voxtypeOsd.enabled)
+          }
+
+          Text {
+            Layout.fillWidth: true
+            wrapMode: Text.Wrap
+            visible: !root.voxtypeOsd.available
+            text: "Voxtype's configuration was not found, so its on-screen display cannot be switched from here."
+            color: root.mutedForeground
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.caption
+          }
+
+          Text {
+            Layout.fillWidth: true
+            wrapMode: Text.Wrap
+            visible: String(root.voxtypeOsd.message || "") !== ""
+            text: String(root.voxtypeOsd.message || "")
+            color: Color.urgent
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.caption
+          }
+
+          Text {
+            Layout.fillWidth: true
+            text: "Browser context"
+            color: root.mutedForeground
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.caption
+            font.bold: true
           }
 
           RowLayout {
@@ -934,8 +953,8 @@ Item {
                   ? "Use the OmaPilot extension icon once per site to grant page access."
                   : (root.browserCompanion.relayInstalled === true
                     ? "Restart Chromium, then pin the OmaPilot extension and enable the current site."
-                    : "Choose Enable browser context to install the relay and bundled extension automatically, then restart your browser.")
-                color: Qt.darker(root.foreground, 1.45)
+                    : "Enable browser context to install the relay and bundled extension, then restart the browser.")
+                color: root.mutedForeground
                 font.family: root.fontFamily
                 font.pixelSize: Style.font.caption
                 wrapMode: Text.Wrap
@@ -1025,7 +1044,7 @@ Item {
             Text {
               Layout.fillWidth: true
               text: "Restart the browser first. If the extension is not loaded, open Extensions, enable Developer mode, choose Load unpacked, and select the bundled Chromium folder."
-              color: Qt.darker(root.foreground, 1.45)
+              color: root.mutedForeground
               font.family: root.fontFamily
               font.pixelSize: Style.font.caption
               wrapMode: Text.Wrap
@@ -1070,7 +1089,7 @@ Item {
             Text {
               Layout.fillWidth: true
               text: "Open This Firefox, choose Load Temporary Add-on, then select manifest.json from the bundled Firefox folder. Repeat after each browser restart until a signed store build is available."
-              color: Qt.darker(root.foreground, 1.45)
+              color: root.mutedForeground
               font.family: root.fontFamily
               font.pixelSize: Style.font.caption
               wrapMode: Text.Wrap
@@ -1148,117 +1167,28 @@ Item {
               onClicked: root.browserRemoveConfirmation = false
             }
           }
+        }
+      }
+
+      Flickable {
+        id: actionsScroll
+        anchors.fill: parent
+        visible: root.selectedTab === "actions"
+        contentWidth: width
+        contentHeight: actionsContent.implicitHeight
+        clip: true
+        boundsBehavior: Flickable.StopAtBounds
+        interactive: contentHeight > height
+
+        ColumnLayout {
+          id: actionsContent
+          width: actionsScroll.width
+          spacing: Style.spacing.lg
 
           Text {
             Layout.fillWidth: true
-            visible: !root.browserCompanionConnected && root.browserCompanion.relayInstalled !== true
-            text: "OmaPilot registers the native-messaging host and adds its bundled extension to detected Omarchy Chromium-family browsers for you. Firefox and Zen still require browser confirmation to load the temporary Firefox build."
-            color: Qt.darker(root.foreground, 1.45)
-            font.family: root.fontFamily
-            font.pixelSize: Style.font.caption
-            wrapMode: Text.Wrap
-            Accessible.role: Accessible.StaticText
-            Accessible.name: text
-          }
-
-          PanelSeparator {
-            Layout.fillWidth: true
-            Layout.topMargin: Style.spacing.md
-            foreground: root.foreground
-          }
-
-          Text {
-            Layout.fillWidth: true
-            text: "Harness"
-            color: root.foreground
-            font.family: root.fontFamily
-            font.pixelSize: Style.font.subtitle
-            font.bold: true
-          }
-
-          Dropdown {
-            id: providerPicker
-            Layout.fillWidth: true
-            showLabel: false
-            options: root.modeProviders
-            value: root.backend ? root.backend.provider : ""
-            enabled: root.backend && !root.backend.busy
-            foreground: root.foreground
-            background: root.background
-            Accessible.name: "Agent harness"
-            onChanged: function(value) { root.providerChanged(value) }
-          }
-
-          Text {
-            Layout.fillWidth: true
-            text: "Model"
-            color: root.foreground
-            font.family: root.fontFamily
-            font.pixelSize: Style.font.subtitle
-            font.bold: true
-          }
-
-          Dropdown {
-            id: modelPicker
-            Layout.fillWidth: true
-            showLabel: false
-            options: root.backend && root.backend.modelOptions.length > 0
-              ? root.backend.modelOptions
-              : [{ value: "", label: "Harness default" }]
-            value: root.backend ? root.backend.model : ""
-            enabled: root.backend && !root.backend.busy
-            foreground: root.foreground
-            background: root.background
-            Accessible.name: "AI model"
-            onChanged: function(value) {
-              root.backend.model = value
-              root.modelChanged(root.backend.provider, value)
-            }
-          }
-
-          Text {
-            Layout.fillWidth: true
-            visible: root.backend
-            text: !root.backend ? "" : Protocol.providerPolicyDescription(root.backend.provider, root.backend.providerPolicy)
-            color: Qt.darker(root.foreground, 1.45)
-            font.family: root.fontFamily
-            font.pixelSize: Style.font.caption
-            wrapMode: Text.Wrap
-            Accessible.role: Accessible.StaticText
-            Accessible.name: text
-          }
-
-          Text {
-            Layout.fillWidth: true
-            visible: root.backend && root.backend.modelOptions.length === 0
-            text: "Using the harness default. This harness did not expose a model catalog."
-            color: Qt.darker(root.foreground, 1.45)
-            font.family: root.fontFamily
-            font.pixelSize: Style.font.caption
-            wrapMode: Text.Wrap
-            Accessible.role: Accessible.StaticText
-            Accessible.name: text
-          }
-
-          PanelSeparator {
-            Layout.fillWidth: true
-            Layout.topMargin: Style.spacing.md
-            foreground: root.foreground
-          }
-
-          Text {
-            Layout.fillWidth: true
-            text: "Quick actions"
-            color: root.foreground
-            font.family: root.fontFamily
-            font.pixelSize: Style.font.subtitle
-            font.bold: true
-          }
-
-          Text {
-            Layout.fillWidth: true
-            text: "Add, edit, remove, or reorder the prompts shown on an empty conversation."
-            color: Qt.darker(root.foreground, 1.45)
+            text: "Prompts shown on an empty conversation. Up to five."
+            color: root.mutedForeground
             font.family: root.fontFamily
             font.pixelSize: Style.font.caption
             wrapMode: Text.Wrap
@@ -1275,34 +1205,6 @@ Item {
             accent: root.accent
             fontFamily: root.fontFamily
             onActionsEdited: function(actions) { root.quickActionsEdited(actions) }
-          }
-
-          PanelSeparator {
-            Layout.fillWidth: true
-            Layout.topMargin: Style.spacing.md
-            foreground: root.foreground
-          }
-
-          Text {
-            Layout.fillWidth: true
-            text: "Conversation"
-            color: root.foreground
-            font.family: root.fontFamily
-            font.pixelSize: Style.font.subtitle
-            font.bold: true
-          }
-
-          Button {
-            Layout.fillWidth: true
-            iconText: "󰋚"
-            text: "Recent chats"
-            tooltipText: "Browse up to 30 completed answers"
-            foreground: root.foreground
-            background: root.background
-            bordered: true
-            focusable: true
-            Accessible.name: tooltipText
-            onClicked: root.recentChatsRequested()
           }
         }
       }

--- a/components/SettingsView.qml
+++ b/components/SettingsView.qml
@@ -139,7 +139,7 @@ Item {
     closePopups(false)
     // Confirmations and the add-action editor are tab-local. Leaving them
     // armed keeps modalInteractionActive true while their controls are gone,
-    // which swallows Ctrl+H / Ctrl+, and panel navigation.
+    // which swallows Ctrl+H and panel navigation.
     if (next !== "servers") serverRemoveConfirmId = ""
     if (next !== "desktop") browserRemoveConfirmation = false
     if (next !== "actions" && quickActionEditor.adding) quickActionEditor.cancelAdding()

--- a/components/StateLightBar.qml
+++ b/components/StateLightBar.qml
@@ -1,0 +1,143 @@
+import QtQuick
+import QtQuick.Effects
+import qs.Commons
+import "StateColor.js" as StateColor
+
+// A persistent state light for the panel.
+//
+// It is intentionally quieter than a progress indicator: the rail never
+// disappears, listening breathes slowly, thinking has a quicker tide, and
+// terminal answer/error states settle into their own colour. Nothing here
+// claims measurable progress or audio amplitude.
+Item {
+  id: root
+
+  // listening | thinking | answering | error
+  property string phase: "listening"
+  property color accent: Color.accent
+  property color urgent: Color.urgent
+  property bool motionEnabled: true
+
+  readonly property color lightColor: StateColor.forPhase(accent, urgent, phase)
+  property color displayedColor: lightColor
+  property real tide: 0.32
+  property real drift: 0
+  readonly property bool atmosphereActive: motionEnabled
+    && (phase === "listening" || phase === "thinking")
+  readonly property bool motionRunning: tideAnimation.running || driftAnimation.running
+
+  implicitHeight: Style.space(10)
+
+  function withAlpha(value) {
+    return Qt.rgba(displayedColor.r, displayedColor.g, displayedColor.b, value)
+  }
+
+  function settledTide() {
+    if (phase === "error") return 0.72
+    if (phase === "answering") return 0.52
+    return 0.32
+  }
+
+  function settleAtmosphere() {
+    if (!atmosphereActive) {
+      tide = settledTide()
+      drift = 0
+    }
+  }
+
+  Behavior on displayedColor {
+    enabled: root.motionEnabled
+    ColorAnimation { duration: 360; easing.type: Easing.OutCubic }
+  }
+
+  SequentialAnimation {
+    id: tideAnimation
+    running: root.atmosphereActive
+    loops: Animation.Infinite
+    NumberAnimation {
+      target: root; property: "tide"; to: 1
+      duration: root.phase === "thinking" ? 1050 : 2400
+      easing.type: Easing.InOutSine
+    }
+    NumberAnimation {
+      target: root; property: "tide"; to: 0.18
+      duration: root.phase === "thinking" ? 1350 : 3100
+      easing.type: Easing.InOutSine
+    }
+  }
+
+  SequentialAnimation {
+    id: driftAnimation
+    running: root.atmosphereActive
+    loops: Animation.Infinite
+    NumberAnimation {
+      target: root; property: "drift"; to: 1
+      duration: root.phase === "thinking" ? 1900 : 5200
+      easing.type: Easing.InOutSine
+    }
+    NumberAnimation {
+      target: root; property: "drift"; to: -1
+      duration: root.phase === "thinking" ? 2400 : 6400
+      easing.type: Easing.InOutSine
+    }
+  }
+
+  // A low, continuous rail keeps the state light legible even at the dimmest
+  // point of its breath and when motion is disabled.
+  Rectangle {
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.verticalCenter: parent.verticalCenter
+    height: 1
+    gradient: Gradient {
+      orientation: Gradient.Horizontal
+      GradientStop { position: 0.0; color: root.withAlpha(0.035) }
+      GradientStop { position: 0.18; color: root.withAlpha(0.10) }
+      GradientStop { position: 0.5; color: root.withAlpha(0.27 + root.tide * 0.15) }
+      GradientStop { position: 0.82; color: root.withAlpha(0.10) }
+      GradientStop { position: 1.0; color: root.withAlpha(0.035) }
+    }
+  }
+
+  // The wandering centre is rendered once, then bloomed. Keeping the movement
+  // inside a narrow central band makes it feel atmospheric rather than busy.
+  Item {
+    id: glowSource
+    anchors.fill: parent
+    visible: false
+
+    Rectangle {
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.verticalCenter: parent.verticalCenter
+      height: 1
+      gradient: Gradient {
+        orientation: Gradient.Horizontal
+        GradientStop { position: 0.0; color: "transparent" }
+        GradientStop { position: 0.42 + root.drift * 0.055; color: root.withAlpha(0.08) }
+        GradientStop { position: 0.50 + root.drift * 0.055; color: root.withAlpha(0.92) }
+        GradientStop { position: 0.58 + root.drift * 0.055; color: root.withAlpha(0.08) }
+        GradientStop { position: 1.0; color: "transparent" }
+      }
+    }
+  }
+
+  MultiEffect {
+    anchors.fill: glowSource
+    source: glowSource
+    autoPaddingEnabled: true
+    blurEnabled: true
+    blur: 0.75
+    blurMax: 18
+    blurMultiplier: 0.85
+    brightness: 0.28 + root.tide * 0.34
+    colorization: 1
+    colorizationColor: root.displayedColor
+    opacity: 0.42 + root.tide * 0.38
+  }
+
+  onPhaseChanged: settleAtmosphere()
+  onMotionEnabledChanged: settleAtmosphere()
+  onAtmosphereActiveChanged: settleAtmosphere()
+  Component.onCompleted: settleAtmosphere()
+}

--- a/components/VoiceNode.qml
+++ b/components/VoiceNode.qml
@@ -35,6 +35,23 @@ Item {
   // amplitude, so a VU meter would be a lie in pixels.
   property real level: 0
   property real presence: lit ? 1 : 0
+  // A second, much slower cycle keeps the active listening/thinking surface
+  // from feeling like a static lamp. It changes atmosphere only; it still
+  // makes no claim about audio.
+  property real tide: 0.35
+  // The brightest part of the full-width gradient wanders by only a few percent.
+  // That slight asymmetry is what keeps the edge from feeling mechanically looped.
+  property real drift: 0
+  readonly property bool atmosphereActive: motionEnabled
+    && (phase === "listening" || phase === "thinking")
+
+  function settleAtmosphere() {
+    if (!atmosphereActive) {
+      tide = 0.4
+      drift = 0
+    }
+    if (!motionEnabled) level = 0.5
+  }
 
   Behavior on presence {
     enabled: root.motionEnabled
@@ -47,17 +64,50 @@ Item {
     NumberAnimation { target: root; property: "level"; to: 1; duration: 820; easing.type: Easing.InOutSine }
     NumberAnimation { target: root; property: "level"; to: 0.34; duration: 980; easing.type: Easing.InOutSine }
   }
+  SequentialAnimation {
+    id: tideAnimation
+    running: root.atmosphereActive
+    loops: Animation.Infinite
+    NumberAnimation {
+      target: root; property: "tide"; to: 1
+      duration: root.phase === "thinking" ? 2700 : 3900
+      easing.type: Easing.InOutSine
+    }
+    NumberAnimation {
+      target: root; property: "tide"; to: 0.18
+      duration: root.phase === "thinking" ? 3400 : 4700
+      easing.type: Easing.InOutSine
+    }
+  }
+  SequentialAnimation {
+    id: driftAnimation
+    running: root.atmosphereActive
+    loops: Animation.Infinite
+    NumberAnimation {
+      target: root; property: "drift"; to: 1
+      duration: root.phase === "thinking" ? 4700 : 6300
+      easing.type: Easing.InOutSine
+    }
+    NumberAnimation {
+      target: root; property: "drift"; to: -1
+      duration: root.phase === "thinking" ? 5600 : 7100
+      easing.type: Easing.InOutSine
+    }
+  }
   // Thinking holds a low steady presence and lets the travelling filament carry
   // the motion, so listening and thinking never read as the same state.
   NumberAnimation {
-    running: root.phase !== "listening"
+    id: levelSettleAnimation
+    running: root.motionEnabled && root.lit && root.phase !== "listening"
     target: root
     property: "level"
     to: root.phase === "thinking" ? 0.42 : (root.phase === "error" ? 0.9 : 0.62)
     duration: 300
     easing.type: Easing.OutCubic
   }
-  onMotionEnabledChanged: if (!motionEnabled) level = 0.5
+  onPhaseChanged: settleAtmosphere()
+  onMotionEnabledChanged: settleAtmosphere()
+  onAtmosphereActiveChanged: settleAtmosphere()
 
   PanelWindow {
     id: surface
@@ -89,19 +139,25 @@ Item {
       }
     }
 
-    // The ember: a wide soft body of light sunk below the screen edge, so only
-    // its bloom reaches the desktop. Blur supplies both falloffs for free.
+    // The ember spans the complete output. Its transparent horizontal gradient
+    // keeps the corners quiet without leaving the lower screen visibly unlit;
+    // the body stays sunk below the edge so only its bloom reaches the desktop.
     Item {
       id: emberSource
       visible: false
-      width: parent.width * 0.82
+      anchors { left: parent.left; right: parent.right }
       height: Style.space(64)
-      anchors.horizontalCenter: parent.horizontalCenter
-      y: parent.height - Style.space(14)
+      y: parent.height - Style.space(14) - root.tide * Style.space(2)
       Rectangle {
         anchors.fill: parent
-        radius: height / 2
-        color: root.lightColor
+        gradient: Gradient {
+          orientation: Gradient.Horizontal
+          GradientStop { position: 0.0; color: Qt.rgba(root.lightColor.r, root.lightColor.g, root.lightColor.b, 0.10) }
+          GradientStop { position: 0.18 + root.drift * 0.025; color: Qt.rgba(root.lightColor.r, root.lightColor.g, root.lightColor.b, 0.48) }
+          GradientStop { position: 0.50 + root.drift * 0.055; color: root.lightColor }
+          GradientStop { position: 0.82 + root.drift * 0.025; color: Qt.rgba(root.lightColor.r, root.lightColor.g, root.lightColor.b, 0.48) }
+          GradientStop { position: 1.0; color: Qt.rgba(root.lightColor.r, root.lightColor.g, root.lightColor.b, 0.10) }
+        }
       }
     }
 
@@ -118,8 +174,8 @@ Item {
       brightness: 0.26
       colorization: 1
       colorizationColor: root.lightColor
-      opacity: root.presence * (0.34 + root.level * 0.28)
-      scale: 1 + root.level * 0.05
+      opacity: root.presence * (0.24 + root.level * 0.22 + root.tide * 0.06)
+      scale: 1 + root.level * 0.035 + root.tide * 0.018
       transformOrigin: Item.Bottom
     }
 
@@ -134,8 +190,8 @@ Item {
       brightness: 0.42
       colorization: 1
       colorizationColor: root.lightColor
-      opacity: root.presence * (0.18 + root.level * 0.18)
-      scale: 1 + root.level * 0.03
+      opacity: root.presence * (0.14 + root.level * 0.16 + root.tide * 0.04)
+      scale: 1 + root.level * 0.022 + root.tide * 0.012
       transformOrigin: Item.Bottom
     }
 

--- a/components/qmldir
+++ b/components/qmldir
@@ -16,4 +16,5 @@ SettingsTabs 1.0 SettingsTabs.qml
 VoiceNode 1.0 VoiceNode.qml
 AnswerCurtain 1.0 AnswerCurtain.qml
 ActivityFilament 1.0 ActivityFilament.qml
+StateLightBar 1.0 StateLightBar.qml
 VoiceWave 1.0 VoiceWave.qml

--- a/components/qmldir
+++ b/components/qmldir
@@ -12,6 +12,7 @@ QuickActions 1.0 QuickActions.qml
 QuickActionEditor 1.0 QuickActionEditor.qml
 ResponseActivityBorder 1.0 ResponseActivityBorder.qml
 SettingsView 1.0 SettingsView.qml
+SettingsTabs 1.0 SettingsTabs.qml
 VoiceNode 1.0 VoiceNode.qml
 AnswerCurtain 1.0 AnswerCurtain.qml
 ActivityFilament 1.0 ActivityFilament.qml

--- a/design/ambient-ux.md
+++ b/design/ambient-ux.md
@@ -159,9 +159,11 @@ bonus, never a requirement.
 
 One light source, one accent, no second palette.
 
-- **Ember** — a wide soft body of light sunk below the bottom edge so only its
-  bloom reaches the desktop. Built from two stacked blooms: a wide halo for
-  atmosphere and a tight core for definition. A single wide blur reads as fog.
+- **Ember** — a full-width transparent gradient sunk below the bottom edge so
+  only its bloom reaches the desktop. Its low-energy corners keep the complete
+  lower edge alive without drawing a visible bar. Two slow, incommensurate
+  cycles shift its breath and center slightly; neither represents microphone
+  amplitude. Two stacked blooms keep atmosphere and definition separate.
 - **Filament** — a hairline at the very edge that makes the glow read as
   deliberate rather than as a rendering artifact.
 - **Runner** — while thinking, one short bright segment sweeps the filament.

--- a/design/voice-node-mock.qml
+++ b/design/voice-node-mock.qml
@@ -82,6 +82,7 @@ ShellRoot {
   property string captionStyle: "plate"
   // Test harness only, never shipped: see the contrast probe in the node.
   property bool probeOn: false
+  property bool motionEnabled: true
   property string answer: ""
   // off | prompt | permission — the console's lane.
   property string console_: "off"
@@ -103,6 +104,8 @@ ShellRoot {
 
   readonly property bool nodeLit: phase !== "dormant"
   readonly property bool curtainUp: phase === "answering" || phase === "error"
+  onPhaseChanged: node.settleAtmosphere()
+  onMotionEnabledChanged: node.settleAtmosphere()
 
   // Auto-dismiss, scaled to how much there is to read rather than a flat
   // timeout — a fixed 8s eats a long answer mid-sentence. Roughly 240ms per
@@ -142,6 +145,10 @@ ShellRoot {
     }
     function answer(text: string): string { root.answer = text; return "ok" }
     function probe(value: string): string { root.probeOn = value === "on"; return root.probeOn ? "on" : "off" }
+    function motion(value: string): string {
+      root.motionEnabled = value !== "off"
+      return root.motionEnabled ? "on" : "off"
+    }
     function lane(value: string): string {
       if (["off", "prompt", "permission"].indexOf(value) === -1) return "unknown lane: " + value
       root.console_ = value
@@ -179,27 +186,53 @@ ShellRoot {
     // visualise one would be a lie in pixels.
     property real level: 0
     property real presence: root.nodeLit ? 1 : 0
+    property real tide: 0.35
+    property real drift: 0
+    readonly property bool atmosphereActive: root.motionEnabled
+      && (root.phase === "listening" || root.phase === "thinking")
+
+    function settleAtmosphere() {
+      if (!atmosphereActive) {
+        tide = 0.4
+        drift = 0
+      }
+      if (!root.motionEnabled) level = 0.5
+    }
 
     Behavior on presence {
+      enabled: root.motionEnabled
       NumberAnimation { duration: root.nodeLit ? 260 : 420; easing.type: Easing.OutCubic }
     }
 
     SequentialAnimation {
-      running: root.phase === "listening"
+      running: root.phase === "listening" && root.motionEnabled
       loops: Animation.Infinite
       NumberAnimation { target: node; property: "level"; to: 1; duration: 820; easing.type: Easing.InOutSine }
       NumberAnimation { target: node; property: "level"; to: 0.34; duration: 980; easing.type: Easing.InOutSine }
     }
+    SequentialAnimation {
+      running: node.atmosphereActive
+      loops: Animation.Infinite
+      NumberAnimation { target: node; property: "tide"; to: 1; duration: root.phase === "thinking" ? 2700 : 3900; easing.type: Easing.InOutSine }
+      NumberAnimation { target: node; property: "tide"; to: 0.18; duration: root.phase === "thinking" ? 3400 : 4700; easing.type: Easing.InOutSine }
+    }
+    SequentialAnimation {
+      running: node.atmosphereActive
+      loops: Animation.Infinite
+      NumberAnimation { target: node; property: "drift"; to: 1; duration: root.phase === "thinking" ? 4700 : 6300; easing.type: Easing.InOutSine }
+      NumberAnimation { target: node; property: "drift"; to: -1; duration: root.phase === "thinking" ? 5600 : 7100; easing.type: Easing.InOutSine }
+    }
     // Thinking holds a low, steady presence; the travelling filament carries
     // the motion instead, so the two states never read the same.
     NumberAnimation {
-      running: root.phase !== "listening"
+      running: root.motionEnabled && root.nodeLit && root.phase !== "listening"
       target: node
       property: "level"
       to: root.phase === "thinking" ? 0.42 : (root.phase === "error" ? 0.9 : 0.62)
       duration: 300
       easing.type: Easing.OutCubic
     }
+    onAtmosphereActiveChanged: settleAtmosphere()
 
     // ---- contrast probe. Not part of the design: a bright band drawn *under*
     // everything so caption legibility over a white browser can be judged
@@ -227,22 +260,26 @@ ShellRoot {
       }
     }
 
-    // ---- the ember: a wide, soft body of light sitting mostly below the
-    // screen edge, so only its bloom rises into the desktop. Blur gives the
-    // horizontal and vertical falloff for free; no gradient stack needed.
+    // ---- the ember: a transparent full-width body sitting mostly below the
+    // screen edge, so the complete lower edge stays alive without becoming a bar.
     Item {
       id: emberSource
       visible: false
-      width: parent.width * 0.54
-      height: 84
-      anchors.horizontalCenter: parent.horizontalCenter
+      anchors { left: parent.left; right: parent.right }
+      height: 64
       // Sink the body under the edge; only its top rim clears it, so what
       // reaches the desktop is bloom rather than the shape itself.
-      y: parent.height - 24
+      y: parent.height - 14 - node.tide * 2
       Rectangle {
         anchors.fill: parent
-        radius: height / 2
-        color: root.lightColor
+        gradient: Gradient {
+          orientation: Gradient.Horizontal
+          GradientStop { position: 0.0; color: Qt.rgba(root.lightColor.r, root.lightColor.g, root.lightColor.b, 0.10) }
+          GradientStop { position: 0.18 + node.drift * 0.025; color: Qt.rgba(root.lightColor.r, root.lightColor.g, root.lightColor.b, 0.48) }
+          GradientStop { position: 0.50 + node.drift * 0.055; color: root.lightColor }
+          GradientStop { position: 0.82 + node.drift * 0.025; color: Qt.rgba(root.lightColor.r, root.lightColor.g, root.lightColor.b, 0.48) }
+          GradientStop { position: 1.0; color: Qt.rgba(root.lightColor.r, root.lightColor.g, root.lightColor.b, 0.10) }
+        }
       }
     }
 
@@ -257,12 +294,12 @@ ShellRoot {
       blurEnabled: true
       blur: 1
       blurMax: 64
-      blurMultiplier: 2.6
-      brightness: 0.30
+      blurMultiplier: 3.2
+      brightness: 0.26
       colorization: 1
       colorizationColor: root.lightColor
-      opacity: node.presence * (0.30 + node.level * 0.26)
-      scale: 1 + node.level * 0.07
+      opacity: node.presence * (0.24 + node.level * 0.22 + node.tide * 0.06)
+      scale: 1 + node.level * 0.035 + node.tide * 0.018
       transformOrigin: Item.Bottom
     }
 
@@ -273,13 +310,13 @@ ShellRoot {
       autoPaddingEnabled: true
       blurEnabled: true
       blur: 1
-      blurMax: 32
-      blurMultiplier: 0.85
-      brightness: 0.55
+      blurMax: 44
+      blurMultiplier: 1.5
+      brightness: 0.42
       colorization: 1
       colorizationColor: root.lightColor
-      opacity: node.presence * (0.26 + node.level * 0.22)
-      scale: 1 + node.level * 0.03
+      opacity: node.presence * (0.14 + node.level * 0.16 + node.tide * 0.04)
+      scale: 1 + node.level * 0.022 + node.tide * 0.012
       transformOrigin: Item.Bottom
     }
 

--- a/tests/check-ui-contract.sh
+++ b/tests/check-ui-contract.sh
@@ -27,6 +27,8 @@ qml_files=(
   "$repo_dir/components/QuickActions.qml"
   "$repo_dir/components/QuickActionEditor.qml"
   "$repo_dir/components/SettingsView.qml"
+  "$repo_dir/components/SettingsTabs.qml"
+  "$repo_dir/components/ActivityFilament.qml"
   "$repo_dir/components/ResponseActivityBorder.qml"
   "$repo_dir/components/internal/PermissionFocusGuard.qml"
   "$repo_dir/components/internal/PanelKeyboardNavigation.qml"
@@ -172,7 +174,10 @@ grep -Fq 'modalInteractionActive: root.modalInteractionActive' \
 grep -Fq 'Accessible.name: tooltipText' "$repo_dir/components/QuickActions.qml"
 grep -Fq 'quickActionsJson' "$repo_dir/Panel.qml"
 grep -Fq 'onQuickActionsEdited:' "$repo_dir/Panel.qml"
-grep -Fq 'text: "OmaPilot settings"' "$repo_dir/components/SettingsView.qml"
+grep -Fq 'Accessible.name: "OmaPilot settings"' "$repo_dir/components/SettingsView.qml"
+grep -Fq 'SettingsTabs {' "$repo_dir/components/SettingsView.qml"
+grep -Fq 'property string selectedTab: "agent"' "$repo_dir/components/SettingsView.qml"
+grep -Fq '{ id: "agent", label: "Agent" }' "$repo_dir/components/Presentation.js"
 grep -Fq 'QuickActionEditor {' "$repo_dir/components/SettingsView.qml"
 grep -Fq 'maximumActions = 5' "$repo_dir/components/QuickActions.js"
 grep -Fq 'function moveAction(actions, index, delta)' "$repo_dir/components/QuickActions.js"
@@ -180,7 +185,11 @@ grep -Fq 'function removeAction(actions, index)' "$repo_dir/components/QuickActi
 grep -Fq 'ActionCatalog.addAction(' "$repo_dir/components/QuickActionEditor.qml"
 grep -Fq 'ActionCatalog.updateAction(' "$repo_dir/components/QuickActionEditor.qml"
 grep -Fq 'label: "Dangerous auto-approve"' "$repo_dir/components/SettingsView.qml"
+grep -Fq 'label: "Desktop context"' "$repo_dir/components/SettingsView.qml"
 grep -Fq 'text: "Browser context"' "$repo_dir/components/SettingsView.qml"
+grep -Fq 'onDesktopContextRequested:' "$repo_dir/Panel.qml"
+grep -Fq 'text: "History"' "$repo_dir/components/HistoryView.qml"
+grep -Fq 'ActivityFilament {' "$repo_dir/components/HistoryView.qml"
 grep -Fq 'text: root.browserCompanion.relayInstalled === true ? "Repair browser setup" : "Enable browser context"' \
   "$repo_dir/components/SettingsView.qml"
 grep -Fq 'onBrowserCompanionInstallRequested:' "$repo_dir/Panel.qml"
@@ -486,7 +495,7 @@ if grep -Eq "visual preview failed|Failed to load|Type .* unavailable|Cannot ass
   exit 1
 fi
 
-for preview_state in actions-settings waiting streaming error error-details context; do
+for preview_state in settings actions-settings history waiting streaming error error-details context; do
   preview_output="$repo_dir/screenshots/implementation-omapilot-$preview_state.png"
   OMAPILOT_PREVIEW_STATE="$preview_state" OMAPILOT_PREVIEW_PATH="$preview_output" \
     QT_QPA_PLATFORM=offscreen timeout 5s quickshell --no-duplicate \

--- a/tests/check-ui-contract.sh
+++ b/tests/check-ui-contract.sh
@@ -151,6 +151,14 @@ grep -Fq 'running: root.atmosphereActive' "$repo_dir/components/StateLightBar.qm
 grep -Fq 'StateColor.forPhase' "$repo_dir/components/StateLightBar.qml"
 grep -Fq 'colorizationColor: root.displayedColor' "$repo_dir/components/StateLightBar.qml"
 grep -Fq 'id: promptRow' "$repo_dir/components/Composer.qml"
+grep -Fq 'iconText: "󰹑"' "$repo_dir/components/Composer.qml"
+grep -Fq '󰍬' "$repo_dir/components/Composer.qml"
+if grep -Fq 'Active window, open apps, workspaces, and playing media' \
+    "$repo_dir/components/Composer.qml"; then
+  printf 'Desktop context disclosure must be the hostname, not a capability list\n' >&2
+  exit 1
+fi
+grep -Fq 'Protocol.providerShortLabel(Quickchat.QuickchatStore.provider)' "$repo_dir/Panel.qml"
 grep -Fq 'font.pixelSize: Style.font.heading' "$repo_dir/components/Composer.qml"
 grep -Fq 'sequences: ["Ctrl+H"]' "$repo_dir/Panel.qml"
 grep -Fq '{ label: "Super+Alt+P settings", lane: "settings" }' "$repo_dir/Panel.qml"

--- a/tests/check-ui-contract.sh
+++ b/tests/check-ui-contract.sh
@@ -28,6 +28,7 @@ qml_files=(
   "$repo_dir/components/QuickActionEditor.qml"
   "$repo_dir/components/SettingsView.qml"
   "$repo_dir/components/SettingsTabs.qml"
+  "$repo_dir/components/StateLightBar.qml"
   "$repo_dir/components/ActivityFilament.qml"
   "$repo_dir/components/ResponseActivityBorder.qml"
   "$repo_dir/components/internal/PermissionFocusGuard.qml"
@@ -128,18 +129,39 @@ grep -Fq 'visible: root.viewMode === "settings"' "$repo_dir/Panel.qml"
 grep -Fq 'settingsView.popupOpen' "$repo_dir/Panel.qml"
 # The ambient redesign removed the panel header (logo, tagline, gear). The
 # chrome assertions below pin the replacement instead: a borderless hero prompt,
-# the shared activity filament, and the single hint row that now carries
-# provider identity, permission posture, and the lane shortcuts. Settings and
-# history lost their buttons, so their keys must exist or they are unreachable.
+# one answer seam, and a hint row carrying provider identity, permission posture,
+# the desktop-global settings binding, and focused-panel history navigation.
 if grep -Fq 'Quickchat.OmaPilotHeader {' "$repo_dir/Panel.qml"; then
   printf 'Panel must not reintroduce the OmaPilot header chrome\n' >&2
   exit 1
 fi
-grep -Fq 'ActivityFilament {' "$repo_dir/components/Composer.qml"
+if grep -Fq 'ActivityFilament {' "$repo_dir/components/Composer.qml"; then
+  printf 'The composer must not draw a second rule above the answer seam\n' >&2
+  exit 1
+fi
+grep -Fq 'Quickchat.StateLightBar {' "$repo_dir/Panel.qml"
+grep -Fq 'Layout.minimumHeight: contentVisible ? Style.space(120) : stateLightBar.implicitHeight' \
+  "$repo_dir/Panel.qml"
+grep -Fq 'visible: answerCard.contentVisible' "$repo_dir/Panel.qml"
+grep -Fq 'readonly property bool atmosphereActive: motionEnabled' \
+  "$repo_dir/components/StateLightBar.qml"
+grep -Fq '&& (phase === "listening" || phase === "thinking")' \
+  "$repo_dir/components/StateLightBar.qml"
+grep -Fq 'running: root.atmosphereActive' "$repo_dir/components/StateLightBar.qml"
+grep -Fq 'StateColor.forPhase' "$repo_dir/components/StateLightBar.qml"
+grep -Fq 'colorizationColor: root.displayedColor' "$repo_dir/components/StateLightBar.qml"
 grep -Fq 'id: promptRow' "$repo_dir/components/Composer.qml"
 grep -Fq 'font.pixelSize: Style.font.heading' "$repo_dir/components/Composer.qml"
 grep -Fq 'sequences: ["Ctrl+H"]' "$repo_dir/Panel.qml"
-grep -Fq 'sequences: ["Ctrl+,"]' "$repo_dir/Panel.qml"
+grep -Fq '{ label: "Super+Alt+P settings", lane: "settings" }' "$repo_dir/Panel.qml"
+if grep -Fq 'Ctrl+,' "$repo_dir/Panel.qml" "$repo_dir/components/Composer.qml"; then
+  printf 'Settings must use only the desktop-global Super+Alt+P binding\n' >&2
+  exit 1
+fi
+if grep -Fq 'id: caret' "$repo_dir/components/Composer.qml"; then
+  printf 'Prompt text must share the content left edge without a decorative caret\n' >&2
+  exit 1
+fi
 grep -Fq 'Presentation.permissionNotice(root.dangerousAutoApprove)' "$repo_dir/Panel.qml"
 grep -Fq 'text: "OmaPilot"' "$repo_dir/components/OmaPilotHeader.qml"
 grep -Fq 'source: Qt.resolvedUrl("../assets/omapilot-mark.png")' \
@@ -224,9 +246,9 @@ grep -Fq 'property bool followLatest: true' "$repo_dir/Panel.qml"
 grep -Fq 'onMovementEnded: followLatest = Presentation.isNearBottom(' "$repo_dir/Panel.qml"
 grep -Fq 'tooltipText: "Jump to the newest response"' "$repo_dir/Panel.qml"
 # The perimeter runner circled the answer card's border. The redesign removed
-# that border, so the activity signal moved to the composer's filament. The
-# component itself is retained for its motion probe and preview fixtures, but
-# the panel must not put a runner back around the response.
+# that border, so state now lives in the persistent answer seam. The old
+# component remains for its motion probe and preview fixtures, but the panel
+# must not put a runner back around the response.
 if grep -Fq 'Quickchat.ResponseActivityBorder {' "$repo_dir/Panel.qml"; then
   printf 'Panel must not reintroduce the response perimeter runner\n' >&2
   exit 1
@@ -234,8 +256,14 @@ fi
 grep -Fq 'id: sweepSource' "$repo_dir/components/ActivityFilament.qml"
 # Every state must resolve through one mapping rather than hardcoding accent.
 grep -Fq 'StateColor.forPhase' "$repo_dir/components/VoiceNode.qml"
+grep -Fq 'anchors { left: parent.left; right: parent.right }' "$repo_dir/components/VoiceNode.qml"
+grep -Fq 'property real tide: 0.35' "$repo_dir/components/VoiceNode.qml"
+grep -Fq 'property real drift: 0' "$repo_dir/components/VoiceNode.qml"
+grep -Fq 'readonly property bool atmosphereActive: motionEnabled' "$repo_dir/components/VoiceNode.qml"
+grep -Fq 'running: root.atmosphereActive' "$repo_dir/components/VoiceNode.qml"
+grep -Fq 'running: root.motionEnabled && root.lit && root.phase !== "listening"' "$repo_dir/components/VoiceNode.qml"
+grep -Fq '0.50 + root.drift * 0.055' "$repo_dir/components/VoiceNode.qml"
 grep -Fq 'StateColor.forPhase' "$repo_dir/components/AnswerCurtain.qml"
-grep -Fq 'StateColor.forPhase' "$repo_dir/Panel.qml"
 grep -Fq 'colorizationColor: root.accent' "$repo_dir/components/ActivityFilament.qml"
 grep -Fq 'id: responseStatusSlot' "$repo_dir/Panel.qml"
 grep -Fq 'Layout.minimumWidth: Style.space(140)' "$repo_dir/Panel.qml"
@@ -268,11 +296,9 @@ if grep -Eq 'responseActivityCore|id: runnerCore|coreSpan' \
   printf 'OmaPilot perimeter motion must render as one blur without a crisp core\n' >&2
   exit 1
 fi
-# Same invariant as before the redesign, on the filament instead of the
-# perimeter runner: response motion is gated on the panel actually being open,
-# so nothing animates off screen.
-grep -Fq 'activityActive: root.responseActivityActive && root.opened' "$repo_dir/Panel.qml"
-grep -Fq 'active: root.activityActive' "$repo_dir/components/Composer.qml"
+# The persistent state light is panel-gated, so its atmosphere stops as soon as
+# the panel closes instead of animating off screen.
+grep -Fq 'motionEnabled: root.motionEnabled && root.opened' "$repo_dir/Panel.qml"
 grep -Fq 'id: activityStatus' "$repo_dir/Panel.qml"
 if grep -Eq 'WaitingIndicator|signalClock|FrameAnimation|onTriggered:' \
     "$repo_dir/Panel.qml" "$repo_dir/components/ResponseActivityBorder.qml"; then
@@ -448,6 +474,33 @@ fi
 if grep -Eq "omapilot motion probe failed|Failed to load|Type .* unavailable|Cannot assign|TypeError" \
     "$smoke_root/motion.log" || ! grep -Fq 'OMAPILOT_MOTION_PROBE_OK' "$smoke_root/motion.log"; then
   cat "$smoke_root/motion.log"
+  exit 1
+fi
+
+cp "$repo_dir/tests/voice-node-lifecycle-probe.qml" "$smoke_root/shell.qml"
+if ! QT_QPA_PLATFORM=wayland timeout 5s quickshell --no-duplicate \
+    --path "$smoke_root" --no-color >"$smoke_root/voice-node-lifecycle.log" 2>&1; then
+  cat "$smoke_root/voice-node-lifecycle.log"
+  exit 1
+fi
+if grep -Eq "omapilot voice node lifecycle probe failed|Failed to load|Type .* unavailable|Cannot assign|TypeError" \
+    "$smoke_root/voice-node-lifecycle.log" \
+    || ! grep -Fq 'OMAPILOT_VOICE_NODE_LIFECYCLE_PROBE_OK' "$smoke_root/voice-node-lifecycle.log"; then
+  cat "$smoke_root/voice-node-lifecycle.log"
+  exit 1
+fi
+
+cp "$repo_dir/tests/state-light-bar-lifecycle-probe.qml" "$smoke_root/shell.qml"
+if ! QT_QPA_PLATFORM=offscreen timeout 5s quickshell --no-duplicate \
+    --path "$smoke_root" --no-color >"$smoke_root/state-light-bar-lifecycle.log" 2>&1; then
+  cat "$smoke_root/state-light-bar-lifecycle.log"
+  exit 1
+fi
+if grep -Eq "omapilot state light bar lifecycle probe failed|Failed to load|Type .* unavailable|Cannot assign|TypeError" \
+    "$smoke_root/state-light-bar-lifecycle.log" \
+    || ! grep -Fq 'OMAPILOT_STATE_LIGHT_BAR_LIFECYCLE_PROBE_OK' \
+      "$smoke_root/state-light-bar-lifecycle.log"; then
+  cat "$smoke_root/state-light-bar-lifecycle.log"
   exit 1
 fi
 

--- a/tests/settings-server-save-probe.qml
+++ b/tests/settings-server-save-probe.qml
@@ -104,6 +104,14 @@ ShellRoot {
         if (view.serverTestModels.length !== 1 || view.serverTestUrl !== "https://keyed.example/v1"
             || Number(view.serverTestModels[0].contextWindow || 0) !== 262144)
           root.fail("clearing a replacement key did not restore the existing credential path")
+        view.serverRemoveConfirmId = "keyed-server"
+        view.browserRemoveConfirmation = true
+        view.selectTab("agent")
+      } else if (root.stage === 5) {
+        if (view.selectedTab !== "agent"
+            || view.serverRemoveConfirmId !== ""
+            || view.browserRemoveConfirmation)
+          root.fail("switching tabs left a hidden confirmation armed")
         if (!root.failed) console.log("OMAPILOT_SERVER_SAVE_PROBE_OK")
         probeTimer.stop()
         Qt.quit()

--- a/tests/state-light-bar-lifecycle-probe.qml
+++ b/tests/state-light-bar-lifecycle-probe.qml
@@ -1,0 +1,61 @@
+import QtQuick
+import Quickshell
+import "components" as OmaPilot
+
+ShellRoot {
+  id: root
+  property bool failed: false
+  property int stage: 0
+  property real frozenTide: 0
+  property real frozenDrift: 0
+
+  function fail(message) {
+    failed = true
+    console.error("omapilot state light bar lifecycle probe failed: " + message)
+  }
+
+  OmaPilot.StateLightBar {
+    id: bar
+    width: 520
+    phase: "listening"
+    motionEnabled: true
+  }
+
+  Timer {
+    id: probeTimer
+    interval: 220
+    running: true
+    repeat: true
+    onTriggered: {
+      if (root.stage === 0) {
+        if (!bar.visible || !bar.atmosphereActive || !bar.motionRunning)
+          root.fail("listening state was not visible and animated")
+        root.frozenTide = bar.tide
+        bar.phase = "thinking"
+      } else if (root.stage === 1) {
+        if (!bar.atmosphereActive || !bar.motionRunning || bar.tide === root.frozenTide)
+          root.fail("thinking state did not continue the atmosphere")
+        bar.phase = "answering"
+      } else if (root.stage === 2) {
+        if (bar.atmosphereActive || bar.motionRunning || bar.tide !== 0.52 || bar.drift !== 0)
+          root.fail("answering state did not settle")
+        bar.phase = "error"
+      } else if (root.stage === 3) {
+        if (bar.atmosphereActive || bar.motionRunning || bar.tide !== 0.72 || bar.drift !== 0)
+          root.fail("error state did not settle")
+        bar.motionEnabled = false
+        bar.phase = "thinking"
+        root.frozenTide = bar.tide
+        root.frozenDrift = bar.drift
+      } else if (root.stage === 4) {
+        if (bar.atmosphereActive || bar.motionRunning
+            || bar.tide !== root.frozenTide || bar.drift !== root.frozenDrift)
+          root.fail("reduced motion allowed atmosphere values to change")
+        if (!root.failed) console.log("OMAPILOT_STATE_LIGHT_BAR_LIFECYCLE_PROBE_OK")
+        probeTimer.stop()
+        Qt.quit()
+      }
+      root.stage += 1
+    }
+  }
+}

--- a/tests/tst_presentation.qml
+++ b/tests/tst_presentation.qml
@@ -13,9 +13,9 @@ TestCase {
   }
 
   function test_responseViewportHasIndependentBounds() {
-    compare(Presentation.responseViewportHeight(20, 88, 420), 88)
-    compare(Presentation.responseViewportHeight(240, 88, 420), 240)
-    compare(Presentation.responseViewportHeight(900, 88, 420), 420)
+    compare(Presentation.responseViewportHeight(20, 48, 420), 48)
+    compare(Presentation.responseViewportHeight(240, 48, 420), 240)
+    compare(Presentation.responseViewportHeight(900, 48, 420), 420)
   }
 
   function test_streamFollowOnlyWhenReaderIsNearBottom() {

--- a/tests/tst_presentation.qml
+++ b/tests/tst_presentation.qml
@@ -52,4 +52,14 @@ TestCase {
     compare(Presentation.escapeAction("chat", false, false, false, true), "cancel")
     compare(Presentation.escapeAction("chat", false, false, false, false), "close-panel")
   }
+
+  function test_settingsTabsAreAClosedLaneSet() {
+    compare(Presentation.settingsTabIds().join(","), "agent,servers,desktop,actions")
+    compare(Presentation.normalizedSettingsTab("desktop"), "desktop")
+    compare(Presentation.normalizedSettingsTab("missing"), "agent")
+    compare(Presentation.adjacentSettingsTab("agent", -1), "agent")
+    compare(Presentation.adjacentSettingsTab("agent", 1), "servers")
+    compare(Presentation.adjacentSettingsTab("actions", 1), "actions")
+    compare(Presentation.adjacentSettingsTab("", 2), "desktop")
+  }
 }

--- a/tests/tst_protocol.qml
+++ b/tests/tst_protocol.qml
@@ -181,6 +181,9 @@ TestCase {
     compare(options[2].value, "opencode")
     // Claude is no longer a selectable harness.
     verify(Protocol.normalizedProvider("claude") === "")
+    compare(Protocol.providerShortLabel("builtin"), "OmaPilot")
+    compare(Protocol.providerShortLabel("codex"), "Codex")
+    compare(Protocol.providerShortLabel("opencode"), "OpenCode")
   }
 
   function test_providerDiscoveryRequiresExactlyTheConfiguredHarness() {

--- a/tests/visual-preview.qml
+++ b/tests/visual-preview.qml
@@ -65,6 +65,14 @@ ShellRoot {
     property var customProviders: []
     property var customProviderSaved: null
     property string customProviderError: ""
+    property var voxtypeOsd: ({ available: true, enabled: true, message: "" })
+    property var browserCompanionStatus: ({
+      phase: "ready", relayInstalled: false, setupAvailable: true,
+      chromiumConnected: false, firefoxConnected: false,
+      chromiumExtensionPath: "", firefoxExtensionPath: "", message: ""
+    })
+    property bool browserCompanionConnected: false
+    property bool browserCompanionBusy: false
     property var builtinAuth: ({ phase: "idle", flowId: "", methodId: "", message: "",
       url: "", verificationUri: "", userCode: "", prompt: null })
     property bool builtinAuthBusy: false
@@ -104,7 +112,7 @@ ShellRoot {
     id: previewWindow
     width: 860
     height: root.previewState === "settings" || root.previewState === "dangerous-settings"
-      || root.previewState === "actions-settings" ? 760
+      || root.previewState === "actions-settings" || root.previewState === "history" ? 760
       : (root.previewState === "error-details" ? 520 : (root.previewState === "context" ? 430 : 320))
     visible: true
     color: "transparent"
@@ -170,11 +178,36 @@ ShellRoot {
         anchors.topMargin: previewSurface.contentTopInset + Style.spacing.popupPadding
         anchors.bottomMargin: previewSurface.contentBottomInset + Style.spacing.popupPadding
         backend: backend
+        selectedTab: root.previewState === "dangerous-settings" ? "desktop"
+          : (root.previewState === "actions-settings" ? "actions" : "agent")
         dangerousAutoApprove: root.previewState === "dangerous-settings"
+        desktopContextEnabled: true
         quickActions: root.previewState === "actions-settings"
           ? ActionCatalog.addAction(ActionCatalog.defaultActions(true, true),
             "Research this", "Research this topic using current sources.", 42)
           : ActionCatalog.defaultActions(true, true)
+        foreground: Color.popups.text
+        background: Color.popups.background
+        accent: Color.accent
+        fontFamily: Style.font.family
+      }
+
+      OmaPilot.HistoryView {
+        id: historyView
+        visible: root.previewState === "history"
+        anchors.fill: parent
+        anchors.leftMargin: previewSurface.contentLeftInset + Style.spacing.popupPadding
+        anchors.rightMargin: previewSurface.contentRightInset + Style.spacing.popupPadding
+        anchors.topMargin: previewSurface.contentTopInset + Style.spacing.popupPadding
+        anchors.bottomMargin: previewSurface.contentBottomInset + Style.spacing.popupPadding
+        history: [
+          { id: "chat-1", title: "Summarize the current window", provider: "builtin",
+            model: "gpt-5.4", timestamp: "Today 14:03" },
+          { id: "chat-2", title: "Draft a reply to this thread", provider: "codex",
+            model: "gpt-5.4", timestamp: "Today 11:40" },
+          { id: "chat-3", title: "What is playing, and should I skip it?", provider: "opencode",
+            model: "", timestamp: "Yesterday 19:12" }
+        ]
         foreground: Color.popups.text
         background: Color.popups.background
         accent: Color.accent
@@ -300,12 +333,13 @@ ShellRoot {
           || root.previewState === "dangerous-settings"
           || root.previewState === "actions-settings")
         && settingsView.implicitHeight <= 0
+      var invalidHistory = root.previewState === "history" && historyView.width <= 0
       var invalidResponse = (root.previewState === "waiting"
           || root.previewState === "streaming" || root.previewState === "error")
         && responsePreview.implicitHeight <= 0
       var invalidErrorDetails = root.previewState === "error-details"
         && errorDetailsView.implicitHeight <= 0
-      if (invalidMain || invalidSettings || invalidResponse || invalidErrorDetails) {
+      if (invalidMain || invalidSettings || invalidHistory || invalidResponse || invalidErrorDetails) {
         console.error("omapilot visual preview failed: invalid component geometry")
         Qt.quit()
         return

--- a/tests/voice-node-lifecycle-probe.qml
+++ b/tests/voice-node-lifecycle-probe.qml
@@ -1,0 +1,61 @@
+import QtQuick
+import Quickshell
+import "components" as OmaPilot
+
+ShellRoot {
+  id: root
+  property bool failed: false
+  property int stage: 0
+  property real frozenLevel: 0
+  property real frozenTide: 0
+  property real frozenDrift: 0
+
+  function fail(message) {
+    failed = true
+    console.error("omapilot voice node lifecycle probe failed: " + message)
+  }
+
+  OmaPilot.VoiceNode {
+    id: node
+    targetScreen: Quickshell.screens.length > 0 ? Quickshell.screens[0] : null
+    phase: "dormant"
+    motionEnabled: false
+  }
+
+  Timer {
+    id: probeTimer
+    interval: 180
+    running: true
+    repeat: true
+    onTriggered: {
+      if (root.stage === 0) {
+        node.phase = "listening"
+        root.frozenLevel = node.level
+        root.frozenTide = node.tide
+        root.frozenDrift = node.drift
+      } else if (root.stage === 1) {
+        if (node.level !== root.frozenLevel || node.tide !== root.frozenTide
+            || node.drift !== root.frozenDrift)
+          root.fail("reduced motion changed atmosphere values while listening")
+        node.phase = "thinking"
+      } else if (root.stage === 2) {
+        if (node.level !== root.frozenLevel || node.tide !== root.frozenTide
+            || node.drift !== root.frozenDrift)
+          root.fail("reduced motion changed atmosphere values across phases")
+        node.motionEnabled = true
+        node.phase = "thinking"
+      } else if (root.stage === 3) {
+        if (!node.atmosphereActive || node.tide === 0.4)
+          root.fail("active thinking atmosphere did not start")
+        node.phase = "error"
+      } else if (root.stage === 4) {
+        if (node.atmosphereActive || node.tide !== 0.4 || node.drift !== 0)
+          root.fail("terminal phase left the atmosphere cycle active")
+        if (!root.failed) console.log("OMAPILOT_VOICE_NODE_LIFECYCLE_PROBE_OK")
+        probeTimer.stop()
+        Qt.quit()
+      }
+      root.stage += 1
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- replace the long scrolling settings form with Agent, Servers, Desktop, and Actions tabs
- keep the existing auth, custom-server, browser, Voxtype, and quick-action flows, with less copy and no wrapping card
- match the composer filament language in settings/history, and restyle history as an unboxed list
- expose desktop context as a Desktop-tab toggle
- fold in the full-width panel state light: one persistent answer seam replaces the composer filament and the old hairline
- drop the decorative prompt caret so request text shares the content left edge
- give the voice node a full-width bottom glow with a slow tide/drift atmosphere

## Validation
- `./tests/check-ui-contract.sh` passed, including the server-save probe, state-light-bar lifecycle probe, voice-node lifecycle probe, and visual previews for Agent, Desktop, Actions, and History
- presentation tests cover the closed tab set and the tighter response viewport
- installed locally from this worktree