### PR TITLE
Make Super+A voice sessions contextual

### DIFF
--- a/Ambient.qml
+++ b/Ambient.qml
@@ -4,6 +4,7 @@ import Quickshell.Hyprland
 import Quickshell.Io
 import qs.Commons
 import "components" as OmaPilot
+import "components/SessionLifecycle.js" as SessionLifecycle
 
 // OmaPilot's ambient overlay root.
 //
@@ -107,10 +108,13 @@ Item {
     }
   }
 
-  // True from the moment a voice turn is armed until its answer is dismissed.
-  // Without this the node would light up for panel-initiated turns too, which
-  // would make the ambient layer noisy rather than intentional.
+  // Presentation and conversation lifetime are deliberately separate. A failed
+  // launch still engages the node long enough to explain itself, but it has not
+  // opened a voice conversation. Once a launch succeeds, that conversation stays
+  // active until the ambient flow is dismissed; the next closed-to-open gesture
+  // then starts fresh instead of reviving an invisible prior chat.
   property bool voiceEngaged: false
+  property bool voiceSessionActive: false
 
   readonly property bool curtainShown:
     voiceEngaged && (failed || hasAnswer)
@@ -192,6 +196,8 @@ Item {
       return "busy"
     }
 
+    voiceSessionActive = true
+
     // A fresh voice gesture supersedes presentation of an in-flight Herdr
     // handoff. The external handoff may still finish, but its tagged outcome is
     // ignored once newChat clears pendingHerdrChatId.
@@ -207,7 +213,9 @@ Item {
       // clears busy asynchronously, so arm the start and let the state change
       // below run it once the previous turn has unwound.
       voiceStartPending = true
-      freshVoiceStartPending = freshChat
+      // Once any gesture has requested a fresh session, later taps during the
+      // same cancellation window must not downgrade it back to continuation.
+      freshVoiceStartPending = freshVoiceStartPending || freshChat
       OmaPilot.QuickchatStore.cancel()
       return "preempting"
     }
@@ -222,7 +230,7 @@ Item {
     return "listening"
   }
 
-  function voiceStart() { return beginVoiceChat(false) }
+  function voiceStart() { return beginVoiceChat(!voiceSessionActive) }
 
   function newVoiceChat() { return beginVoiceChat(true) }
 
@@ -238,11 +246,13 @@ Item {
   // twice. `voiceStart`/`voiceStop` remain separately bindable for anyone who
   // prefers true push-to-talk.
   function voiceToggle() {
-    if (OmaPilot.QuickchatStore.state === "dictating") {
+    var activation = SessionLifecycle.voiceActivationMode(
+      voiceSessionActive, OmaPilot.QuickchatStore.state)
+    if (activation === "finish") {
       OmaPilot.QuickchatStore.stopDictation()
       return "finishing"
     }
-    return voiceStart()
+    return beginVoiceChat(activation === "fresh")
   }
 
   function voiceCancel() {
@@ -261,6 +271,7 @@ Item {
     // which is the one failure mode an invisible ambient layer must never have.
     if (OmaPilot.QuickchatStore.state === "dictating")
       OmaPilot.QuickchatStore.cancel()
+    voiceSessionActive = false
     voiceEngaged = false
     OmaPilot.QuickchatStore.clearDesktopContextLatch()
   }
@@ -337,8 +348,9 @@ Item {
   // ------------------------------------------------------------------- IPC
   // The voice gesture cannot be a surface keybinding, because the ambient
   // surfaces never take keyboard focus by design. It has to arrive over IPC from
-  // a compositor binding. Keep current-chat and fresh-chat gestures as separate
-  // methods so their continuation behavior is explicit at that boundary.
+  // a compositor binding. The default gesture derives fresh-versus-continue
+  // from the ambient session lease; `newVoiceChat` remains an explicit force-new
+  // escape hatch while that lease is still active.
   IpcHandler {
     target: "io.github.spencerbull.omapilot"
     function voiceStart(): string {
@@ -359,6 +371,7 @@ Item {
     function status(): string {
       return "phase=" + root.phase
         + " store=" + root.storeState
+        + " session=" + (root.voiceSessionActive ? "active" : "closed")
         + " screen=" + (root.activeScreen ? root.activeScreen.name : "none")
         + " dismissMs=" + root.dismissDelay
     }

--- a/Ambient.qml
+++ b/Ambient.qml
@@ -146,11 +146,21 @@ Item {
   // starts recording. A fresh-chat hotkey can arrive while a turn or dictation
   // is still unwinding, so the reset has to wait for the broker to settle.
   property bool freshVoiceStartPending: false
+  // QuickchatStore.newChat() synchronously publishes its composing state. Keep
+  // that intentional reset distinct from an empty completed dictation, which
+  // the normal state handler dismisses as a silence-only voice turn.
+  property bool freshChatResetInProgress: false
   // Why the node is lit in its error state, shown as the caption.
   property string voiceNotice: ""
   // True after this voice turn's answer has been spoken, so the curtain can
   // linger briefly instead of waiting out a reading-time guess.
   property bool answerSpoken: false
+
+  function resetFreshVoiceChat() {
+    freshChatResetInProgress = true
+    OmaPilot.QuickchatStore.newChat()
+    freshChatResetInProgress = false
+  }
 
   function beginVoiceChat(freshChat) {
     // A voice hotkey must always produce visible feedback. The first version
@@ -202,7 +212,7 @@ Item {
     // handoff. The external handoff may still finish, but its tagged outcome is
     // ignored once newChat clears pendingHerdrChatId.
     if (freshChat && OmaPilot.QuickchatStore.pendingHerdrChatId !== "") {
-      OmaPilot.QuickchatStore.newChat()
+      resetFreshVoiceChat()
       freshChatReset = true
     }
 
@@ -220,7 +230,7 @@ Item {
       return "preempting"
     }
 
-    if (freshChat && !freshChatReset) OmaPilot.QuickchatStore.newChat()
+    if (freshChat && !freshChatReset) resetFreshVoiceChat()
 
     if (!OmaPilot.QuickchatStore.startDictation()) {
       voiceNotice = OmaPilot.QuickchatStore.statusMessage !== ""
@@ -280,6 +290,7 @@ Item {
   // flow that is the submit signal: the user already spoke their intent, so
   // making them confirm it in a text box would defeat the gesture.
   onStoreStateChanged: {
+    if (freshChatResetInProgress) return
     if (voiceStartPending && !OmaPilot.QuickchatStore.busy) {
       var freshChat = freshVoiceStartPending
       voiceStartPending = false
@@ -289,7 +300,7 @@ Item {
       // the fresh chat's status after this handler returns.
       Qt.callLater(function() {
         if (!root.voiceEngaged) return
-        if (freshChat) OmaPilot.QuickchatStore.newChat()
+        if (freshChat) root.resetFreshVoiceChat()
         if (!OmaPilot.QuickchatStore.startDictation()) {
           root.voiceNotice = OmaPilot.QuickchatStore.statusMessage !== ""
             ? OmaPilot.QuickchatStore.statusMessage : "Voice input is not available right now"

--- a/README.md
+++ b/README.md
@@ -82,16 +82,16 @@ omarchy plugin remove io.github.spencerbull.quickchat
 
 ## Global hotkeys
 
-OmaPilot exposes compositor-safe IPC actions for continuing the current typed
-or voice conversation, starting a fresh one, and handing the current chat to
+OmaPilot exposes compositor-safe IPC actions for a contextual voice session,
+forced-fresh typed or voice conversations, and handing the current chat to
 Herdr. Add the bindings you want to `~/.config/hypr/bindings.lua`:
 
 ```lua
--- Continue the current voice chat, or start one when no chat exists.
+-- Start fresh when the ambient flow is closed; continue while it is visible.
 o.bind("SUPER + A", "Talk to OmaPilot",
   "omarchy-shell -q io.github.spencerbull.omapilot voiceToggle")
 
--- Start a fresh voice chat. Omarchy uses this chord for ChatGPT by default.
+-- Force a fresh voice chat, even while the ambient flow is still active.
 hl.unbind("SUPER + SHIFT + A")
 o.bind("SUPER + SHIFT + A", "New OmaPilot voice chat",
   "omarchy-shell -q io.github.spencerbull.omapilot newVoiceChat")
@@ -102,11 +102,14 @@ o.bind("SUPER + ALT + H", "Continue OmaPilot chat in Herdr",
   "omarchy-shell -q io.github.spencerbull.quickchat continueInHerdr")
 ```
 
-`Super+A` resumes the current durable conversation; `Super+Shift+A` clears that
-continuation before recording. New typed chat opens the panel with an empty
-composer. Continue in Herdr does nothing until the current conversation has a
-saved chat ID. These are user-owned bindings: installing or updating the plugin
-does not rewrite Hyprland configuration.
+`Super+A` starts a new durable conversation whenever the ambient node and answer
+curtain have closed. While that flow remains active, pressing it again finishes
+live dictation or begins a follow-up in the same conversation. The answer timer,
+explicit dismissal, and cancellation close the voice session; they do not erase
+its saved history. `Super+Shift+A` remains the force-new escape hatch. New typed
+chat opens the panel with an empty composer. Continue in Herdr does nothing until
+the current conversation has a saved chat ID. These are user-owned bindings:
+installing or updating the plugin does not rewrite Hyprland configuration.
 
 Removal deletes the cloned plugin. OmaPilot deliberately leaves user-owned history and cached runtime files in place. Use **Clear all** before removal to erase history and cached chat images. If the plugin is already gone, inspect and remove the compatibility-path `quickchat` directories under your effective `XDG_STATE_HOME` and `XDG_CACHE_HOME` with a file manager; the default locations are `~/.local/state/quickchat` and `~/.cache/quickchat`.
 

--- a/components/QuickchatStore.qml
+++ b/components/QuickchatStore.qml
@@ -4,6 +4,7 @@ import QtQuick
 import Quickshell
 import Quickshell.Io
 import "Protocol.js" as Protocol
+import "SessionLifecycle.js" as SessionLifecycle
 
 // One process and one ephemeral UI model for every screen. The broker is the
 // only durable authority; this singleton merely normalizes its NDJSON stream
@@ -25,6 +26,10 @@ Scope {
   property string statusMessage: "Starting OmaPilot…"
   property string currentId: ""
   property string currentChatId: ""
+  // `submit()` clears currentChatId while a new history record is pending. Keep
+  // the last committed chat separately so an interrupted follow-up can resume
+  // the conversation that existed before that canceled/failed turn.
+  property string submittedResumeChatId: ""
   property string question: ""
   property string answerMarkdown: ""
   property var errorDetails: null
@@ -258,6 +263,7 @@ Scope {
     var prompt = String(text || "").trim()
     if (!prompt || !canSubmit) return false
     var resumeChatId = currentChatId
+    submittedResumeChatId = resumeChatId
     currentId = "qml-" + Date.now() + "-" + Math.floor(Math.random() * 100000)
     currentChatId = ""
     question = prompt
@@ -440,6 +446,7 @@ Scope {
     clearContextAttachments()
     currentId = ""
     currentChatId = ""
+    submittedResumeChatId = ""
     question = ""
     answerMarkdown = ""
     errorDetails = null
@@ -466,6 +473,12 @@ Scope {
       return
     }
     resetChat()
+  }
+
+  function restoreSubmittedContinuation() {
+    currentChatId = SessionLifecycle.settledChatId(
+      currentChatId, submittedResumeChatId)
+    submittedResumeChatId = ""
   }
 
   onBusyChanged: {
@@ -627,6 +640,7 @@ Scope {
 
   function loadChat(chat) {
     if (!chat) return
+    submittedResumeChatId = ""
     currentChatId = String(chat.id || "")
     currentId = ""
     question = String(chat.question || "")
@@ -936,6 +950,7 @@ Scope {
         if (Array.isArray(event.chat.images)) images = event.chat.images
         prependHistory(event.chat)
       } else if (event.chatId) currentChatId = String(event.chatId)
+      restoreSubmittedContinuation()
       if (event.history) history = Protocol.normalizedHistory(event.history)
       state = "complete"
       errorDetails = null
@@ -984,6 +999,7 @@ Scope {
       if (String(event.code || "").toLowerCase() === "cancelled") {
         answerMarkdown = ""
         images = []
+        restoreSubmittedContinuation()
         state = "canceled"
         pendingPermission = null
         permissionQueue = []
@@ -999,6 +1015,7 @@ Scope {
         images = []
         answerChanged()
       }
+      restoreSubmittedContinuation()
       state = event.unavailable === true ? "unavailable" : "error"
       pendingPermission = null
       permissionQueue = []

--- a/components/SessionLifecycle.js
+++ b/components/SessionLifecycle.js
@@ -1,0 +1,19 @@
+.pragma library
+
+// One contextual Super+A gesture owns the common voice lifecycle. The ambient
+// session lease, not the presence of an old saved chat, decides whether a press
+// starts fresh or continues. A live recording is the one special case: the same
+// gesture finishes and submits it.
+function voiceActivationMode(sessionActive, storeState) {
+  if (sessionActive === true && String(storeState || "") === "dictating")
+    return "finish"
+  return sessionActive === true ? "continue" : "fresh"
+}
+
+// While a follow-up is running, the store hides its last committed chat ID so
+// Herdr cannot hand off a half-written turn. A failed or canceled follow-up must
+// restore that ID; a successful turn's new ID always wins.
+function settledChatId(currentChatId, submittedResumeChatId) {
+  var current = String(currentChatId || "")
+  return current !== "" ? current : String(submittedResumeChatId || "")
+}

--- a/design/ambient-ux.md
+++ b/design/ambient-ux.md
@@ -129,8 +129,10 @@ to be a compositor binding that routes over IPC.
 ## Hotkeys
 
 The ambient surface never takes keyboard focus, so global hotkeys route through
-the plugin's IPC targets. The default conversation gesture and its fresh-chat
-variant are:
+the plugin's IPC targets. Super+A owns a visible conversation lease: it starts
+fresh when the ambient flow is closed, continues while that flow is active, and
+finishes live dictation. The explicit fresh-chat variant remains available as a
+force-new escape hatch:
 
 ```lua
 o.bind("SUPER + A", "Talk to OmaPilot",
@@ -145,6 +147,11 @@ o.bind("SUPER + ALT + N", "New OmaPilot chat",
 o.bind("SUPER + ALT + H", "Continue OmaPilot chat in Herdr",
   "omarchy-shell -q io.github.spencerbull.quickchat continueInHerdr")
 ```
+
+The answer timer, explicit dismissal, and cancellation close the voice lease
+without deleting its completed history. The next Super+A resets the presentation
+and continuation immediately before recording, after any in-flight cancellation
+has settled.
 
 These are **documented user bindings, not something OmaPilot writes**. The
 plugin does not edit Hyprland configuration; that constraint is unchanged.

--- a/tests/ambient-session-lifecycle-probe.qml
+++ b/tests/ambient-session-lifecycle-probe.qml
@@ -1,0 +1,47 @@
+import QtQuick
+import Quickshell
+import "components" as OmaPilot
+
+ShellRoot {
+  id: root
+  property bool failed: false
+
+  function fail(message) {
+    failed = true
+    console.error("omapilot ambient session lifecycle probe failed: " + message)
+  }
+
+  Ambient {
+    id: ambient
+  }
+
+  Timer {
+    interval: 80
+    running: true
+    onTriggered: {
+      OmaPilot.QuickchatStore.initialized = true
+      OmaPilot.QuickchatStore.dictationPhase = ""
+      OmaPilot.QuickchatStore.currentId = ""
+      OmaPilot.QuickchatStore.currentChatId = "completed-chat"
+      OmaPilot.QuickchatStore.transcript = ""
+      OmaPilot.QuickchatStore.answerMarkdown = "A completed answer"
+      OmaPilot.QuickchatStore.state = "complete"
+      ambient.voiceEngaged = true
+      ambient.voiceSessionActive = true
+
+      ambient.resetFreshVoiceChat()
+
+      if (!ambient.voiceEngaged)
+        root.fail("fresh reset dismissed the ambient presentation")
+      if (!ambient.voiceSessionActive)
+        root.fail("fresh reset closed the voice-session lease")
+      if (OmaPilot.QuickchatStore.state !== "composing")
+        root.fail("fresh reset did not return the store to composing")
+      if (OmaPilot.QuickchatStore.currentChatId !== "")
+        root.fail("fresh reset retained the completed chat continuation")
+
+      if (!root.failed) console.log("OMAPILOT_AMBIENT_SESSION_LIFECYCLE_PROBE_OK")
+      Qt.quit()
+    }
+  }
+}

--- a/tests/check-ui-contract.sh
+++ b/tests/check-ui-contract.sh
@@ -255,7 +255,9 @@ grep -Fq 'session=" + (root.voiceSessionActive ? "active" : "closed")' \
   "$repo_dir/Ambient.qml"
 grep -Fq 'freshVoiceStartPending = freshVoiceStartPending || freshChat' \
   "$repo_dir/Ambient.qml"
-grep -Fq 'if (freshChat && !freshChatReset) OmaPilot.QuickchatStore.newChat()' \
+grep -Fq 'property bool freshChatResetInProgress: false' "$repo_dir/Ambient.qml"
+grep -Fq 'if (freshChatResetInProgress) return' "$repo_dir/Ambient.qml"
+grep -Fq 'if (freshChat && !freshChatReset) resetFreshVoiceChat()' \
   "$repo_dir/Ambient.qml"
 grep -Fq 'function continueInHerdr() { root.continueInHerdr() }' \
   "$repo_dir/components/QuickchatStore.qml"
@@ -566,7 +568,8 @@ QT_QPA_PLATFORM=offscreen /usr/lib/qt6/bin/qmltestrunner \
 
 smoke_root="$(mktemp -d)"
 cp "$repo_dir/tests/smoke.qml" "$smoke_root/shell.qml"
-cp "$repo_dir/BarWidget.qml" "$repo_dir/ContextCaptureOverlay.qml" "$repo_dir/Panel.qml" "$smoke_root/"
+cp "$repo_dir/Ambient.qml" "$repo_dir/BarWidget.qml" \
+  "$repo_dir/ContextCaptureOverlay.qml" "$repo_dir/Panel.qml" "$smoke_root/"
 cp -a "$repo_dir/components" "$smoke_root/components"
 cp -a "$repo_dir/assets" "$smoke_root/assets"
 cp -a "$omarchy_shell/Commons" "$omarchy_shell/Ui" "$smoke_root/"
@@ -576,6 +579,21 @@ QUICKCHAT_BROKER_PATH=/usr/bin/false QT_QPA_PLATFORM=wayland \
   >"$smoke_root/output.log" 2>&1
 if grep -Eq "smoke loader failed|overlay smoke loader failed|Failed to load|Type .* unavailable|Cannot assign" "$smoke_root/output.log"; then
   cat "$smoke_root/output.log"
+  exit 1
+fi
+
+cp "$repo_dir/tests/ambient-session-lifecycle-probe.qml" "$smoke_root/shell.qml"
+if ! QUICKCHAT_BROKER_PATH=/usr/bin/false QT_QPA_PLATFORM=wayland \
+    timeout 5s quickshell --no-duplicate --path "$smoke_root" --no-color \
+    >"$smoke_root/ambient-session-lifecycle.log" 2>&1; then
+  cat "$smoke_root/ambient-session-lifecycle.log"
+  exit 1
+fi
+if grep -Eq "omapilot ambient session lifecycle probe failed|Failed to load|Type .* unavailable|Cannot assign|TypeError|ReferenceError" \
+    "$smoke_root/ambient-session-lifecycle.log" \
+    || ! grep -Fq 'OMAPILOT_AMBIENT_SESSION_LIFECYCLE_PROBE_OK' \
+      "$smoke_root/ambient-session-lifecycle.log"; then
+  cat "$smoke_root/ambient-session-lifecycle.log"
   exit 1
 fi
 

--- a/tests/check-ui-contract.sh
+++ b/tests/check-ui-contract.sh
@@ -248,7 +248,13 @@ grep -Fq 'Protocol.ttsKeySetCommand(provider, apiKey)' "$repo_dir/components/Qui
 grep -Fq 'onVoiceEnabledRequested:' "$repo_dir/Panel.qml"
 grep -Fq 'if (!OmaPilot.QuickchatStore.voiceEnabled)' "$repo_dir/Ambient.qml"
 grep -Fq 'function newVoiceChat(): string {' "$repo_dir/Ambient.qml"
-grep -Fq 'freshVoiceStartPending = freshChat' "$repo_dir/Ambient.qml"
+grep -Fq 'property bool voiceSessionActive: false' "$repo_dir/Ambient.qml"
+grep -Fq 'SessionLifecycle.voiceActivationMode(' "$repo_dir/Ambient.qml"
+grep -Fq 'voiceSessionActive = false' "$repo_dir/Ambient.qml"
+grep -Fq 'session=" + (root.voiceSessionActive ? "active" : "closed")' \
+  "$repo_dir/Ambient.qml"
+grep -Fq 'freshVoiceStartPending = freshVoiceStartPending || freshChat' \
+  "$repo_dir/Ambient.qml"
 grep -Fq 'if (freshChat && !freshChatReset) OmaPilot.QuickchatStore.newChat()' \
   "$repo_dir/Ambient.qml"
 grep -Fq 'function continueInHerdr() { root.continueInHerdr() }' \
@@ -257,6 +263,9 @@ grep -Fq '|| (pendingHerdrChatId === "" && currentId !== "" && busy)' \
   "$repo_dir/components/QuickchatStore.qml"
 grep -Fq 'if (root.newChatPending && !root.busy) root.resetChat()' \
   "$repo_dir/components/QuickchatStore.qml"
+grep -Fq 'submittedResumeChatId = resumeChatId' "$repo_dir/components/QuickchatStore.qml"
+test "$(grep -Fc 'restoreSubmittedContinuation()' \
+  "$repo_dir/components/QuickchatStore.qml")" -ge 3
 grep -Fq 'pendingHerdrChatId = currentChatId' "$repo_dir/components/QuickchatStore.qml"
 grep -Fq 'String(event.chatId || "") !== pendingHerdrChatId' \
   "$repo_dir/components/QuickchatStore.qml"
@@ -545,6 +554,10 @@ QT_QPA_PLATFORM=offscreen /usr/lib/qt6/bin/qmltestrunner \
 QT_QPA_PLATFORM=offscreen /usr/lib/qt6/bin/qmltestrunner \
   -input "$repo_dir/tests/tst_state_phrases.qml" \
   -import "$repo_dir" || fail "state phrase tests failed"
+
+QT_QPA_PLATFORM=offscreen /usr/lib/qt6/bin/qmltestrunner \
+  -input "$repo_dir/tests/tst_session_lifecycle.qml" \
+  -import "$repo_dir" || fail "session lifecycle tests failed"
 
 QT_QPA_PLATFORM=offscreen /usr/lib/qt6/bin/qmltestrunner \
   -input "$repo_dir/tests/tst_quick_actions.qml" \

--- a/tests/tst_session_lifecycle.qml
+++ b/tests/tst_session_lifecycle.qml
@@ -1,0 +1,29 @@
+import QtQuick
+import QtTest
+import "../components/SessionLifecycle.js" as SessionLifecycle
+
+TestCase {
+  name: "SessionLifecycle"
+
+  function test_closedVoiceFlowStartsFresh() {
+    var states = ["composing", "dictating", "preparing", "streaming", "complete", "error"]
+    for (var i = 0; i < states.length; i++)
+      compare(SessionLifecycle.voiceActivationMode(false, states[i]), "fresh")
+  }
+
+  function test_activeVoiceFlowFinishesOnlyLiveDictation() {
+    compare(SessionLifecycle.voiceActivationMode(true, "dictating"), "finish")
+    var continuingStates = ["composing", "preparing", "streaming", "complete", "error", "unavailable"]
+    for (var i = 0; i < continuingStates.length; i++)
+      compare(SessionLifecycle.voiceActivationMode(true, continuingStates[i]), "continue")
+  }
+
+  function test_completedTurnWinsOverSubmittedContinuation() {
+    compare(SessionLifecycle.settledChatId("new-chat", "prior-chat"), "new-chat")
+  }
+
+  function test_interruptedTurnRestoresSubmittedContinuation() {
+    compare(SessionLifecycle.settledChatId("", "prior-chat"), "prior-chat")
+    compare(SessionLifecycle.settledChatId("", ""), "")
+  }
+}


### PR DESCRIPTION
## Summary

- start a fresh durable chat when Super+A opens a closed ambient voice flow
- continue the same chat while the ambient session remains active, with a second press finishing live dictation
- close the voice-session lease on dismissal, timeout, or cancellation while retaining saved history
- restore the prior resumable chat after canceled or failed follow-ups
- document the lifecycle and add focused QML coverage

## Verification

- `./scripts/validate.sh`
- 24 test files passed; 239 tests passed; 8 live-provider tests skipped
- live installed IPC flow verified: closed -> active -> same active session -> closed -> fresh active session
- `hyprctl configerrors` returned no errors