### PR TITLE
Guide first-run OmaPilot setup

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -40,9 +40,17 @@ Panel {
     ? Protocol.normalizedWebHandoffProvider(settings.webHandoffProvider) : "duckduckgo"
   readonly property bool voiceEnabled: settings && settings.voiceEnabled === true
   readonly property string ttsProvider: settings && Protocol.normalizedTtsProvider(settings.ttsProvider)
-    ? Protocol.normalizedTtsProvider(settings.ttsProvider) : "kokoro"
+    ? Protocol.normalizedTtsProvider(settings.ttsProvider) : "elevenlabs"
   readonly property string ttsModel: settings && typeof settings.ttsModel === "string" ? settings.ttsModel : ""
   readonly property string ttsVoice: settings && typeof settings.ttsVoice === "string" ? settings.ttsVoice : ""
+  readonly property bool onboardingComplete: settings && settings.onboardingComplete === true
+  readonly property var selectedTtsCatalog: Protocol.ttsProviderStatus(
+    OmaPilot.OmaPilotStore.voiceStatus, root.ttsProvider)
+  readonly property bool voiceSetupReady: root.voiceEnabled
+    && root.selectedTtsCatalog && root.selectedTtsCatalog.available === true
+  readonly property string setupStage: Presentation.setupStage(
+    OmaPilot.OmaPilotStore.providerReady, root.voiceEnabled,
+    root.voiceSetupReady, root.onboardingComplete)
   readonly property string quickActionsJson: settings
     && typeof settings.quickActionsJson === "string" ? settings.quickActionsJson : ""
   readonly property var quickActionItems: ActionCatalog.actionsFromSettings(
@@ -188,7 +196,8 @@ Panel {
     Qt.callLater(function() { historyView.forceInitialFocus() })
   }
 
-  function openSettings() {
+  function openSettings(tab) {
+    if (tab) settingsView.selectTab(tab)
     viewMode = "settings"
     OmaPilot.OmaPilotStore.requestCustomProviders()
     OmaPilot.OmaPilotStore.requestVoxtypeOsd()
@@ -274,6 +283,9 @@ Panel {
         OmaPilot.OmaPilotStore.toastRequested("Context capture overlay could not be opened")
     }
     function onContextBrowserPickerRequested() { root.closeForExternalHandoff() }
+    function onHotkeyInstalled() {
+      if (root.voiceSetupReady) root.persistSettings({ onboardingComplete: true })
+    }
   }
 
   Shortcut {
@@ -366,6 +378,21 @@ Panel {
           onSubmitted: answerScroll.resetForNewTurn()
           onHistoryRequested: root.viewMode === "history" ? root.showChat() : root.openHistory()
           onEscapeRequested: root.close()
+        }
+
+        OmaPilot.SetupGuide {
+          id: setupGuide
+          Layout.fillWidth: true
+          visible: (root.setupStage === "voice" || root.setupStage === "hotkeys")
+            && OmaPilot.OmaPilotStore.question === ""
+            && OmaPilot.OmaPilotStore.answerMarkdown === ""
+            && !OmaPilot.OmaPilotStore.busy
+          stage: root.setupStage
+          foreground: root.foreground
+          background: root.surface
+          accent: root.accent
+          fontFamily: root.fontFamily
+          onActionRequested: root.openSettings(root.setupStage === "voice" ? "voice" : "desktop")
         }
         // The answer, unboxed. It used to live in a filled, bordered card with a
         // runner travelling its perimeter — a window inside a window. Now it sits
@@ -982,7 +1009,7 @@ Panel {
           root.persistSettings({ voiceEnabled: enabled === true })
         }
         onTtsProviderRequested: function(provider) {
-          var selected = Protocol.normalizedTtsProvider(provider) || "kokoro"
+          var selected = Protocol.normalizedTtsProvider(provider) || "elevenlabs"
           var catalog = Protocol.ttsProviderStatus(OmaPilot.OmaPilotStore.voiceStatus, selected)
           var model = Protocol.ttsDefaultModel(catalog)
           var voice = Protocol.ttsDefaultVoice(catalog, model)

--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ compact error notice opens an inspectable details pane.
   broker and Codex ACP payloads but execute them with the system Node runtime.
 - Credentials for the built-in harness, or an installed and authenticated ACP harness.
 - Optional: Voxtype for dictation and Herdr for durable continuation.
-- Optional: a TTS provider to speak answers. Kokoro is local
-  (`pip install kokoro soundfile` on Python 3.10–3.12, plus `espeak-ng`).
-  ElevenLabs and OpenAI need an API key entered in Settings; keys are stored
+- Optional: a TTS provider to speak answers. ElevenLabs is the guided default
+  and needs an API key entered in Settings. Kokoro is local
+  (`pip install kokoro soundfile` on Python 3.10–3.12, plus `espeak-ng`), while
+  OpenAI also needs an API key. Cloud keys are stored
   in `~/.config/omapilot/voice-auth.json`, not widget settings. Voice stays
   off until enabled there.
 - `grim` for contextual screenshots. ImageMagick, already used by OmaPilot's
@@ -71,6 +72,11 @@ inside the broker, opens the provider's browser page for OAuth when needed, and
 renders provider choices, device codes, progress, and errors in Settings.
 Browser OAuth completes through a broker-owned localhost callback; callback
 URLs are never user input. It never opens the Pi terminal.
+
+After authentication, the empty conversation shows the next first-run step:
+configure Voice with ElevenLabs, then open Desktop settings and explicitly press
+**Install global hotkeys**. Chat remains usable throughout; setup never edits
+Hyprland configuration without that final button press.
 
 ## Install
 

--- a/TODO.md
+++ b/TODO.md
@@ -1278,7 +1278,7 @@ turn per provider.
   - [x] Render and exercise the first-run states in the local UI.
   - [ ] Receive a clean independent Fable review or resolve every finding.
   - [x] Commit, push, and open PR 26 against `dev`.
-  - [ ] Confirm PR 26 CI passes on the final head.
+  - [x] Confirm PR 26 CI passes on the published implementation head.
 - Worker state: `HERDR_ENV` is unset in this T3 session, so no named Herdr
   worker may be started or controlled. The required Fable review remains a PR
   checkpoint. After local validation, the owner explicitly instructed the
@@ -1297,3 +1297,5 @@ turn per provider.
   this session is outside Herdr. The reviewed candidate was committed as
   `79e53ab`; PR 26 is open at
   `https://github.com/spencerbull/omarchy-omapilot/pull/26` against `dev`.
+  GitHub CI passed `validate` in 1m42s and `package` in 23s on the published
+  implementation-plus-publication-ledger head `a996e10`.

--- a/TODO.md
+++ b/TODO.md
@@ -1277,10 +1277,12 @@ turn per provider.
   - [x] Pass focused tests, full validation, generated-artifact, and diff gates.
   - [x] Render and exercise the first-run states in the local UI.
   - [ ] Receive a clean independent Fable review or resolve every finding.
-  - [ ] Commit, push, inspect CI, and open the PR against `dev`.
+  - [x] Commit, push, and open PR 26 against `dev`.
+  - [ ] Confirm PR 26 CI passes on the final head.
 - Worker state: `HERDR_ENV` is unset in this T3 session, so no named Herdr
-  worker may be started or controlled yet. The required Fable review remains a
-  checkpoint; the orchestrator owns implementation and local verification.
+  worker may be started or controlled. The required Fable review remains a PR
+  checkpoint. After local validation, the owner explicitly instructed the
+  orchestrator to publish the PR before that review could run.
 - Current checkpoint: the existing authentication recovery remains unchanged;
   authenticated empty chats now show Voice step 2 and Global keybinds step 3.
   Voice opens with ElevenLabs selected, and Desktop opens with the explicit
@@ -1292,4 +1294,6 @@ turn per provider.
   Git whitespace gates. Shellcheck is unavailable and skipped. Rendered evidence
   is in ignored `screenshots/implementation-omapilot-{setup-voice,setup-hotkeys,
   voice-settings,desktop-settings}.png`. Fable review remains pending because
-  this session is outside Herdr.
+  this session is outside Herdr. The reviewed candidate was committed as
+  `79e53ab`; PR 26 is open at
+  `https://github.com/spencerbull/omarchy-omapilot/pull/26` against `dev`.

--- a/TODO.md
+++ b/TODO.md
@@ -1251,3 +1251,45 @@ turn per provider.
   uncommitted policy-copy edits were restored byte-for-byte and remain owned by
   their original author. No account setup, user configuration, push, install,
   shell restart, or live personal-data read occurred.
+
+## Guided first-run setup checkpoint 14 (2026-08-23)
+
+- Goal: turn OmaPilot's existing authentication failure recovery into a small,
+  ordered first-run path that continues through voice and explicit global-hotkey
+  setup.
+- Done criteria: unauthenticated users retain the existing sign-in recovery;
+  successful authentication reveals a focused Voice next step; new installs
+  default to ElevenLabs; completing voice reveals a shortcut next step that
+  opens the existing explicit-consent Global hotkeys control; successful hotkey
+  installation persists setup completion; focused, full, rendered/runtime, and
+  independent Fable review gates pass; a PR is opened against `dev`.
+- Branch/worktree: `feat/oobe-guided-setup` at
+  `/home/sbull/.t3/worktrees/omarchy-omapilot/t3code-bb33724e`, based exactly on
+  `origin/dev` commit `cb34395`.
+- Allowed: scoped QML, manifest, docs/tests, local build and rendered/runtime
+  verification, commit, push, and PR creation. Forbidden: merge, release,
+  production/customer data, secrets, billing, edits to other worktrees, or
+  implicit hotkey installation without the user's button press.
+- Verification gates:
+  - [x] Align the isolated worktree to current `origin/dev` and inventory the
+    authentication, voice, and explicit-consent hotkey paths.
+  - [x] Implement the ordered setup guide and ElevenLabs default with coverage.
+  - [x] Pass focused tests, full validation, generated-artifact, and diff gates.
+  - [x] Render and exercise the first-run states in the local UI.
+  - [ ] Receive a clean independent Fable review or resolve every finding.
+  - [ ] Commit, push, inspect CI, and open the PR against `dev`.
+- Worker state: `HERDR_ENV` is unset in this T3 session, so no named Herdr
+  worker may be started or controlled yet. The required Fable review remains a
+  checkpoint; the orchestrator owns implementation and local verification.
+- Current checkpoint: the existing authentication recovery remains unchanged;
+  authenticated empty chats now show Voice step 2 and Global keybinds step 3.
+  Voice opens with ElevenLabs selected, and Desktop opens with the explicit
+  installer visible. Completion is persisted only after voice is ready and the
+  existing hotkey installer exits successfully; the user remains in Settings to
+  see its result. `./scripts/validate.sh` passes 243 runtime tests with 8 opt-in
+  live-provider skips plus manifest, hotkey, browser, release, typecheck, lint,
+  build, QML/UI, native Wayland smoke, rendered-state, plugin-validation, and
+  Git whitespace gates. Shellcheck is unavailable and skipped. Rendered evidence
+  is in ignored `screenshots/implementation-omapilot-{setup-voice,setup-hotkeys,
+  voice-settings,desktop-settings}.png`. Fable review remains pending because
+  this session is outside Herdr.

--- a/components/OmaPilotStore.qml
+++ b/components/OmaPilotStore.qml
@@ -64,7 +64,7 @@ Scope {
   property real ttsLevel: 0
   property string ttsSpeakId: ""
   property bool voiceEnabled: false
-  property string ttsProvider: "kokoro"
+  property string ttsProvider: "elevenlabs"
   property string ttsModel: ""
   property string ttsVoice: ""
   // Last server-registration failure, surfaced in settings rather than the chat
@@ -147,6 +147,7 @@ Scope {
   signal contextOverlayRequested(string payload)
   signal contextBrowserPickerRequested()
   signal ttsSpoken()
+  signal hotkeyInstalled()
   signal contextAttachmentAdded()
 
   function routeIpc(method) {
@@ -168,7 +169,7 @@ Scope {
     var desiredDesktopContext = String(source.desktopContext || "On") !== "Off"
     var desiredWebHandoffProvider = Protocol.normalizedWebHandoffProvider(source.webHandoffProvider) || "duckduckgo"
     var desiredVoiceEnabled = source.voiceEnabled === true
-    var desiredTtsProvider = Protocol.normalizedTtsProvider(source.ttsProvider) || "kokoro"
+    var desiredTtsProvider = Protocol.normalizedTtsProvider(source.ttsProvider) || "elevenlabs"
     var desiredTtsModel = String(source.ttsModel || "")
     var desiredTtsVoice = String(source.ttsVoice || "")
     var harnessChanged = desiredProvider !== configuredProvider
@@ -1156,6 +1157,7 @@ Scope {
         root.hotkeyMessage = root.hotkeyAction === "remove"
           ? "Managed global hotkeys removed."
           : "Global hotkeys installed. Existing bindings were preserved."
+        if (root.hotkeyAction === "install") root.hotkeyInstalled()
       } else {
         root.hotkeyMessage = root.hotkeyProcessError !== ""
           ? root.hotkeyProcessError

--- a/components/Presentation.js
+++ b/components/Presentation.js
@@ -37,6 +37,13 @@ function permissionNotice(dangerousAutoApprove) {
     : "Device changes require an exact approval."
 }
 
+function setupStage(providerReady, voiceEnabled, ttsReady, onboardingComplete) {
+  if (providerReady !== true) return "authentication"
+  if (onboardingComplete === true) return "complete"
+  if (voiceEnabled !== true || ttsReady !== true) return "voice"
+  return "hotkeys"
+}
+
 function responsePhase(state, hasAnswer) {
   var value = String(state || "")
   var contentVisible = hasAnswer === true

--- a/components/Protocol.js
+++ b/components/Protocol.js
@@ -579,8 +579,8 @@ function normalizedTtsProvider(value) {
 
 function ttsProviderOptions() {
   return [
-    { value: "kokoro", label: "Kokoro (local)" },
     { value: "elevenlabs", label: "ElevenLabs" },
+    { value: "kokoro", label: "Kokoro (local)" },
     { value: "openai", label: "OpenAI" }
   ]
 }
@@ -663,7 +663,7 @@ function normalizedVoiceStatus(event) {
 }
 
 function ttsProviderStatus(status, provider) {
-  var id = normalizedTtsProvider(provider) || "kokoro"
+  var id = normalizedTtsProvider(provider) || "elevenlabs"
   var rows = status && Array.isArray(status.tts) ? status.tts : []
   for (var i = 0; i < rows.length; i++)
     if (String(rows[i] && rows[i].id || "") === id) return rows[i]
@@ -753,7 +753,7 @@ function ttsKeyTestCommand(provider, apiKey) {
 function ttsSpeakCommand(id, provider, model, voice, text) {
   var payload = {
     id: String(id || ""),
-    provider: normalizedTtsProvider(provider) || "kokoro",
+    provider: normalizedTtsProvider(provider) || "elevenlabs",
     text: String(text || "").slice(0, 8000)
   }
   var selectedModel = String(model || "").trim()

--- a/components/SettingsView.qml
+++ b/components/SettingsView.qml
@@ -31,7 +31,7 @@ Item {
   readonly property var voiceStatus: backend && backend.voiceStatus
     ? backend.voiceStatus : Protocol.emptyVoiceStatus()
   property bool voiceEnabled: false
-  property string ttsProvider: "kokoro"
+  property string ttsProvider: "elevenlabs"
   property string ttsModel: ""
   property string ttsVoice: ""
   property string ttsDraftKey: ""
@@ -930,7 +930,7 @@ Item {
           Text {
             Layout.fillWidth: true
             wrapMode: Text.Wrap
-            text: "Kokoro runs locally. ElevenLabs and OpenAI need an API key, stored in voice-auth.json — never in widget settings."
+            text: "ElevenLabs is the guided default. Add its API key here for spoken replies. Kokoro runs locally; cloud keys stay in voice-auth.json — never in widget settings."
             color: root.mutedForeground
             font.family: root.fontFamily
             font.pixelSize: Style.font.caption

--- a/components/SetupGuide.qml
+++ b/components/SetupGuide.qml
@@ -1,0 +1,99 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.Commons
+import qs.Ui
+
+BorderSurface {
+  id: root
+
+  required property string stage
+  property color foreground: Color.popups.text
+  property color background: Color.popups.background
+  property color accent: Color.accent
+  property string fontFamily: Style.font.family
+
+  readonly property bool voiceStage: stage === "voice"
+  readonly property string progressText: voiceStage ? "STEP 2 OF 3" : "STEP 3 OF 3"
+  readonly property string titleText: voiceStage ? "Set up voice" : "Add global keybinds"
+  readonly property string detailText: voiceStage
+    ? "Enable voice and connect ElevenLabs for spoken replies. Listening uses Voxtype."
+    : "Open Desktop settings, then press Install global hotkeys. Existing shortcut chords are preserved."
+  readonly property string actionText: voiceStage ? "Set up voice" : "Open global keybinds"
+
+  signal actionRequested()
+
+  implicitHeight: content.implicitHeight + contentTopInset + contentBottomInset
+    + Style.spacing.xl * 2
+  color: Style.normalFillFor(root.foreground, root.accent)
+  borderSpec: Border.controlSpec("normal", root.foreground, root.accent)
+  radius: Style.cornerRadius
+  Accessible.role: Accessible.Grouping
+  Accessible.name: titleText + ". " + detailText
+
+  ColumnLayout {
+    id: content
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.top: parent.top
+    anchors.leftMargin: parent.contentLeftInset + Style.spacing.xl
+    anchors.rightMargin: parent.contentRightInset + Style.spacing.xl
+    anchors.topMargin: parent.contentTopInset + Style.spacing.xl
+    spacing: Style.spacing.md
+
+    RowLayout {
+      Layout.fillWidth: true
+      spacing: Style.spacing.md
+
+      Text {
+        Layout.fillWidth: true
+        text: "Finish setting up OmaPilot"
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.body
+        font.bold: true
+      }
+
+      Text {
+        text: root.progressText
+        color: root.accent
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.caption
+        font.bold: true
+        font.letterSpacing: 0.7
+      }
+    }
+
+    Text {
+      Layout.fillWidth: true
+      text: root.titleText
+      color: root.foreground
+      font.family: root.fontFamily
+      font.pixelSize: Style.font.subtitle
+      font.bold: true
+      wrapMode: Text.Wrap
+    }
+
+    Text {
+      Layout.fillWidth: true
+      text: root.detailText
+      color: Qt.darker(root.foreground, 1.35)
+      font.family: root.fontFamily
+      font.pixelSize: Style.font.bodySmall
+      wrapMode: Text.Wrap
+    }
+
+    Button {
+      Layout.alignment: Qt.AlignLeft
+      text: root.actionText
+      iconText: root.voiceStage ? "󰍬" : "󰌌"
+      foreground: root.foreground
+      background: root.background
+      accent: root.accent
+      active: true
+      bordered: true
+      focusable: true
+      Accessible.name: text
+      onClicked: root.actionRequested()
+    }
+  }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -30,9 +30,10 @@
       "webHandoffProvider": "duckduckgo",
       "dangerousAutoApprove": false,
       "voiceEnabled": false,
-      "ttsProvider": "kokoro",
+      "ttsProvider": "elevenlabs",
       "ttsModel": "",
-      "ttsVoice": ""
+      "ttsVoice": "",
+      "onboardingComplete": false
     },
     "schema": [
       {
@@ -98,9 +99,9 @@
         "key": "ttsProvider",
         "type": "enum",
         "label": "TTS provider",
-        "options": ["kokoro", "elevenlabs", "openai"],
-        "defaultValue": "kokoro",
-        "description": "Kokoro is local. ElevenLabs and OpenAI need an API key stored in voice-auth.json."
+        "options": ["elevenlabs", "kokoro", "openai"],
+        "defaultValue": "elevenlabs",
+        "description": "ElevenLabs is the guided default. Kokoro is local; ElevenLabs and OpenAI keys are stored in voice-auth.json."
       },
       {
         "key": "ttsModel",

--- a/scripts/check-manifest.sh
+++ b/scripts/check-manifest.sh
@@ -36,9 +36,10 @@ jq -e '
     "webHandoffProvider":"duckduckgo",
     "dangerousAutoApprove":false,
     "voiceEnabled":false,
-    "ttsProvider":"kokoro",
+    "ttsProvider":"elevenlabs",
     "ttsModel":"",
-    "ttsVoice":""
+    "ttsVoice":"",
+    "onboardingComplete":false
   }
   and ([.barWidget.schema[].key] | sort) == (["builtinModel", "codexModel", "dangerousAutoApprove", "desktopContext", "opencodeModel", "provider", "ttsModel", "ttsProvider", "ttsVoice", "voiceEnabled", "webHandoffProvider"] | sort)
   and (.barWidget.schema[] | select(.key == "webHandoffProvider")) == {
@@ -67,9 +68,9 @@ jq -e '
     "key":"ttsProvider",
     "type":"enum",
     "label":"TTS provider",
-    "options":["kokoro", "elevenlabs", "openai"],
-    "defaultValue":"kokoro",
-    "description":"Kokoro is local. ElevenLabs and OpenAI need an API key stored in voice-auth.json."
+    "options":["elevenlabs", "kokoro", "openai"],
+    "defaultValue":"elevenlabs",
+    "description":"ElevenLabs is the guided default. Kokoro is local; ElevenLabs and OpenAI keys are stored in voice-auth.json."
   }
 ' "$manifest" >/dev/null || fail "OmaPilot manifest contract drifted"
 

--- a/scripts/install-hotkeys.sh
+++ b/scripts/install-hotkeys.sh
@@ -189,18 +189,19 @@ installed_count=0
   printf '%s\n' "$end_marker"
 } >"$block_file"
 
-if ((installed_count > 0)); then
-  {
-    cat "$bindings_file"
-    printf '\n'
-    cat "$block_file"
-  } >"$candidate_file"
+((installed_count > 0)) ||
+  fail "no global hotkeys were installed because all shortcut chords are already in use"
 
-  if command -v luac >/dev/null; then
-    luac -p "$candidate_file" || fail "generated bindings are not valid Lua"
-  fi
+{
+  cat "$bindings_file"
+  printf '\n'
+  cat "$block_file"
+} >"$candidate_file"
 
-  printf '\n' >>"$bindings_file"
-  cat "$block_file" >>"$bindings_file"
-  reload_hyprland
+if command -v luac >/dev/null; then
+  luac -p "$candidate_file" || fail "generated bindings are not valid Lua"
 fi
+
+printf '\n' >>"$bindings_file"
+cat "$block_file" >>"$bindings_file"
+reload_hyprland

--- a/tests/check-ui-contract.sh
+++ b/tests/check-ui-contract.sh
@@ -28,6 +28,7 @@ qml_files=(
   "$repo_dir/components/QuickActionEditor.qml"
   "$repo_dir/components/SettingsView.qml"
   "$repo_dir/components/SettingsTabs.qml"
+  "$repo_dir/components/SetupGuide.qml"
   "$repo_dir/components/StateLightBar.qml"
   "$repo_dir/components/ThinkingScanner.qml"
   "$repo_dir/components/VoiceNode.qml"
@@ -63,6 +64,15 @@ grep -Fq 'onHotkeyInstallRequested: OmaPilot.OmaPilotStore.installHotkeys()' \
   "$repo_dir/Panel.qml"
 grep -Fq 'text: root.hotkeyBusy ? "Updating hotkeys…" : "Install global hotkeys"' \
   "$repo_dir/components/SettingsView.qml"
+grep -Fq 'OmaPilot.SetupGuide {' "$repo_dir/Panel.qml"
+grep -Fq 'function setupStage(providerReady, voiceEnabled, ttsReady, onboardingComplete)' \
+  "$repo_dir/components/Presentation.js"
+grep -Fq 'onActionRequested: root.openSettings(root.setupStage === "voice" ? "voice" : "desktop")' \
+  "$repo_dir/Panel.qml"
+grep -Fq 'function onHotkeyInstalled()' "$repo_dir/Panel.qml"
+grep -Fq 'if (root.voiceSetupReady) root.persistSettings({ onboardingComplete: true })' \
+  "$repo_dir/Panel.qml"
+grep -Fq 'signal hotkeyInstalled()' "$repo_dir/components/OmaPilotStore.qml"
 if grep -Fq 'command: [root.hotkeyInstallerPath, "--once"' \
   "$repo_dir/components/OmaPilotStore.qml"; then
   printf 'Hotkey installation must require an explicit settings action\n' >&2
@@ -751,7 +761,8 @@ if grep -Eq "visual preview failed|Failed to load|Type .* unavailable|Cannot ass
   exit 1
 fi
 
-for preview_state in settings skills-settings actions-settings history waiting streaming error error-details context; do
+for preview_state in settings skills-settings voice-settings desktop-settings actions-settings \
+    setup-voice setup-hotkeys history waiting streaming error error-details context; do
   preview_output="$repo_dir/screenshots/implementation-omapilot-$preview_state.png"
   OMAPILOT_PREVIEW_STATE="$preview_state" OMAPILOT_PREVIEW_PATH="$preview_output" \
     QT_QPA_PLATFORM=offscreen timeout 5s quickshell --no-duplicate \

--- a/tests/test-hotkey-installer.sh
+++ b/tests/test-hotkey-installer.sh
@@ -72,6 +72,19 @@ test "$(grep -Fc -- '-- BEGIN OmaPilot managed hotkeys' "$bindings")" -eq 1
 "$installed_installer" --remove
 clean_bindings="$test_root/clean-bindings.lua"
 cp -- "$bindings" "$clean_bindings"
+
+cat >>"$bindings" <<'LUA'
+o.bind("SUPER + SHIFT + A", "My existing voice chat", "my-voice-chat")
+o.bind("SUPER + ALT + H", "My existing handoff", "my-handoff")
+LUA
+all_collisions_checksum=$(sha256sum "$bindings")
+if "$installed_installer" 2>/dev/null; then
+  printf 'expected all-collisions installation to fail without completing setup\n' >&2
+  exit 1
+fi
+test "$(sha256sum "$bindings")" = "$all_collisions_checksum"
+assert_absent '-- BEGIN OmaPilot managed hotkeys' "$bindings"
+
 for mode in --remove --force; do
   cp -- "$clean_bindings" "$bindings"
   printf '%s\n' \

--- a/tests/tst_presentation.qml
+++ b/tests/tst_presentation.qml
@@ -29,6 +29,15 @@ TestCase {
     verify(Presentation.permissionNotice(true).indexOf("auto-approved") >= 0)
   }
 
+  function test_setupAdvancesInOrder() {
+    compare(Presentation.setupStage(false, false, false, false), "authentication")
+    compare(Presentation.setupStage(true, false, false, false), "voice")
+    compare(Presentation.setupStage(true, true, false, false), "voice")
+    compare(Presentation.setupStage(true, true, true, false), "hotkeys")
+    compare(Presentation.setupStage(true, true, true, true), "complete")
+    compare(Presentation.setupStage(true, false, false, true), "complete")
+  }
+
   function test_waitingAndStreamingPhasesDoNotFakeProgress() {
     var waiting = Presentation.responsePhase("preparing", false)
     compare(waiting.label, "WAITING")

--- a/tests/tst_protocol.qml
+++ b/tests/tst_protocol.qml
@@ -415,7 +415,7 @@ TestCase {
     compare(status.dictation.available, true)
     compare(status.tts.length, 2)
     compare(Protocol.normalizedTtsProvider("ElevenLabs"), "elevenlabs")
-    compare(Protocol.ttsProviderOptions()[0].value, "kokoro")
+    compare(Protocol.ttsProviderOptions()[0].value, "elevenlabs")
     var openai = Protocol.ttsProviderStatus(status, "openai")
     compare(Protocol.ttsDefaultModel(openai), "gpt-4o-mini-tts")
     compare(Protocol.ttsVoiceOptions(openai, "tts-1").length, 1)

--- a/tests/visual-preview.qml
+++ b/tests/visual-preview.qml
@@ -87,9 +87,9 @@ ShellRoot {
     property var ttsTest: null
     property string ttsTestError: ""
     property bool voiceEnabled: false
-    property string ttsProvider: "kokoro"
-    property string ttsModel: "kokoro-82m"
-    property string ttsVoice: "af_heart"
+    property string ttsProvider: "elevenlabs"
+    property string ttsModel: "eleven_multilingual_v2"
+    property string ttsVoice: "wyWA56cQNU2KqUW4eCsI"
     property var browserCompanionStatus: ({
       phase: "ready", relayInstalled: false, setupAvailable: true,
       chromiumConnected: false, firefoxConnected: false,
@@ -172,9 +172,13 @@ ShellRoot {
   Window {
     id: previewWindow
     width: 860
-    height: root.previewState === "settings" || root.previewState === "skills-settings" || root.previewState === "dangerous-settings"
+    height: root.previewState === "settings" || root.previewState === "skills-settings"
+      || root.previewState === "voice-settings" || root.previewState === "desktop-settings"
+      || root.previewState === "dangerous-settings"
       || root.previewState === "actions-settings" || root.previewState === "history" ? 760
-      : (root.previewState === "error-details" ? 520 : (root.previewState === "context" ? 430 : 320))
+      : (root.previewState === "error-details" ? 520
+        : (root.previewState === "context" ? 430
+          : (root.previewState === "setup-voice" || root.previewState === "setup-hotkeys" ? 420 : 320)))
     visible: true
     color: "transparent"
     flags: Qt.FramelessWindowHint
@@ -189,7 +193,9 @@ ShellRoot {
       radius: Style.cornerRadius
 
       ColumnLayout {
-        visible: root.previewState === "empty" || root.previewState === "dangerous" || root.previewState === "context"
+        visible: root.previewState === "empty" || root.previewState === "dangerous"
+          || root.previewState === "context" || root.previewState === "setup-voice"
+          || root.previewState === "setup-hotkeys"
         anchors.fill: parent
         anchors.leftMargin: previewSurface.contentLeftInset + Style.spacing.popupPadding
         anchors.rightMargin: previewSurface.contentRightInset + Style.spacing.popupPadding
@@ -221,6 +227,17 @@ ShellRoot {
         OmaPilot.QuickActions {
           id: actions
           Layout.fillWidth: true
+          visible: root.previewState !== "setup-voice" && root.previewState !== "setup-hotkeys"
+          foreground: Color.popups.text
+          background: Color.popups.background
+          accent: Color.accent
+          fontFamily: Style.font.family
+        }
+
+        OmaPilot.SetupGuide {
+          Layout.fillWidth: true
+          visible: root.previewState === "setup-voice" || root.previewState === "setup-hotkeys"
+          stage: root.previewState === "setup-hotkeys" ? "hotkeys" : "voice"
           foreground: Color.popups.text
           background: Color.popups.background
           accent: Color.accent
@@ -232,6 +249,8 @@ ShellRoot {
         id: settingsView
         visible: root.previewState === "settings"
           || root.previewState === "skills-settings"
+          || root.previewState === "voice-settings"
+          || root.previewState === "desktop-settings"
           || root.previewState === "dangerous-settings"
           || root.previewState === "actions-settings"
         anchors.fill: parent
@@ -240,16 +259,17 @@ ShellRoot {
         anchors.topMargin: previewSurface.contentTopInset + Style.spacing.popupPadding
         anchors.bottomMargin: previewSurface.contentBottomInset + Style.spacing.popupPadding
         backend: backend
-        selectedTab: root.previewState === "dangerous-settings" ? "desktop"
+        selectedTab: root.previewState === "dangerous-settings" || root.previewState === "desktop-settings" ? "desktop"
           : (root.previewState === "skills-settings" ? "skills"
+          : (root.previewState === "voice-settings" ? "voice"
           : (root.previewState === "actions-settings" ? "actions" : "agent")
-          )
+          ))
         dangerousAutoApprove: root.previewState === "dangerous-settings"
         desktopContextEnabled: true
         voiceEnabled: false
-        ttsProvider: "kokoro"
-        ttsModel: "kokoro-82m"
-        ttsVoice: "af_heart"
+        ttsProvider: "elevenlabs"
+        ttsModel: "eleven_multilingual_v2"
+        ttsVoice: "wyWA56cQNU2KqUW4eCsI"
         quickActions: root.previewState === "actions-settings"
           ? ActionCatalog.addAction(ActionCatalog.defaultActions(true, true),
             "Research this", "Research this topic using current sources.", 42)


### PR DESCRIPTION
## Summary

- continue the existing authentication recovery with an ordered Voice then Global keybinds setup guide
- make ElevenLabs the default TTS provider for new installs while preserving existing provider choices
- keep hotkey installation explicitly user-triggered and persist onboarding completion only after successful setup

## Validation

- `./scripts/validate.sh`
- 243 runtime tests passed; 8 opt-in live-provider tests skipped
- manifest, hotkey installer, browser companion, release metadata, typecheck, lint, build, QML/UI, native Wayland smoke, rendered setup states, plugin validation, and `git diff --check` passed
- Shellcheck was unavailable and skipped

## Review note

The independent Fable review could not run because the implementation session was not Herdr-managed. The branch was published after the owner explicitly requested the PR following successful validation.