### PR TITLE
Add opt-in global hotkeys and fix OmaPilot IPC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
           cache: npm
       - name: Check manifest contract
         run: ./scripts/check-manifest.sh
+      - name: Check first-run hotkey installation
+        run: ./tests/test-hotkey-installer.sh
       - name: Validate with pinned Omarchy Quattro
         env:
           OMARCHY_QUATTRO_COMMIT: ef6d9e6605b121df15bf310e630e04f0c1119fc8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           cache: npm
       - name: Check manifest contract
         run: ./scripts/check-manifest.sh
-      - name: Check first-run hotkey installation
+      - name: Check opt-in hotkey installation
         run: ./tests/test-hotkey-installer.sh
       - name: Validate with pinned Omarchy Quattro
         env:

--- a/Ambient.qml
+++ b/Ambient.qml
@@ -106,6 +106,12 @@ Item {
       if (!root.voiceEngaged || root.storeState !== "complete") return
       root.answerSpoken = true
     }
+    function onIpcVoiceStartRequested() { root.voiceStart() }
+    function onIpcVoiceStopRequested() { root.voiceStop() }
+    function onIpcVoiceToggleRequested() { root.voiceToggle() }
+    function onIpcNewVoiceChatRequested() { root.newVoiceChat() }
+    function onIpcVoiceCancelRequested() { root.voiceCancel() }
+    function onIpcAmbientDismissRequested() { root.dismiss() }
   }
 
   // Presentation and conversation lifetime are deliberately separate. A failed
@@ -356,37 +362,14 @@ Item {
     onTriggered: root.dismiss()
   }
 
-  // ------------------------------------------------------------------- IPC
+  // --------------------------------------------------------------- IPC routing
   // The voice gesture cannot be a surface keybinding, because the ambient
   // surfaces never take keyboard focus by design. It has to arrive over IPC from
-  // a compositor binding. The default gesture derives fresh-versus-continue
-  // from the ambient session lease; `newVoiceChat` remains an explicit force-new
-  // escape hatch while that lease is still active.
-  IpcHandler {
-    target: "io.github.spencerbull.omapilot"
-    function voiceStart(): string {
-      var result = root.voiceStart()
-      return result ? String(result) : "listening"
-    }
-    function voiceStop(): string { root.voiceStop(); return "ok" }
-    function voiceToggle(): string {
-      var result = root.voiceToggle()
-      return result ? String(result) : "ok"
-    }
-    function newVoiceChat(): string {
-      var result = root.newVoiceChat()
-      return result ? String(result) : "ok"
-    }
-    function voiceCancel(): string { root.voiceCancel(); return "ok" }
-    function dismiss(): string { root.dismiss(); return "ok" }
-    function status(): string {
-      return "phase=" + root.phase
-        + " store=" + root.storeState
-        + " session=" + (root.voiceSessionActive ? "active" : "closed")
-        + " screen=" + (root.activeScreen ? root.activeScreen.name : "none")
-        + " dismissMs=" + root.dismissDelay
-    }
-  }
+  // a compositor binding. OmaPilotStore owns the plugin's one IPC target and
+  // relays voice requests here; registering a second handler would make
+  // Quickshell reject one entire action set. The default gesture derives
+  // fresh-versus-continue from the ambient session lease; `newVoiceChat`
+  // remains an explicit force-new escape hatch while that lease is still active.
 
   // --------------------------------------------------------------- surfaces
   OmaPilot.VoiceNode {

--- a/Panel.qml
+++ b/Panel.qml
@@ -967,6 +967,8 @@ Panel {
         onBrowserCompanionRefreshRequested: OmaPilot.OmaPilotStore.requestBrowserCompanionStatus()
         onBrowserCompanionOpenSettingsRequested: function(family) { OmaPilot.OmaPilotStore.openBrowserCompanionSettings(family) }
         onBrowserCompanionCopyPathRequested: function(family) { OmaPilot.OmaPilotStore.copyBrowserCompanionPath(family) }
+        onHotkeyInstallRequested: OmaPilot.OmaPilotStore.installHotkeys()
+        onHotkeyRemoveRequested: OmaPilot.OmaPilotStore.removeHotkeys()
         onCustomProviderAddRequested: function(id, name, baseUrl, api, models, apiKey) {
           OmaPilot.OmaPilotStore.addCustomProvider(id, name, baseUrl, api, models, apiKey)
         }

--- a/README.md
+++ b/README.md
@@ -84,13 +84,11 @@ omarchy plugin enable io.github.spencerbull.omapilot right
 
 The Omarchy installer only clones, validates, and enables the plugin. Omarchy
 runs no plugin install hook, and OmaPilot does not request administrator access
-or invoke a package manager. On the first real plugin load, OmaPilot adds its
-described global shortcuts to `~/.config/hypr/bindings.lua`. It skips any chord
-already defined in that user file, except for replacing Omarchy's stock
-`Super+Shift+A` ChatGPT shortcut. A one-time marker under
-`${XDG_STATE_HOME:-$HOME/.local/state}/omapilot` prevents later shell starts from
-reapplying shortcuts the user has changed or removed. Development previews and
-worktrees never trigger the edit. The reviewed repository revision includes
+or invoke a package manager. Installation and first load do not edit Hyprland
+configuration. To add the described global shortcuts, explicitly choose
+**Settings → Desktop → Install global hotkeys**. OmaPilot then adds one marked
+block to `~/.config/hypr/bindings.lua` while preserving every shortcut chord
+already defined there. The reviewed repository revision includes
 reproducible Linux x86-64 broker and Codex ACP launchers, so a normal install
 does not run `npm`, `npx`, or silently download executable code. The launchers
 execute their embedded JavaScript payloads directly from the read-only launcher
@@ -109,8 +107,8 @@ omarchy plugin remove io.github.spencerbull.omapilot
 
 OmaPilot exposes compositor-safe IPC actions for a contextual voice session,
 forced-fresh typed or voice conversations, and handing the current chat to
-Herdr. The first installed load adds these bindings to
-`~/.config/hypr/bindings.lua`, where their descriptions appear in
+Herdr. Choose **Settings → Desktop → Install global hotkeys** to add these
+bindings to `~/.config/hypr/bindings.lua`, where their descriptions appear in
 **Learn → Keybindings**:
 
 ```lua
@@ -137,9 +135,10 @@ its saved history. `Super+Shift+A` remains the force-new escape hatch. New typed
 chat opens the panel with an empty composer. Continue in Herdr does nothing until
 the current conversation has a saved chat ID.
 
-The managed block is written only once and becomes normal user-owned Hyprland
-configuration. Existing user-defined collisions are left alone. To retry while
-still preserving collisions, or to deliberately replace every chord, run:
+The managed block is written only after that explicit action and becomes normal
+user-owned Hyprland configuration. Existing user-defined collisions are left
+alone. To install from a terminal while still preserving collisions, or to
+deliberately replace every chord, run:
 
 ```bash
 ~/.config/omarchy/plugins/io.github.spencerbull.omapilot/scripts/install-hotkeys.sh

--- a/README.md
+++ b/README.md
@@ -82,13 +82,19 @@ omarchy plugin validate ~/.config/omarchy/plugins/io.github.spencerbull.omapilot
 omarchy plugin enable io.github.spencerbull.omapilot right
 ```
 
-The Omarchy installer only clones, validates, and enables the plugin. It runs no
-install hook, does not request administrator access, and does not invoke a
-package manager or mutate host configuration. The reviewed repository revision
-includes reproducible Linux x86-64 broker and Codex ACP launchers, so a normal
-install does not run `npm`, `npx`, or silently download executable code. The
-launchers execute their embedded JavaScript payloads directly from the
-read-only launcher file with system Node;
+The Omarchy installer only clones, validates, and enables the plugin. Omarchy
+runs no plugin install hook, and OmaPilot does not request administrator access
+or invoke a package manager. On the first real plugin load, OmaPilot adds its
+described global shortcuts to `~/.config/hypr/bindings.lua`. It skips any chord
+already defined in that user file, except for replacing Omarchy's stock
+`Super+Shift+A` ChatGPT shortcut. A one-time marker under
+`${XDG_STATE_HOME:-$HOME/.local/state}/omapilot` prevents later shell starts from
+reapplying shortcuts the user has changed or removed. Development previews and
+worktrees never trigger the edit. The reviewed repository revision includes
+reproducible Linux x86-64 broker and Codex ACP launchers, so a normal install
+does not run `npm`, `npx`, or silently download executable code. The launchers
+execute their embedded JavaScript payloads directly from the read-only launcher
+file with system Node;
 Git history anchors those generated files to their TypeScript source and pinned
 lockfile. Release archives add an SBOM, provenance record, and SHA-256 checksum.
 
@@ -103,7 +109,9 @@ omarchy plugin remove io.github.spencerbull.omapilot
 
 OmaPilot exposes compositor-safe IPC actions for a contextual voice session,
 forced-fresh typed or voice conversations, and handing the current chat to
-Herdr. Add the bindings you want to `~/.config/hypr/bindings.lua`:
+Herdr. The first installed load adds these bindings to
+`~/.config/hypr/bindings.lua`, where their descriptions appear in
+**Learn → Keybindings**:
 
 ```lua
 -- Start fresh when the ambient flow is closed; continue while it is visible.
@@ -127,8 +135,24 @@ live dictation or begins a follow-up in the same conversation. The answer timer,
 explicit dismissal, and cancellation close the voice session; they do not erase
 its saved history. `Super+Shift+A` remains the force-new escape hatch. New typed
 chat opens the panel with an empty composer. Continue in Herdr does nothing until
-the current conversation has a saved chat ID. These are user-owned bindings:
-installing or updating the plugin does not rewrite Hyprland configuration.
+the current conversation has a saved chat ID.
+
+The managed block is written only once and becomes normal user-owned Hyprland
+configuration. Existing user-defined collisions are left alone. To retry while
+still preserving collisions, or to deliberately replace every chord, run:
+
+```bash
+~/.config/omarchy/plugins/io.github.spencerbull.omapilot/scripts/install-hotkeys.sh
+~/.config/omarchy/plugins/io.github.spencerbull.omapilot/scripts/install-hotkeys.sh --force
+```
+
+Before removing the plugin, remove only its managed block, then use Omarchy's
+standard removal command:
+
+```bash
+~/.config/omarchy/plugins/io.github.spencerbull.omapilot/scripts/install-hotkeys.sh --remove
+omarchy plugin remove io.github.spencerbull.omapilot
+```
 
 Removal deletes the cloned plugin. OmaPilot deliberately leaves user-owned history and cached runtime files in place. Use **Clear all** before removal to erase history and cached chat images. If the plugin is already gone, inspect and remove the OmaPilot directories under your effective `XDG_STATE_HOME` and `XDG_CACHE_HOME` with a file manager; the default locations are `~/.local/state/omapilot` and `~/.cache/omapilot`.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,6 +8,14 @@ Security fixes are provided for the current OmaPilot release.
 
 Omarchy plugins run unsandboxed inside the long-lived `omarchy-shell` process. Review OmaPilot before enabling it. OmaPilot minimizes that authority by delegating provider traffic to a separate broker process and starting each agent with one provider-specific, fail-closed automatic policy.
 
+- On the first load from Omarchy's installed plugin directory, a one-time
+  helper appends a visibly marked hotkey block to the user's Hyprland
+  `bindings.lua`. It refuses preview and development paths, serializes concurrent
+  attempts, preserves chords directly defined in the user file, validates
+  generated Lua when `luac` is available, and has a removal mode limited to its own markers.
+  A state marker prevents later shell starts from silently restoring shortcuts
+  the user changed or removed.
+
 - The embedded Pi harness loads declarative skills, context files, and named
   agent profiles from the standard `~/.agents` roots. It does not
   auto-load executable Pi extensions. Read, grep, find, and list tools use the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,13 +8,14 @@ Security fixes are provided for the current OmaPilot release.
 
 Omarchy plugins run unsandboxed inside the long-lived `omarchy-shell` process. Review OmaPilot before enabling it. OmaPilot minimizes that authority by delegating provider traffic to a separate broker process and starting each agent with one provider-specific, fail-closed automatic policy.
 
-- On the first load from Omarchy's installed plugin directory, a one-time
-  helper appends a visibly marked hotkey block to the user's Hyprland
-  `bindings.lua`. It refuses preview and development paths, serializes concurrent
-  attempts, preserves chords directly defined in the user file, validates
-  generated Lua when `luac` is available, and has a removal mode limited to its own markers.
-  A state marker prevents later shell starts from silently restoring shortcuts
-  the user changed or removed.
+- OmaPilot does not edit Hyprland configuration during installation or first
+  load. **Settings → Desktop → Install global hotkeys** is an explicit action
+  that runs a helper from the installed plugin directory and appends a visibly
+  marked block to the user's `bindings.lua`. The helper refuses preview and
+  development paths, serializes concurrent attempts, preserves chords directly
+  defined in the user file, validates generated Lua when `luac` is available,
+  and has a removal mode limited to its own markers. It never silently restores
+  shortcuts the user later changes or removes.
 
 - The embedded Pi harness loads declarative skills, context files, and named
   agent profiles from the standard `~/.agents` roots. It does not

--- a/components/OmaPilotStore.qml
+++ b/components/OmaPilotStore.qml
@@ -51,6 +51,9 @@ Scope {
   property bool customProviderTestPending: false
   property string customProviderTestError: ""
   property var voxtypeOsd: ({ available: false, enabled: true, message: "" })
+  property string hotkeyAction: ""
+  property string hotkeyMessage: ""
+  property string hotkeyProcessError: ""
   property var voiceStatus: Protocol.emptyVoiceStatus()
   property var ttsTest: null
   property bool ttsTestPending: false
@@ -122,6 +125,7 @@ Scope {
     || browserCompanionStatus.firefoxConnected === true
   readonly property bool browserCompanionBusy: browserCompanionStatus.phase === "installing"
     || browserCompanionStatus.phase === "removing"
+  readonly property bool hotkeyBusy: hotkeyInstaller.running
   readonly property bool builtinAuthBusy: ["starting", "prompt", "info", "browser", "device_code"]
     .indexOf(String(builtinAuth.phase || "")) >= 0
 
@@ -342,6 +346,24 @@ Scope {
   function uninstallBrowserCompanion() {
     if (browserCompanionBusy) return
     sendCommand(Protocol.command("browser_companion_uninstall"))
+  }
+
+  function installHotkeys() {
+    if (hotkeyBusy) return
+    hotkeyAction = "install"
+    hotkeyMessage = "Installing global hotkeys…"
+    hotkeyProcessError = ""
+    hotkeyInstaller.command = [hotkeyInstallerPath, "--installed-plugin-only"]
+    hotkeyInstaller.running = true
+  }
+
+  function removeHotkeys() {
+    if (hotkeyBusy) return
+    hotkeyAction = "remove"
+    hotkeyMessage = "Removing managed hotkeys…"
+    hotkeyProcessError = ""
+    hotkeyInstaller.command = [hotkeyInstallerPath, "--installed-plugin-only", "--remove"]
+    hotkeyInstaller.running = true
   }
 
   function openBrowserCompanionSettings(family) {
@@ -1120,23 +1142,35 @@ Scope {
     function status(): string { return "store=" + root.state }
   }
 
-  // Omarchy intentionally has no plugin install hooks. The first real plugin
-  // load is therefore the only reliable place to add compositor bindings. The
-  // helper refuses development/preview paths, records its one-time attempt,
-  // preserves user-defined collisions, and owns only its marked block.
+  // Hotkeys modify user-owned compositor configuration, so this helper starts
+  // only after the user chooses an action in Settings > Desktop. It refuses
+  // development/preview paths, preserves collisions, and owns only its marked
+  // block.
   Process {
     id: hotkeyInstaller
-    command: [root.hotkeyInstallerPath, "--once", "--installed-plugin-only"]
-    running: true
+    command: [root.hotkeyInstallerPath, "--installed-plugin-only"]
+    running: false
 
     onExited: function(exitCode, exitStatus) {
-      if (exitCode !== 0)
-        console.warn("omapilot: automatic hotkey installation failed with exit code " + exitCode)
+      if (exitCode === 0) {
+        root.hotkeyMessage = root.hotkeyAction === "remove"
+          ? "Managed global hotkeys removed."
+          : "Global hotkeys installed. Existing bindings were preserved."
+      } else {
+        root.hotkeyMessage = root.hotkeyProcessError !== ""
+          ? root.hotkeyProcessError
+          : "Hotkey setup failed with exit code " + exitCode + "."
+        console.warn("omapilot: hotkey setup failed with exit code " + exitCode)
+      }
+      root.hotkeyAction = ""
     }
 
     stderr: SplitParser {
       onRead: function(line) {
-        if (String(line || "").trim() !== "") console.warn("omapilot: " + line)
+        var message = String(line || "").trim()
+        if (message === "") return
+        root.hotkeyProcessError = message.replace(/^install-hotkeys: /, "")
+        console.warn("omapilot: " + message)
       }
     }
   }

--- a/components/OmaPilotStore.qml
+++ b/components/OmaPilotStore.qml
@@ -22,6 +22,14 @@ Scope {
     return url
   }
   readonly property string brokerPath: Quickshell.env("OMAPILOT_BROKER_PATH") || bundledBrokerPath
+  readonly property string hotkeyInstallerPath: {
+    var url = String(Qt.resolvedUrl("../scripts/install-hotkeys.sh"))
+    if (url.indexOf("file://") === 0) {
+      try { return decodeURIComponent(url.slice("file://".length)) }
+      catch (error) { return url.slice("file://".length) }
+    }
+    return url
+  }
   property string state: "preparing"
   property string statusMessage: "Starting OmaPilot…"
   property string currentId: ""
@@ -1097,6 +1105,27 @@ Scope {
     function continueInHerdr() { root.continueInHerdr() }
     function history() { root.routeIpc("history") }
     function settings() { root.routeIpc("settings") }
+  }
+
+  // Omarchy intentionally has no plugin install hooks. The first real plugin
+  // load is therefore the only reliable place to add compositor bindings. The
+  // helper refuses development/preview paths, records its one-time attempt,
+  // preserves user-defined collisions, and owns only its marked block.
+  Process {
+    id: hotkeyInstaller
+    command: [root.hotkeyInstallerPath, "--once", "--installed-plugin-only"]
+    running: true
+
+    onExited: function(exitCode, exitStatus) {
+      if (exitCode !== 0)
+        console.warn("omapilot: automatic hotkey installation failed with exit code " + exitCode)
+    }
+
+    stderr: SplitParser {
+      onRead: function(line) {
+        if (String(line || "").trim() !== "") console.warn("omapilot: " + line)
+      }
+    }
   }
 
   Process {

--- a/components/OmaPilotStore.qml
+++ b/components/OmaPilotStore.qml
@@ -134,6 +134,12 @@ Scope {
   signal ipcToggleRequested()
   signal ipcHistoryRequested()
   signal ipcSettingsRequested()
+  signal ipcVoiceStartRequested()
+  signal ipcVoiceStopRequested()
+  signal ipcVoiceToggleRequested()
+  signal ipcNewVoiceChatRequested()
+  signal ipcVoiceCancelRequested()
+  signal ipcAmbientDismissRequested()
   signal contextOverlayRequested(string payload)
   signal contextBrowserPickerRequested()
   signal ttsSpoken()
@@ -1105,6 +1111,13 @@ Scope {
     function continueInHerdr() { root.continueInHerdr() }
     function history() { root.routeIpc("history") }
     function settings() { root.routeIpc("settings") }
+    function voiceStart(): string { root.ipcVoiceStartRequested(); return "ok" }
+    function voiceStop(): string { root.ipcVoiceStopRequested(); return "ok" }
+    function voiceToggle(): string { root.ipcVoiceToggleRequested(); return "ok" }
+    function newVoiceChat(): string { root.ipcNewVoiceChatRequested(); return "ok" }
+    function voiceCancel(): string { root.ipcVoiceCancelRequested(); return "ok" }
+    function dismiss(): string { root.ipcAmbientDismissRequested(); return "ok" }
+    function status(): string { return "store=" + root.state }
   }
 
   // Omarchy intentionally has no plugin install hooks. The first real plugin

--- a/components/SettingsView.qml
+++ b/components/SettingsView.qml
@@ -55,6 +55,8 @@ Item {
     ? String(backend.customProviderError) : ""
   readonly property bool browserCompanionConnected: backend ? backend.browserCompanionConnected === true : false
   readonly property bool browserCompanionBusy: backend ? backend.browserCompanionBusy === true : false
+  readonly property bool hotkeyBusy: backend ? backend.hotkeyBusy === true : false
+  readonly property string hotkeyMessage: backend ? String(backend.hotkeyMessage || "") : ""
   property bool browserRemoveConfirmation: false
   property bool browserSetupExpanded: false
   // Add-an-endpoint form state. Nothing here is persisted until the broker
@@ -115,6 +117,8 @@ Item {
   signal browserCompanionRefreshRequested()
   signal browserCompanionOpenSettingsRequested(string family)
   signal browserCompanionCopyPathRequested(string family)
+  signal hotkeyInstallRequested()
+  signal hotkeyRemoveRequested()
   signal customProviderAddRequested(string id, string name, string baseUrl, string api, var models, string apiKey)
   signal customProviderTestRequested(string baseUrl, string apiKey)
   signal customProviderRemoveRequested(string id)
@@ -1448,6 +1452,72 @@ Item {
             fontFamily: root.fontFamily
             Accessible.name: label
             onClicked: root.desktopContextRequested(!root.desktopContextEnabled)
+          }
+
+          Text {
+            Layout.fillWidth: true
+            text: "Global hotkeys"
+            color: root.mutedForeground
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.caption
+            font.bold: true
+          }
+
+          Text {
+            Layout.fillWidth: true
+            text: "Install a clearly marked OmaPilot block in ~/.config/hypr/bindings.lua. Nothing is changed until you choose Install, and existing shortcut chords are preserved."
+            color: root.mutedForeground
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.caption
+            wrapMode: Text.Wrap
+            Accessible.role: Accessible.StaticText
+            Accessible.name: text
+          }
+
+          RowLayout {
+            Layout.fillWidth: true
+            spacing: Style.spacing.md
+
+            Button {
+              Layout.fillWidth: true
+              text: root.hotkeyBusy ? "Updating hotkeys…" : "Install global hotkeys"
+              tooltipText: "Add OmaPilot shortcuts without replacing existing shortcut chords"
+              foreground: root.foreground
+              background: root.background
+              accent: root.accent
+              active: true
+              bordered: true
+              focusable: true
+              enabled: root.backend && !root.hotkeyBusy
+              Accessible.name: tooltipText
+              onClicked: root.hotkeyInstallRequested()
+            }
+
+            Button {
+              text: "Remove"
+              tooltipText: "Remove only the hotkey block managed by OmaPilot"
+              foreground: root.foreground
+              background: root.background
+              bordered: true
+              focusable: true
+              enabled: root.backend && !root.hotkeyBusy
+              Accessible.name: tooltipText
+              onClicked: root.hotkeyRemoveRequested()
+            }
+          }
+
+          Text {
+            Layout.fillWidth: true
+            visible: root.hotkeyMessage !== ""
+            text: root.hotkeyMessage
+            color: root.hotkeyMessage.toLowerCase().indexOf("fail") >= 0
+              || root.hotkeyMessage.toLowerCase().indexOf("refus") >= 0
+              ? Color.urgent : root.mutedForeground
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.caption
+            wrapMode: Text.Wrap
+            Accessible.role: Accessible.StaticText
+            Accessible.name: text
           }
 
           Text {

--- a/design/ambient-ux.md
+++ b/design/ambient-ux.md
@@ -153,8 +153,11 @@ without deleting its completed history. The next Super+A resets the presentation
 and continuation immediately before recording, after any in-flight cancellation
 has settled.
 
-These are **documented user bindings, not something OmaPilot writes**. The
-plugin does not edit Hyprland configuration; that constraint is unchanged.
+The installed plugin now writes these as a one-time managed block in the user's
+Hyprland bindings file. It leaves pre-existing user chords alone, replaces the
+stock `Super+Shift+A` ChatGPT binding only when the user has not already
+overridden it, and never reapplies the block after the user changes or removes
+it. Preview and development worktrees do not run the installer.
 
 Layer rules are likewise optional and user-owned. Real backdrop blur behind the
 ambient surfaces needs

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,7 +16,13 @@ The widget follows the current Quattro host contract:
   routes panel actions through Quattro's focused-monitor bar-widget resolver;
   ownership follows the host's reassigned module list across monitor changes.
 
-OmaPilot does not edit `shell.json`, Omarchy sources, Hyprland configuration, or Herdr configuration directly.
+OmaPilot does not edit `shell.json`, Omarchy sources, or Herdr configuration.
+Because Omarchy intentionally exposes no plugin install hook, the first loaded
+installed copy runs a repository-owned helper that appends one marked block to
+`~/.config/hypr/bindings.lua`. The helper runs only once, skips chords already
+defined in the user file, validates the generated Lua when `luac` is available,
+reloads Hyprland, and can remove only its own block. Preview and development
+paths fail closed without touching the desktop configuration.
 
 Voice is opt-in from Settings after install. Widget settings store only
 `voiceEnabled`, `ttsProvider`, `ttsModel`, and `ttsVoice`. Cloud TTS keys live
@@ -26,9 +32,9 @@ are probed with the supplied key before that key is saved. After a Super+A
 voice turn completes, the broker speaks the answer with the selected TTS
 provider and plays it locally. Dictation still uses Voxtype.
 
-One narrowly scoped exception exists for Voxtype. Its floating OSD renders its
-own waveform at the bottom centre of the focused output — the same place the
-voice node occupies — and two indicators for one state is worse than either.
+One separate, narrowly scoped exception exists for Voxtype. Its floating OSD
+renders its own waveform at the bottom centre of the focused output — the same
+place the voice node occupies — and two indicators for one state is worse than either.
 Voxtype documents a master switch for it, and its own `voxtype config set`
 supports only `engine`, so the value cannot be delegated. Settings therefore
 offers an explicit toggle that writes `[osd] enabled` in

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,12 +17,13 @@ The widget follows the current Quattro host contract:
   ownership follows the host's reassigned module list across monitor changes.
 
 OmaPilot does not edit `shell.json`, Omarchy sources, or Herdr configuration.
-Because Omarchy intentionally exposes no plugin install hook, the first loaded
-installed copy runs a repository-owned helper that appends one marked block to
-`~/.config/hypr/bindings.lua`. The helper runs only once, skips chords already
-defined in the user file, validates the generated Lua when `luac` is available,
-reloads Hyprland, and can remove only its own block. Preview and development
-paths fail closed without touching the desktop configuration.
+Installation and first load do not edit Hyprland configuration. An explicit
+**Settings → Desktop → Install global hotkeys** action runs a repository-owned
+helper that appends one marked block to `~/.config/hypr/bindings.lua`. The
+helper skips chords already defined in the user file, validates the generated
+Lua when `luac` is available, reloads Hyprland, and can remove only its own
+block. Preview and development paths fail closed without touching the desktop
+configuration.
 
 Voice is opt-in from Settings after install. Widget settings store only
 `voiceEnabled`, `ttsProvider`, `ttsModel`, and `ttsVoice`. Cloud TTS keys live

--- a/scripts/install-hotkeys.sh
+++ b/scripts/install-hotkeys.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+plugin_id="io.github.spencerbull.omapilot"
+begin_marker="-- BEGIN OmaPilot managed hotkeys"
+end_marker="-- END OmaPilot managed hotkeys"
+
+once=0
+installed_plugin_only=0
+force=0
+remove=0
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/install-hotkeys.sh [--once] [--installed-plugin-only] [--force|--remove]
+
+Install OmaPilot's global bindings into the user's Hyprland bindings.lua.
+
+  --once                   Do nothing after the first automatic attempt.
+  --installed-plugin-only  Run only from OmaPilot's normal installed path.
+  --force                  Replace colliding user bindings for OmaPilot's chords.
+  --remove                 Remove only the block managed by this script.
+USAGE
+}
+
+fail() {
+  printf 'install-hotkeys: %s\n' "$*" >&2
+  exit 1
+}
+
+while (($#)); do
+  case "$1" in
+    --once)
+      once=1
+      ;;
+    --installed-plugin-only)
+      installed_plugin_only=1
+      ;;
+    --force)
+      force=1
+      ;;
+    --remove)
+      remove=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      fail "unknown option: $1"
+      ;;
+  esac
+  shift
+done
+
+(( !(force && remove) )) || fail "--force and --remove cannot be used together"
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -L)
+plugin_dir=$(cd -- "$script_dir/.." && pwd -L)
+
+if ((installed_plugin_only)); then
+  expected_plugin_dir="${HOME:?HOME is required}/.config/omarchy/plugins/$plugin_id"
+  [[ $plugin_dir == "$expected_plugin_dir" ]] || exit 0
+fi
+
+config_home="${XDG_CONFIG_HOME:-${HOME:?HOME is required}/.config}"
+bindings_file="${OMAPILOT_HOTKEYS_BINDINGS_FILE:-$config_home/hypr/bindings.lua}"
+state_root="${XDG_STATE_HOME:-$HOME/.local/state}"
+state_dir="${OMAPILOT_HOTKEYS_STATE_DIR:-$state_root/omapilot}"
+once_marker="$state_dir/hotkeys-v1"
+lock_file="$state_dir/hotkeys.lock"
+
+mkdir -p -- "$state_dir"
+command -v flock >/dev/null || fail "flock is required"
+exec 9>"$lock_file"
+flock 9
+
+if ((once)) && [[ -f $once_marker ]]; then
+  exit 0
+fi
+
+[[ -f $bindings_file ]] || fail "Hyprland bindings file not found: $bindings_file"
+
+reload_hyprland() {
+  [[ ${OMAPILOT_HOTKEYS_NO_RELOAD:-0} != 1 ]] || return 0
+  command -v hyprctl >/dev/null || return 0
+  [[ -n ${HYPRLAND_INSTANCE_SIGNATURE:-} ]] || return 0
+
+  hyprctl reload >/dev/null || fail "Hyprland reload failed"
+  local errors
+  errors=$(hyprctl configerrors)
+  if [[ -n ${errors//[[:space:]]/} ]]; then
+    printf 'install-hotkeys: Hyprland reported configuration errors:\n%s\n' "$errors" >&2
+    return 1
+  fi
+}
+
+marker_count() {
+  local marker="$1"
+  grep -Fxc -- "$marker" "$bindings_file" || true
+}
+
+begin_count=$(marker_count "$begin_marker")
+end_count=$(marker_count "$end_marker")
+(( begin_count <= 1 && end_count <= 1 && begin_count == end_count )) ||
+  fail "refusing to edit malformed OmaPilot markers in $bindings_file"
+
+remove_managed_block() {
+  local temporary
+  temporary=$(mktemp "$state_dir/bindings.XXXXXX")
+  awk -v begin="$begin_marker" -v end="$end_marker" '
+    $0 == begin { managed = 1; next }
+    $0 == end { managed = 0; next }
+    !managed { print }
+  ' "$bindings_file" >"$temporary"
+  cat "$temporary" >"$bindings_file"
+  rm -f -- "$temporary"
+}
+
+if ((remove)); then
+  if ((begin_count == 1)); then
+    remove_managed_block
+    reload_hyprland
+  fi
+  printf 'removed\n' >"$once_marker"
+  exit 0
+fi
+
+if ((begin_count == 1)); then
+  if ((force)); then
+    remove_managed_block
+  else
+    reload_hyprland
+    printf 'installed\n' >"$once_marker"
+    exit 0
+  fi
+fi
+
+has_user_binding() {
+  local chord="$1"
+  awk -v chord="$chord" '
+    /^[[:space:]]*(o\.bind|hl\.bind|hl\.unbind)[[:space:]]*\(/ &&
+      index($0, "\"" chord "\"") { found = 1; exit }
+    END { exit !found }
+  ' "$bindings_file"
+}
+
+chords=(
+  "SUPER + A"
+  "SUPER + SHIFT + A"
+  "SUPER + ALT + N"
+  "SUPER + ALT + H"
+)
+descriptions=(
+  "Talk to OmaPilot"
+  "New OmaPilot voice chat"
+  "New OmaPilot chat"
+  "Continue OmaPilot chat in Herdr"
+)
+commands=(
+  "omarchy-shell -q io.github.spencerbull.omapilot voiceToggle"
+  "omarchy-shell -q io.github.spencerbull.omapilot newVoiceChat"
+  "omarchy-shell -q io.github.spencerbull.omapilot newChat"
+  "omarchy-shell -q io.github.spencerbull.omapilot continueInHerdr"
+)
+
+block_file=$(mktemp "$state_dir/hotkeys.XXXXXX")
+candidate_file=$(mktemp "$state_dir/bindings-candidate.XXXXXX")
+trap 'rm -f -- "${block_file:-}" "${candidate_file:-}"' EXIT
+
+installed_count=0
+{
+  printf '%s\n' "$begin_marker"
+  printf '%s\n' '-- Added once by the installed OmaPilot plugin. Edit these bindings freely.'
+  for index in "${!chords[@]}"; do
+    if ((!force)) && has_user_binding "${chords[$index]}"; then
+      printf 'install-hotkeys: leaving existing %s binding unchanged\n' \
+        "${chords[$index]}" >&2
+      continue
+    fi
+
+    printf 'hl.unbind("%s")\n' "${chords[$index]}"
+    printf 'o.bind("%s", "%s",\n  "%s")\n' \
+      "${chords[$index]}" "${descriptions[$index]}" "${commands[$index]}"
+    installed_count=$((installed_count + 1))
+  done
+  printf '%s\n' "$end_marker"
+} >"$block_file"
+
+if ((installed_count > 0)); then
+  {
+    cat "$bindings_file"
+    printf '\n'
+    cat "$block_file"
+  } >"$candidate_file"
+
+  if command -v luac >/dev/null; then
+    luac -p "$candidate_file" || fail "generated bindings are not valid Lua"
+  fi
+
+  printf '\n' >>"$bindings_file"
+  cat "$block_file" >>"$bindings_file"
+  reload_hyprland
+fi
+
+printf 'installed\n' >"$once_marker"

--- a/scripts/install-hotkeys.sh
+++ b/scripts/install-hotkeys.sh
@@ -105,6 +105,17 @@ begin_count=$(marker_count "$begin_marker")
 end_count=$(marker_count "$end_marker")
 (( begin_count <= 1 && end_count <= 1 && begin_count == end_count )) ||
   fail "refusing to edit malformed OmaPilot markers in $bindings_file"
+if ((begin_count == 1)); then
+  read -r begin_line end_line < <(
+    awk -v begin="$begin_marker" -v end="$end_marker" '
+      $0 == begin { begin_line = NR }
+      $0 == end { end_line = NR }
+      END { print begin_line, end_line }
+    ' "$bindings_file"
+  )
+  ((begin_line < end_line)) ||
+    fail "refusing to edit reversed OmaPilot markers in $bindings_file"
+fi
 
 remove_managed_block() {
   local temporary
@@ -141,7 +152,8 @@ has_user_binding() {
   local chord="$1"
   awk -v chord="$chord" '
     /^[[:space:]]*(o\.bind|hl\.bind|hl\.unbind)[[:space:]]*\(/ &&
-      index($0, "\"" chord "\"") { found = 1; exit }
+      (index($0, "\"" chord "\"") ||
+       index($0, sprintf("%c%s%c", 39, chord, 39))) { found = 1; exit }
     END { exit !found }
   ' "$bindings_file"
 }

--- a/scripts/install-hotkeys.sh
+++ b/scripts/install-hotkeys.sh
@@ -5,19 +5,17 @@ plugin_id="io.github.spencerbull.omapilot"
 begin_marker="-- BEGIN OmaPilot managed hotkeys"
 end_marker="-- END OmaPilot managed hotkeys"
 
-once=0
 installed_plugin_only=0
 force=0
 remove=0
 
 usage() {
   cat <<'USAGE'
-Usage: scripts/install-hotkeys.sh [--once] [--installed-plugin-only] [--force|--remove]
+Usage: scripts/install-hotkeys.sh [--installed-plugin-only] [--force|--remove]
 
 Install OmaPilot's global bindings into the user's Hyprland bindings.lua.
 
-  --once                   Do nothing after the first automatic attempt.
-  --installed-plugin-only  Run only from OmaPilot's normal installed path.
+  --installed-plugin-only  Require OmaPilot's normal installed path.
   --force                  Replace colliding user bindings for OmaPilot's chords.
   --remove                 Remove only the block managed by this script.
 USAGE
@@ -30,9 +28,6 @@ fail() {
 
 while (($#)); do
   case "$1" in
-    --once)
-      once=1
-      ;;
     --installed-plugin-only)
       installed_plugin_only=1
       ;;
@@ -61,24 +56,20 @@ plugin_dir=$(cd -- "$script_dir/.." && pwd -L)
 
 if ((installed_plugin_only)); then
   expected_plugin_dir="${HOME:?HOME is required}/.config/omarchy/plugins/$plugin_id"
-  [[ $plugin_dir == "$expected_plugin_dir" ]] || exit 0
+  [[ $plugin_dir == "$expected_plugin_dir" ]] ||
+    fail "refusing to edit bindings outside the installed plugin: $expected_plugin_dir"
 fi
 
 config_home="${XDG_CONFIG_HOME:-${HOME:?HOME is required}/.config}"
 bindings_file="${OMAPILOT_HOTKEYS_BINDINGS_FILE:-$config_home/hypr/bindings.lua}"
 state_root="${XDG_STATE_HOME:-$HOME/.local/state}"
 state_dir="${OMAPILOT_HOTKEYS_STATE_DIR:-$state_root/omapilot}"
-once_marker="$state_dir/hotkeys-v1"
 lock_file="$state_dir/hotkeys.lock"
 
 mkdir -p -- "$state_dir"
 command -v flock >/dev/null || fail "flock is required"
 exec 9>"$lock_file"
 flock 9
-
-if ((once)) && [[ -f $once_marker ]]; then
-  exit 0
-fi
 
 [[ -f $bindings_file ]] || fail "Hyprland bindings file not found: $bindings_file"
 
@@ -134,7 +125,6 @@ if ((remove)); then
     remove_managed_block
     reload_hyprland
   fi
-  printf 'removed\n' >"$once_marker"
   exit 0
 fi
 
@@ -143,7 +133,6 @@ if ((begin_count == 1)); then
     remove_managed_block
   else
     reload_hyprland
-    printf 'installed\n' >"$once_marker"
     exit 0
   fi
 fi
@@ -184,7 +173,7 @@ trap 'rm -f -- "${block_file:-}" "${candidate_file:-}"' EXIT
 installed_count=0
 {
   printf '%s\n' "$begin_marker"
-  printf '%s\n' '-- Added once by the installed OmaPilot plugin. Edit these bindings freely.'
+  printf '%s\n' '-- Added at the user request from OmaPilot settings. Edit these bindings freely.'
   for index in "${!chords[@]}"; do
     if ((!force)) && has_user_binding "${chords[$index]}"; then
       printf 'install-hotkeys: leaving existing %s binding unchanged\n' \
@@ -215,5 +204,3 @@ if ((installed_count > 0)); then
   cat "$block_file" >>"$bindings_file"
   reload_hyprland
 fi
-
-printf 'installed\n' >"$once_marker"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -5,11 +5,13 @@ repo_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
 cd "$repo_root"
 
 ./scripts/check-manifest.sh
+./tests/test-hotkey-installer.sh
 node ./browser-companion/scripts/check.mjs
 
 if command -v shellcheck >/dev/null && shellcheck --version >/dev/null 2>&1; then
   mapfile -t shell_files < <(find scripts browser-companion -type f \
     \( -name '*.sh' -o -name 'omapilot-browser-companion-host' \) -print | sort)
+  shell_files+=(tests/test-hotkey-installer.sh)
   shellcheck "${shell_files[@]}"
 else
   printf 'validate: shellcheck unavailable; skipping shell lint\n' >&2

--- a/tests/check-ui-contract.sh
+++ b/tests/check-ui-contract.sh
@@ -55,8 +55,19 @@ grep -Fq 'Quickshell.env("OMAPILOT_BROKER_PATH") || bundledBrokerPath' \
   "$repo_dir/components/OmaPilotStore.qml"
 grep -Fq 'Qt.resolvedUrl("../scripts/install-hotkeys.sh")' \
   "$repo_dir/components/OmaPilotStore.qml"
-grep -Fq 'command: [root.hotkeyInstallerPath, "--once", "--installed-plugin-only"]' \
+grep -Fq 'command: [root.hotkeyInstallerPath, "--installed-plugin-only"]' \
   "$repo_dir/components/OmaPilotStore.qml"
+grep -Fq 'running: false' "$repo_dir/components/OmaPilotStore.qml"
+grep -Fq 'function installHotkeys()' "$repo_dir/components/OmaPilotStore.qml"
+grep -Fq 'onHotkeyInstallRequested: OmaPilot.OmaPilotStore.installHotkeys()' \
+  "$repo_dir/Panel.qml"
+grep -Fq 'text: root.hotkeyBusy ? "Updating hotkeys…" : "Install global hotkeys"' \
+  "$repo_dir/components/SettingsView.qml"
+if grep -Fq 'command: [root.hotkeyInstallerPath, "--once"' \
+  "$repo_dir/components/OmaPilotStore.qml"; then
+  printf 'Hotkey installation must require an explicit settings action\n' >&2
+  exit 1
+fi
 grep -Fq -- '-- BEGIN OmaPilot managed hotkeys' \
   "$repo_dir/scripts/install-hotkeys.sh"
 grep -Fq 'property string configuredProvider: "builtin"' \
@@ -506,7 +517,7 @@ grep -Fq 'Protocol.historyContinuationBlocked(' "$repo_dir/components/OmaPilotSt
 grep -Fq 'if (!providerReady || continuationBlocked || busy) return false' "$repo_dir/components/OmaPilotStore.qml"
 grep -Fq 'if (!OmaPilot.OmaPilotStore.submit(spoken))' "$repo_dir/Ambient.qml"
 # The broker's Voxtype OSD switch is a separate config-write boundary from the
-# first-load hotkey helper. It must stay a single-key, comment-preserving,
+# opt-in hotkey helper. It must stay a single-key, comment-preserving,
 # backed-up, user-initiated edit, and the exception must stay documented.
 grep -Fq '.omapilot.bak' "$repo_dir/runtime/src/voxtype-osd.ts"
 grep -Fq 'One separate, narrowly scoped exception exists for Voxtype' \

--- a/tests/check-ui-contract.sh
+++ b/tests/check-ui-contract.sh
@@ -254,12 +254,14 @@ grep -Fq 'Protocol.command("voice_status")' "$repo_dir/components/OmaPilotStore.
 grep -Fq 'Protocol.ttsKeySetCommand(provider, apiKey)' "$repo_dir/components/OmaPilotStore.qml"
 grep -Fq 'onVoiceEnabledRequested:' "$repo_dir/Panel.qml"
 grep -Fq 'if (!OmaPilot.OmaPilotStore.voiceEnabled)' "$repo_dir/Ambient.qml"
-grep -Fq 'function newVoiceChat(): string {' "$repo_dir/Ambient.qml"
+grep -Fq 'function newVoiceChat() {' "$repo_dir/Ambient.qml"
+grep -Fq 'function onIpcNewVoiceChatRequested() { root.newVoiceChat() }' \
+  "$repo_dir/Ambient.qml"
 grep -Fq 'property bool voiceSessionActive: false' "$repo_dir/Ambient.qml"
 grep -Fq 'SessionLifecycle.voiceActivationMode(' "$repo_dir/Ambient.qml"
 grep -Fq 'voiceSessionActive = false' "$repo_dir/Ambient.qml"
-grep -Fq 'session=" + (root.voiceSessionActive ? "active" : "closed")' \
-  "$repo_dir/Ambient.qml"
+grep -Fq 'function status(): string { return "store=" + root.state }' \
+  "$repo_dir/components/OmaPilotStore.qml"
 grep -Fq 'freshVoiceStartPending = freshVoiceStartPending || freshChat' \
   "$repo_dir/Ambient.qml"
 grep -Fq 'property bool freshChatResetInProgress: false' "$repo_dir/Ambient.qml"
@@ -534,10 +536,13 @@ grep -Fq 'errorDetails = Protocol.normalizedError(event, statusMessage)' \
 grep -Fq 'readonly property bool opened:' "$repo_dir/BarWidget.qml"
 grep -Fq 'function closeForPopoutSwitch()' "$repo_dir/BarWidget.qml"
 test "$(grep -Fc 'IpcHandler {' "$repo_dir/components/OmaPilotStore.qml")" -eq 1
-if grep -Fq 'IpcHandler {' "$repo_dir/BarWidget.qml"; then
-  printf 'BarWidget must not register one IPC target per monitor\n' >&2
+if grep -Fq 'IpcHandler {' "$repo_dir/BarWidget.qml" \
+    || grep -Fq 'IpcHandler {' "$repo_dir/Ambient.qml"; then
+  printf 'Only OmaPilotStore may register the plugin IPC target\n' >&2
   exit 1
 fi
+grep -Fq 'function voiceToggle(): string {' "$repo_dir/components/OmaPilotStore.qml"
+grep -Fq 'signal ipcVoiceToggleRequested()' "$repo_dir/components/OmaPilotStore.qml"
 grep -Fq 'function onIpcOpenRequested()' "$repo_dir/BarWidget.qml"
 grep -Fq 'if (root.routedWidget() === root) root.open()' "$repo_dir/BarWidget.qml"
 grep -Fq 'signal ipcOpenRequested()' "$repo_dir/components/OmaPilotStore.qml"
@@ -602,7 +607,7 @@ cp -a "$omarchy_shell/Commons" "$omarchy_shell/Ui" "$smoke_root/"
 OMAPILOT_BROKER_PATH=/usr/bin/false QT_QPA_PLATFORM=wayland \
   timeout 5s quickshell --no-duplicate --path "$smoke_root" --no-color \
   >"$smoke_root/output.log" 2>&1
-if grep -Eq "smoke loader failed|overlay smoke loader failed|Failed to load|Type .* unavailable|Cannot assign" "$smoke_root/output.log"; then
+if grep -Eq "smoke loader failed|overlay smoke loader failed|Failed to load|Type .* unavailable|Cannot assign|Handler was registered but will not be used" "$smoke_root/output.log"; then
   cat "$smoke_root/output.log"
   exit 1
 fi

--- a/tests/check-ui-contract.sh
+++ b/tests/check-ui-contract.sh
@@ -53,6 +53,12 @@ grep -Fq 'Qt.resolvedUrl("../runtime/bin/omapilot-broker")' \
   "$repo_dir/components/OmaPilotStore.qml"
 grep -Fq 'Quickshell.env("OMAPILOT_BROKER_PATH") || bundledBrokerPath' \
   "$repo_dir/components/OmaPilotStore.qml"
+grep -Fq 'Qt.resolvedUrl("../scripts/install-hotkeys.sh")' \
+  "$repo_dir/components/OmaPilotStore.qml"
+grep -Fq 'command: [root.hotkeyInstallerPath, "--once", "--installed-plugin-only"]' \
+  "$repo_dir/components/OmaPilotStore.qml"
+grep -Fq -- '-- BEGIN OmaPilot managed hotkeys' \
+  "$repo_dir/scripts/install-hotkeys.sh"
 grep -Fq 'property string configuredProvider: "builtin"' \
   "$repo_dir/components/OmaPilotStore.qml"
 grep -Fq 'harness: provider' "$repo_dir/components/OmaPilotStore.qml"
@@ -497,11 +503,12 @@ grep -Fq 'continuationProvider = currentChatId !== "" ? historicalProvider : ""'
 grep -Fq 'Protocol.historyContinuationBlocked(' "$repo_dir/components/OmaPilotStore.qml"
 grep -Fq 'if (!providerReady || continuationBlocked || busy) return false' "$repo_dir/components/OmaPilotStore.qml"
 grep -Fq 'if (!OmaPilot.OmaPilotStore.submit(spoken))' "$repo_dir/Ambient.qml"
-# The Voxtype OSD switch is the one place OmaPilot writes another tool's config.
-# It must stay a single-key, comment-preserving, backed-up, user-initiated edit,
-# and the exception must stay documented.
+# The broker's Voxtype OSD switch is a separate config-write boundary from the
+# first-load hotkey helper. It must stay a single-key, comment-preserving,
+# backed-up, user-initiated edit, and the exception must stay documented.
 grep -Fq '.omapilot.bak' "$repo_dir/runtime/src/voxtype-osd.ts"
-grep -Fq 'One narrowly scoped exception exists for Voxtype' "$repo_dir/docs/architecture.md"
+grep -Fq 'One separate, narrowly scoped exception exists for Voxtype' \
+  "$repo_dir/docs/architecture.md"
 if grep -Eq 'writeFileSync\(configPath' "$repo_dir/runtime/src/voxtype-osd.ts"; then
   printf 'Voxtype config must be replaced atomically, not written in place\n' >&2
   exit 1

--- a/tests/test-hotkey-installer.sh
+++ b/tests/test-hotkey-installer.sh
@@ -25,6 +25,7 @@ assert_absent() {
 cat >"$bindings" <<'LUA'
 -- Existing user configuration.
 o.bind("SUPER + A", "My existing assistant", "my-assistant")
+o.bind('SUPER + ALT + N', 'My existing new chat', 'my-new-chat')
 LUA
 
 "$installer" --once --installed-plugin-only
@@ -46,18 +47,21 @@ second_checksum=$(sha256sum "$bindings")
 test "$(grep -Fc -- '-- BEGIN OmaPilot managed hotkeys' "$bindings")" -eq 1
 test "$(grep -Fc -- 'o.bind("SUPER + A", "My existing assistant"' "$bindings")" -eq 1
 assert_absent 'o.bind("SUPER + A", "Talk to OmaPilot"' "$bindings"
+grep -Fq -- "o.bind('SUPER + ALT + N', 'My existing new chat'" "$bindings"
+assert_absent 'o.bind("SUPER + ALT + N", "New OmaPilot chat"' "$bindings"
 grep -Fq -- 'hl.unbind("SUPER + SHIFT + A")' "$bindings"
 grep -Fq -- 'io.github.spencerbull.omapilot newVoiceChat' "$bindings"
-grep -Fq -- 'io.github.spencerbull.omapilot newChat' "$bindings"
 grep -Fq -- 'io.github.spencerbull.omapilot continueInHerdr' "$bindings"
 grep -Fxq -- 'installed' "$XDG_STATE_HOME/omapilot/hotkeys-v1"
 
 "$installed_installer" --force
 grep -Fq -- 'o.bind("SUPER + A", "Talk to OmaPilot"' "$bindings"
+grep -Fq -- 'io.github.spencerbull.omapilot newChat' "$bindings"
 test "$(grep -Fc -- '-- BEGIN OmaPilot managed hotkeys' "$bindings")" -eq 1
 
 "$installed_installer" --remove
 grep -Fq -- 'My existing assistant' "$bindings"
+grep -Fq -- 'My existing new chat' "$bindings"
 assert_absent '-- BEGIN OmaPilot managed hotkeys' "$bindings"
 grep -Fxq -- 'removed' "$XDG_STATE_HOME/omapilot/hotkeys-v1"
 
@@ -66,13 +70,35 @@ assert_absent '-- BEGIN OmaPilot managed hotkeys' "$bindings"
 
 "$installed_installer"
 assert_absent 'o.bind("SUPER + A", "Talk to OmaPilot"' "$bindings"
+assert_absent 'o.bind("SUPER + ALT + N", "New OmaPilot chat"' "$bindings"
 test "$(grep -Fc -- '-- BEGIN OmaPilot managed hotkeys' "$bindings")" -eq 1
 
 "$installed_installer" --remove
+clean_bindings="$test_root/clean-bindings.lua"
+cp -- "$bindings" "$clean_bindings"
+for mode in --remove --force; do
+  cp -- "$clean_bindings" "$bindings"
+  printf '%s\n' \
+    '-- END OmaPilot managed hotkeys' \
+    '-- user configuration between reversed markers' \
+    '-- BEGIN OmaPilot managed hotkeys' \
+    '-- user configuration after reversed markers' >>"$bindings"
+  reversed_checksum=$(sha256sum "$bindings")
+  if "$installed_installer" "$mode" 2>/dev/null; then
+    printf 'expected reversed marker check to fail for %s\n' "$mode" >&2
+    exit 1
+  fi
+  test "$(sha256sum "$bindings")" = "$reversed_checksum"
+  grep -Fq -- '-- user configuration after reversed markers' "$bindings"
+done
+
+cp -- "$clean_bindings" "$bindings"
 printf '%s\n' '-- BEGIN OmaPilot managed hotkeys' >>"$bindings"
+unmatched_checksum=$(sha256sum "$bindings")
 if "$installed_installer" 2>/dev/null; then
   printf 'expected malformed marker check to fail\n' >&2
   exit 1
 fi
+test "$(sha256sum "$bindings")" = "$unmatched_checksum"
 
 printf 'Hotkey installer tests: ok\n'

--- a/tests/test-hotkey-installer.sh
+++ b/tests/test-hotkey-installer.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+installer="$repo_root/scripts/install-hotkeys.sh"
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/omapilot-hotkeys-test.XXXXXX")
+trap 'rm -rf -- "$test_root"' EXIT
+
+export HOME="$test_root/home"
+export XDG_CONFIG_HOME="$HOME/.config"
+export XDG_STATE_HOME="$HOME/.local/state"
+export OMAPILOT_HOTKEYS_NO_RELOAD=1
+bindings="$XDG_CONFIG_HOME/hypr/bindings.lua"
+mkdir -p -- "$(dirname -- "$bindings")"
+
+assert_absent() {
+  local needle="$1"
+  local file="$2"
+  if grep -Fq -- "$needle" "$file"; then
+    printf 'unexpected text in %s: %s\n' "$file" "$needle" >&2
+    exit 1
+  fi
+}
+
+cat >"$bindings" <<'LUA'
+-- Existing user configuration.
+o.bind("SUPER + A", "My existing assistant", "my-assistant")
+LUA
+
+"$installer" --once --installed-plugin-only
+[[ ! -e $XDG_STATE_HOME/omapilot/hotkeys-v1 ]]
+assert_absent '-- BEGIN OmaPilot managed hotkeys' "$bindings"
+
+installed_dir="$HOME/.config/omarchy/plugins/io.github.spencerbull.omapilot"
+installed_installer="$installed_dir/scripts/install-hotkeys.sh"
+mkdir -p -- "$(dirname -- "$installed_installer")"
+cp -- "$installer" "$installed_installer"
+chmod 0755 "$installed_installer"
+
+"$installed_installer" --once --installed-plugin-only
+first_checksum=$(sha256sum "$bindings")
+"$installed_installer" --once --installed-plugin-only
+second_checksum=$(sha256sum "$bindings")
+[[ $first_checksum == "$second_checksum" ]]
+
+test "$(grep -Fc -- '-- BEGIN OmaPilot managed hotkeys' "$bindings")" -eq 1
+test "$(grep -Fc -- 'o.bind("SUPER + A", "My existing assistant"' "$bindings")" -eq 1
+assert_absent 'o.bind("SUPER + A", "Talk to OmaPilot"' "$bindings"
+grep -Fq -- 'hl.unbind("SUPER + SHIFT + A")' "$bindings"
+grep -Fq -- 'io.github.spencerbull.omapilot newVoiceChat' "$bindings"
+grep -Fq -- 'io.github.spencerbull.omapilot newChat' "$bindings"
+grep -Fq -- 'io.github.spencerbull.omapilot continueInHerdr' "$bindings"
+grep -Fxq -- 'installed' "$XDG_STATE_HOME/omapilot/hotkeys-v1"
+
+"$installed_installer" --force
+grep -Fq -- 'o.bind("SUPER + A", "Talk to OmaPilot"' "$bindings"
+test "$(grep -Fc -- '-- BEGIN OmaPilot managed hotkeys' "$bindings")" -eq 1
+
+"$installed_installer" --remove
+grep -Fq -- 'My existing assistant' "$bindings"
+assert_absent '-- BEGIN OmaPilot managed hotkeys' "$bindings"
+grep -Fxq -- 'removed' "$XDG_STATE_HOME/omapilot/hotkeys-v1"
+
+"$installed_installer" --once --installed-plugin-only
+assert_absent '-- BEGIN OmaPilot managed hotkeys' "$bindings"
+
+"$installed_installer"
+assert_absent 'o.bind("SUPER + A", "Talk to OmaPilot"' "$bindings"
+test "$(grep -Fc -- '-- BEGIN OmaPilot managed hotkeys' "$bindings")" -eq 1
+
+"$installed_installer" --remove
+printf '%s\n' '-- BEGIN OmaPilot managed hotkeys' >>"$bindings"
+if "$installed_installer" 2>/dev/null; then
+  printf 'expected malformed marker check to fail\n' >&2
+  exit 1
+fi
+
+printf 'Hotkey installer tests: ok\n'

--- a/tests/test-hotkey-installer.sh
+++ b/tests/test-hotkey-installer.sh
@@ -28,8 +28,10 @@ o.bind("SUPER + A", "My existing assistant", "my-assistant")
 o.bind('SUPER + ALT + N', 'My existing new chat', 'my-new-chat')
 LUA
 
-"$installer" --once --installed-plugin-only
-[[ ! -e $XDG_STATE_HOME/omapilot/hotkeys-v1 ]]
+if "$installer" --installed-plugin-only 2>/dev/null; then
+  printf 'expected development-path installation to fail closed\n' >&2
+  exit 1
+fi
 assert_absent '-- BEGIN OmaPilot managed hotkeys' "$bindings"
 
 installed_dir="$HOME/.config/omarchy/plugins/io.github.spencerbull.omapilot"
@@ -38,9 +40,9 @@ mkdir -p -- "$(dirname -- "$installed_installer")"
 cp -- "$installer" "$installed_installer"
 chmod 0755 "$installed_installer"
 
-"$installed_installer" --once --installed-plugin-only
+"$installed_installer" --installed-plugin-only
 first_checksum=$(sha256sum "$bindings")
-"$installed_installer" --once --installed-plugin-only
+"$installed_installer" --installed-plugin-only
 second_checksum=$(sha256sum "$bindings")
 [[ $first_checksum == "$second_checksum" ]]
 
@@ -52,8 +54,6 @@ assert_absent 'o.bind("SUPER + ALT + N", "New OmaPilot chat"' "$bindings"
 grep -Fq -- 'hl.unbind("SUPER + SHIFT + A")' "$bindings"
 grep -Fq -- 'io.github.spencerbull.omapilot newVoiceChat' "$bindings"
 grep -Fq -- 'io.github.spencerbull.omapilot continueInHerdr' "$bindings"
-grep -Fxq -- 'installed' "$XDG_STATE_HOME/omapilot/hotkeys-v1"
-
 "$installed_installer" --force
 grep -Fq -- 'o.bind("SUPER + A", "Talk to OmaPilot"' "$bindings"
 grep -Fq -- 'io.github.spencerbull.omapilot newChat' "$bindings"
@@ -62,10 +62,6 @@ test "$(grep -Fc -- '-- BEGIN OmaPilot managed hotkeys' "$bindings")" -eq 1
 "$installed_installer" --remove
 grep -Fq -- 'My existing assistant' "$bindings"
 grep -Fq -- 'My existing new chat' "$bindings"
-assert_absent '-- BEGIN OmaPilot managed hotkeys' "$bindings"
-grep -Fxq -- 'removed' "$XDG_STATE_HOME/omapilot/hotkeys-v1"
-
-"$installed_installer" --once --installed-plugin-only
 assert_absent '-- BEGIN OmaPilot managed hotkeys' "$bindings"
 
 "$installed_installer"


### PR DESCRIPTION
## Summary

- consolidate all OmaPilot typed-chat and ambient voice actions under one IPC handler so the documented `omarchy-shell` commands work without duplicate-target registration
- add global hotkeys only after the user explicitly chooses **Settings → Desktop → Install global hotkeys**
- preserve existing shortcut chords by default, validate the generated Lua, reload Hyprland, and limit removal to the marked OmaPilot block
- document the user-configuration ownership and marketplace-consent boundary
- add regression coverage for the installer and duplicate IPC registration

## Validation

- PR #24 `validate` and `package` checks passed
- `./tests/test-hotkey-installer.sh`
- ShellCheck 0.11.0
- `./tests/check-ui-contract.sh`
- `./scripts/validate.sh`
- 25 test files passed, 243 tests passed, and 8 live-provider tests skipped
- generated runtime and browser-companion artifacts remained unchanged

## Submission gate

This makes the marketplace statement that OmaPilot does not overwrite user configuration without explicit consent accurate. Before merging this PR, install its exact revision and verify the opt-in button plus the documented native voice hotkey end to end on the laptop display.