### PR TITLE
Fix voice cancel hotkey installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ hl.unbind("SUPER + SHIFT + A")
 o.bind("SUPER + SHIFT + A", "New OmaPilot voice chat",
   "omarchy-shell -q io.github.spencerbull.omapilot newVoiceChat")
 
+o.bind("SUPER + ALT + X", "Cancel OmaPilot voice mode",
+  "omarchy-shell -q io.github.spencerbull.omapilot voiceCancel")
+
 o.bind("SUPER + ALT + N", "New OmaPilot chat",
   "omarchy-shell -q io.github.spencerbull.omapilot newChat")
 o.bind("SUPER + ALT + H", "Continue OmaPilot chat in Herdr",
@@ -137,14 +140,16 @@ o.bind("SUPER + ALT + H", "Continue OmaPilot chat in Herdr",
 curtain have closed. While that flow remains active, pressing it again finishes
 live dictation or begins a follow-up in the same conversation. The answer timer,
 explicit dismissal, and cancellation close the voice session; they do not erase
-its saved history. `Super+Shift+A` remains the force-new escape hatch. New typed
-chat opens the panel with an empty composer. Continue in Herdr does nothing until
-the current conversation has a saved chat ID.
+its saved history. `Super+Shift+A` remains the force-new escape hatch, while
+`Super+Alt+X` cancels and closes the active voice flow. New typed chat opens the
+panel with an empty composer. Continue in Herdr does nothing until the current
+conversation has a saved chat ID.
 
 The managed block is written only after that explicit action and becomes normal
 user-owned Hyprland configuration. Existing user-defined collisions are left
-alone. To install from a terminal while still preserving collisions, or to
-deliberately replace every chord, run:
+alone. Running the installer again adds newly introduced defaults to its marked
+block without rewriting existing bindings. To install from a terminal while
+still preserving collisions, or to deliberately replace every chord, run:
 
 ```bash
 ~/.config/omarchy/plugins/io.github.spencerbull.omapilot/scripts/install-hotkeys.sh

--- a/scripts/install-hotkeys.sh
+++ b/scripts/install-hotkeys.sh
@@ -128,12 +128,12 @@ if ((remove)); then
   exit 0
 fi
 
+update_existing=0
 if ((begin_count == 1)); then
   if ((force)); then
     remove_managed_block
   else
-    reload_hyprland
-    exit 0
+    update_existing=1
   fi
 fi
 
@@ -150,18 +150,21 @@ has_user_binding() {
 chords=(
   "SUPER + A"
   "SUPER + SHIFT + A"
+  "SUPER + ALT + X"
   "SUPER + ALT + N"
   "SUPER + ALT + H"
 )
 descriptions=(
   "Talk to OmaPilot"
   "New OmaPilot voice chat"
+  "Cancel OmaPilot voice mode"
   "New OmaPilot chat"
   "Continue OmaPilot chat in Herdr"
 )
 commands=(
   "omarchy-shell -q io.github.spencerbull.omapilot voiceToggle"
   "omarchy-shell -q io.github.spencerbull.omapilot newVoiceChat"
+  "omarchy-shell -q io.github.spencerbull.omapilot voiceCancel"
   "omarchy-shell -q io.github.spencerbull.omapilot newChat"
   "omarchy-shell -q io.github.spencerbull.omapilot continueInHerdr"
 )
@@ -172,8 +175,10 @@ trap 'rm -f -- "${block_file:-}" "${candidate_file:-}"' EXIT
 
 installed_count=0
 {
-  printf '%s\n' "$begin_marker"
-  printf '%s\n' '-- Added at the user request from OmaPilot settings. Edit these bindings freely.'
+  if ((!update_existing)); then
+    printf '%s\n' "$begin_marker"
+    printf '%s\n' '-- Added at the user request from OmaPilot settings. Edit these bindings freely.'
+  fi
   for index in "${!chords[@]}"; do
     if ((!force)) && has_user_binding "${chords[$index]}"; then
       printf 'install-hotkeys: leaving existing %s binding unchanged\n' \
@@ -186,22 +191,38 @@ installed_count=0
       "${chords[$index]}" "${descriptions[$index]}" "${commands[$index]}"
     installed_count=$((installed_count + 1))
   done
-  printf '%s\n' "$end_marker"
+  if ((!update_existing)); then
+    printf '%s\n' "$end_marker"
+  fi
 } >"$block_file"
 
-((installed_count > 0)) ||
+if ((installed_count == 0)); then
+  if ((update_existing)); then
+    reload_hyprland
+    exit 0
+  fi
   fail "no global hotkeys were installed because all shortcut chords are already in use"
+fi
 
-{
-  cat "$bindings_file"
-  printf '\n'
-  cat "$block_file"
-} >"$candidate_file"
+if ((update_existing)); then
+  awk -v end="$end_marker" -v additions="$block_file" '
+    $0 == end {
+      while ((getline line < additions) > 0) print line
+      close(additions)
+    }
+    { print }
+  ' "$bindings_file" >"$candidate_file"
+else
+  {
+    cat "$bindings_file"
+    printf '\n'
+    cat "$block_file"
+  } >"$candidate_file"
+fi
 
 if command -v luac >/dev/null; then
   luac -p "$candidate_file" || fail "generated bindings are not valid Lua"
 fi
 
-printf '\n' >>"$bindings_file"
-cat "$block_file" >>"$bindings_file"
+cat "$candidate_file" >"$bindings_file"
 reload_hyprland

--- a/tests/test-hotkey-installer.sh
+++ b/tests/test-hotkey-installer.sh
@@ -53,6 +53,8 @@ grep -Fq -- "o.bind('SUPER + ALT + N', 'My existing new chat'" "$bindings"
 assert_absent 'o.bind("SUPER + ALT + N", "New OmaPilot chat"' "$bindings"
 grep -Fq -- 'hl.unbind("SUPER + SHIFT + A")' "$bindings"
 grep -Fq -- 'io.github.spencerbull.omapilot newVoiceChat' "$bindings"
+grep -Fq -- 'hl.unbind("SUPER + ALT + X")' "$bindings"
+grep -Fq -- 'io.github.spencerbull.omapilot voiceCancel' "$bindings"
 grep -Fq -- 'io.github.spencerbull.omapilot continueInHerdr' "$bindings"
 "$installed_installer" --force
 grep -Fq -- 'o.bind("SUPER + A", "Talk to OmaPilot"' "$bindings"
@@ -75,6 +77,7 @@ cp -- "$bindings" "$clean_bindings"
 
 cat >>"$bindings" <<'LUA'
 o.bind("SUPER + SHIFT + A", "My existing voice chat", "my-voice-chat")
+o.bind("SUPER + ALT + X", "My existing voice cancel", "my-voice-cancel")
 o.bind("SUPER + ALT + H", "My existing handoff", "my-handoff")
 LUA
 all_collisions_checksum=$(sha256sum "$bindings")
@@ -84,6 +87,28 @@ if "$installed_installer" 2>/dev/null; then
 fi
 test "$(sha256sum "$bindings")" = "$all_collisions_checksum"
 assert_absent '-- BEGIN OmaPilot managed hotkeys' "$bindings"
+
+cp -- "$clean_bindings" "$bindings"
+cat >>"$bindings" <<'LUA'
+-- BEGIN OmaPilot managed hotkeys
+-- Legacy block from before the voice-cancel shortcut was added.
+hl.unbind("SUPER + SHIFT + A")
+o.bind("SUPER + SHIFT + A", "New OmaPilot voice chat",
+  "omarchy-shell -q io.github.spencerbull.omapilot newVoiceChat")
+hl.unbind("SUPER + ALT + H")
+o.bind("SUPER + ALT + H", "Continue OmaPilot chat in Herdr",
+  "omarchy-shell -q io.github.spencerbull.omapilot continueInHerdr")
+-- END OmaPilot managed hotkeys
+LUA
+legacy_checksum=$(sha256sum "$bindings")
+"$installed_installer"
+test "$(grep -Fc -- '-- BEGIN OmaPilot managed hotkeys' "$bindings")" -eq 1
+grep -Fq -- 'hl.unbind("SUPER + ALT + X")' "$bindings"
+grep -Fq -- 'io.github.spencerbull.omapilot voiceCancel' "$bindings"
+test "$(sha256sum "$bindings")" != "$legacy_checksum"
+upgraded_checksum=$(sha256sum "$bindings")
+"$installed_installer"
+test "$(sha256sum "$bindings")" = "$upgraded_checksum"
 
 for mode in --remove --force; do
   cp -- "$clean_bindings" "$bindings"


### PR DESCRIPTION
## Summary

- install Super+Alt+X as the compositor-safe voiceCancel shortcut
- reconcile newly introduced defaults into an existing OmaPilot managed block without replacing user bindings
- cover fresh installs, collisions, legacy-block upgrades, and repeat-install idempotency
- document the cancel shortcut and upgrade behavior

## Verification

- ./scripts/validate.sh
  - 25 test files passed, 2 skipped
  - 243 tests passed, 8 skipped
  - typecheck, lint, build, manifest, browser companion, release metadata, and installer contracts passed
- live installed-runtime check
  - existing four-key managed block upgraded with Super+Alt+X
  - Hyprland loaded the binding with no config errors
  - voiceCancel IPC exited successfully
  - a second installer run left bindings.lua byte-for-byte unchanged

## Note

Shellcheck was unavailable because the local mise shim has no configured version; bash syntax validation passed.