### PR TITLE
Fix scrolling for long ambient answers

### DIFF
--- a/components/AnswerCurtain.qml
+++ b/components/AnswerCurtain.qml
@@ -9,9 +9,10 @@ import "." as OmaPilot
 // The answer curtain: slides down from the top of the focused output, under the
 // Omarchy bar, holds the response, then leaves.
 //
-// Click-through and unfocused by default, so an answer can arrive while the user
-// keeps typing. `ExclusionMode.Normal` with a zero zone means it respects the
-// bar's reserved strip but reserves nothing itself, so no window ever reflows.
+// Unfocused and click-through outside the answer viewport, so an answer can
+// arrive while the user keeps typing. `ExclusionMode.Normal` with a zero zone
+// means it respects the bar's reserved strip but reserves nothing itself, so no
+// window ever reflows.
 //
 // The slide is ours rather than the compositor's: Omarchy pins layersIn and
 // layersOut to a global fade, so the surface stays static and the card animates
@@ -35,6 +36,8 @@ Item {
 
   signal linkActivated(string url)
 
+  onShownChanged: if (shown) answerScroll.contentY = 0
+
   PanelWindow {
     id: surface
     screen: root.targetScreen
@@ -45,7 +48,12 @@ Item {
     visible: root.shown || card.slid > 0.001
     exclusionMode: ExclusionMode.Normal
     exclusiveZone: 0
-    mask: Region {}
+    // Preserve the ambient surface's click-through behavior outside the card.
+    // Keeping this region stable also lets streaming content become scrollable
+    // without remapping the input mask.
+    mask: Region {
+      item: card
+    }
     WlrLayershell.layer: WlrLayer.Overlay
     WlrLayershell.namespace: "omapilot-curtain"
     WlrLayershell.keyboardFocus: WlrKeyboardFocus.None
@@ -63,8 +71,10 @@ Item {
       }
 
       width: Math.min(parent.width - Style.space(96), Style.space(940))
+      readonly property real naturalBodyHeight:
+        provenanceRow.height + body.spacing + answerContent.implicitHeight
       height: Math.min(surface.height - Style.space(24),
-                       body.implicitHeight + Style.space(52))
+                       naturalBodyHeight + Style.space(52))
       anchors.horizontalCenter: parent.horizontalCenter
       y: -height * (1 - card.slid) + Style.space(14) * card.slid
       opacity: card.slid
@@ -127,11 +137,13 @@ Item {
           leftMargin: Style.space(30); rightMargin: Style.space(30)
           topMargin: Style.space(24)
         }
+        height: Math.max(0, parent.height - Style.space(52))
         spacing: Style.spacing.xxl
 
         // Provenance row: what was asked, and who answered. Nothing else — no
         // logo, no gear, no buttons. Restraint is the point.
         Item {
+          id: provenanceRow
           width: parent.width
           height: Math.max(askText.implicitHeight, whoText.implicitHeight)
           Text {
@@ -155,15 +167,28 @@ Item {
           }
         }
 
-        OmaPilot.MarkdownView {
+        Flickable {
+          id: answerScroll
+          objectName: "answerCurtainScroll"
           width: parent.width
-          markdown: root.markdown
-          images: root.images
-          foreground: Color.popups.text
-          background: Color.popups.background
-          accent: root.lightColor
-          fontFamily: Style.font.family
-          onLinkActivated: function(url) { root.linkActivated(url) }
+          height: Math.max(0, body.height - provenanceRow.height - body.spacing)
+          contentWidth: width
+          contentHeight: answerContent.implicitHeight
+          clip: true
+          boundsBehavior: Flickable.StopAtBounds
+          interactive: contentHeight > height
+
+          OmaPilot.MarkdownView {
+            id: answerContent
+            width: answerScroll.width
+            markdown: root.markdown
+            images: root.images
+            foreground: Color.popups.text
+            background: Color.popups.background
+            accent: root.lightColor
+            fontFamily: Style.font.family
+            onLinkActivated: function(url) { root.linkActivated(url) }
+          }
         }
       }
     }

--- a/design/ambient-ux.md
+++ b/design/ambient-ux.md
@@ -19,11 +19,11 @@ substance of this document.
 | Surface | Edge | Focus | Input region | Purpose |
 | --- | --- | --- | --- | --- |
 | **Node** | bottom | never | none (`mask: Region {}`) | Voice presence and live transcript. Light, not a widget. |
-| **Curtain** | top, under the bar | none, grabbable | none until grabbed | The answer. Glance, then gone. |
+| **Curtain** | top, under the bar | none | card only | The answer. Glance, scroll if needed, then gone. |
 | **Console** | centred | exclusive while open | full | The deliberate lane: typing, choices, settings, history, permissions, auth. |
 
-The node and the curtain are **ambient**: they never take a click or a
-keystroke, so they cannot interrupt what the user is doing. The console is the
+The node and the curtain are **ambient**: they never take a keystroke, and the
+curtain takes pointer input only inside its card. The console is the
 only surface that takes focus, and only on explicit summon or when a decision
 genuinely blocks progress.
 
@@ -45,7 +45,7 @@ Every capability the panel and bar widget own today, and where it goes.
 | Provider / model selection | Composer dropdowns | Console → settings |
 | Submit | Composer send button | Voice release, or console Enter |
 | Streaming answer | panel response card | Curtain |
-| Markdown, images, links | `MarkdownView` in panel | Curtain (grab to scroll, copy, open) |
+| Markdown, images, links | `MarkdownView` in panel | Curtain (scroll overflowing answers without keyboard focus) |
 | Response activity runner | response card perimeter | Node filament runner (ported) |
 | Quick actions | panel chips | Console, keyboard-first list |
 | History (latest 30) | `HistoryView` in panel | Console → history lane |
@@ -115,9 +115,10 @@ user is typing in, the illusion dies immediately.
 
 - Node — `WlrKeyboardFocus.None`, `mask: Region {}`, `ExclusionMode.Ignore`.
   Permanently inert. Feedback only.
-- Curtain — `keyboardFocus: None` and click-through by default, so an answer can
-  appear while the user keeps typing. A hotkey *grabs* it, switching it to
-  focused and interactive for scrolling, copying, and opening links.
+- Curtain — `keyboardFocus: None` and click-through outside its card, so an
+  answer can appear while the user keeps typing. Its response viewport accepts
+  pointer input, enabling bounded wheel and touch scrolling when content
+  overflows without taking keyboard focus.
   `ExclusionMode.Normal` with `exclusiveZone: 0`, so it respects the bar's
   reserved strip and reserves nothing itself — no window ever reflows.
 - Console — `WlrKeyboardFocus.Exclusive` while open, `ExclusionMode.Ignore`.
@@ -248,12 +249,9 @@ a 31-word answer computes 11 940 ms.
 The timer only runs once the answer has settled, so streaming never races it,
 and it restarts when new content arrives.
 
-**Accepted cost.** Production should also hold the timer while the curtain is
-grabbed, but it cannot pause on hover: the node and curtain are click-through
-(`mask: Region {}`), so they receive no pointer events at all. Giving the
-curtain an input region would buy hover-to-pause at the price of intercepting
-clicks in a strip across the top of the screen. Never intercepting a click is
-worth more than hover-to-pause, so the grab hotkey is the escape hatch.
+**Accepted cost.** The timer does not yet pause while the user scrolls. The
+curtain's input region is limited to the card rather than the whole
+top strip, so the rest of the surface remains click-through.
 
 When dormant, every OmaPilot surface unmaps — the plugin leaves nothing on the
 output while idle.

--- a/tests/answer-curtain-preview.qml
+++ b/tests/answer-curtain-preview.qml
@@ -1,0 +1,34 @@
+import QtQuick
+import Quickshell
+import Quickshell.Hyprland
+import "components" as OmaPilot
+
+// Ephemeral real-desktop fixture for verifying the capped answer curtain. The
+// numbered paragraphs make wheel or touch scrolling visible in screenshots.
+ShellRoot {
+  id: root
+
+  readonly property string focusedScreenName:
+    Hyprland.focusedMonitor ? String(Hyprland.focusedMonitor.name || "") : ""
+  readonly property var activeScreen: {
+    var screens = Quickshell.screens || []
+    for (var i = 0; i < screens.length; i++)
+      if (String(screens[i].name || "") === root.focusedScreenName) return screens[i]
+    return screens.length > 0 ? screens[0] : null
+  }
+  readonly property string longAnswer: {
+    var paragraphs = []
+    for (var i = 1; i <= 48; i++)
+      paragraphs.push("Paragraph " + i + " — enough content to verify the ambient answer viewport can scroll.")
+    return paragraphs.join("\n\n")
+  }
+
+  OmaPilot.AnswerCurtain {
+    shown: true
+    question: "Show a long ambient answer"
+    markdown: root.longAnswer
+    provenance: "preview · issue 31"
+    targetScreen: root.activeScreen
+    motionEnabled: false
+  }
+}

--- a/tests/check-ui-contract.sh
+++ b/tests/check-ui-contract.sh
@@ -34,6 +34,7 @@ qml_files=(
   "$repo_dir/components/VoiceNode.qml"
   "$repo_dir/components/VoiceWave.qml"
   "$repo_dir/components/ActivityFilament.qml"
+  "$repo_dir/components/AnswerCurtain.qml"
   "$repo_dir/components/ResponseActivityBorder.qml"
   "$repo_dir/components/internal/PermissionFocusGuard.qml"
   "$repo_dir/components/internal/PanelKeyboardNavigation.qml"
@@ -43,6 +44,7 @@ qml_files=(
   "$repo_dir/components/Protocol.js"
   "$repo_dir/components/Presentation.js"
   "$repo_dir/components/QuickActions.js"
+  "$repo_dir/tests/answer-curtain-preview.qml"
   "$repo_dir/tests/motion-preview.qml"
   "$repo_dir/tests/state-motion-preview.qml"
   "$repo_dir/tests/voice-node-preview.qml"
@@ -424,6 +426,15 @@ grep -Fq 'onRotatingActivityStatusChanged:' "$repo_dir/Panel.qml"
 grep -Fq 'text: root.activityStatusText' "$repo_dir/Panel.qml"
 grep -Fq 'StatePhrases.thinkingAt(0)' "$repo_dir/tests/visual-preview.qml"
 grep -Fq 'StateColor.forPhase' "$repo_dir/components/AnswerCurtain.qml"
+grep -Fq 'id: answerScroll' "$repo_dir/components/AnswerCurtain.qml"
+grep -Fq 'contentHeight: answerContent.implicitHeight' \
+  "$repo_dir/components/AnswerCurtain.qml"
+grep -Fq 'boundsBehavior: Flickable.StopAtBounds' \
+  "$repo_dir/components/AnswerCurtain.qml"
+grep -Fq 'interactive: contentHeight > height' \
+  "$repo_dir/components/AnswerCurtain.qml"
+grep -Fq 'item: card' \
+  "$repo_dir/components/AnswerCurtain.qml"
 grep -Fq 'colorizationColor: root.accent' "$repo_dir/components/ActivityFilament.qml"
 grep -Fq 'id: responseStatusSlot' "$repo_dir/Panel.qml"
 grep -Fq 'Layout.minimumWidth: Style.space(140)' "$repo_dir/Panel.qml"


### PR DESCRIPTION
## Summary

- wrap the ambient answer body in a bounded Flickable so content beyond the curtain height cap remains reachable
- preserve zero keyboard focus and keep the layer click-through outside the answer card
- reset each newly shown answer to the top
- add a reproducible long-answer preview plus QML contract coverage
- align the ambient UX input-region documentation

Closes #31

## Validation

- ./scripts/validate.sh — 245 runtime tests passed, 9 intentional skips; typecheck, lint, build, manifest, browser companion, hotkey installer, and Omarchy plugin validation passed
- bash tests/check-ui-contract.sh — 91 focused QML tests passed, plus Wayland overlay and lifecycle probes
- real Wayland long-answer fixture — 417 px viewport, 351 px overflow, and bounded Flickable movement from offset 0 to 120 confirmed
- git diff --check

## Manual verification

- installed commit `4a2eaa8` into the live Omarchy shell
- user confirmed mouse-wheel/trackpad scrolling through a long ambient answer
- recorded result attached in [the PR verification comment](https://github.com/spencerbull/omarchy-omapilot/pull/33#issuecomment-5401327368)

## Residual test gap

Local shellcheck was unavailable; CI supplies that gate.