### PR TITLE
Add capture-and-talk voice shortcut

### DIFF
--- a/Ambient.qml
+++ b/Ambient.qml
@@ -110,8 +110,10 @@ Item {
     function onIpcVoiceStopRequested() { root.voiceStop() }
     function onIpcVoiceToggleRequested() { root.voiceToggle() }
     function onIpcNewVoiceChatRequested() { root.newVoiceChat() }
+    function onIpcCaptureVoiceRequested() { root.captureVoice() }
     function onIpcVoiceCancelRequested() { root.voiceCancel() }
     function onIpcAmbientDismissRequested() { root.dismiss() }
+    function onContextAttachmentAdded() { root.startCapturedVoice() }
   }
 
   // Presentation and conversation lifetime are deliberately separate. A failed
@@ -161,10 +163,57 @@ Item {
   // True after this voice turn's answer has been spoken, so the curtain can
   // linger briefly instead of waiting out a reading-time guess.
   property bool answerSpoken: false
+  // `captureVoice` waits for the broker to attach the selected screenshot
+  // before entering the normal Super+A lifecycle. A fresh voice reset must
+  // preserve that one attachment so the eventual transcript and image share a
+  // single submit.
+  property bool capturedVoicePending: false
+  property bool preserveCapturedContextOnFreshReset: false
+
+  function captureVoice() {
+    if (!OmaPilot.OmaPilotStore.contextCaptureAvailable) {
+      voiceEngaged = true
+      voiceNotice = OmaPilot.OmaPilotStore.statusMessage !== ""
+        ? OmaPilot.OmaPilotStore.statusMessage : "Screen capture is not available right now"
+      return "not ready"
+    }
+    OmaPilot.OmaPilotStore.latchDesktopContext()
+    capturedVoicePending = true
+    if (!OmaPilot.OmaPilotStore.beginContextCapture()) {
+      capturedVoicePending = false
+      return "not ready"
+    }
+    return "capturing"
+  }
+
+  function startCapturedVoice() {
+    if (!capturedVoicePending) return
+    capturedVoicePending = false
+    var attachments = OmaPilot.OmaPilotStore.contextAttachments
+    var attachment = attachments.length > 0 ? attachments[attachments.length - 1] : null
+    var hasScreenshot = false
+    var representations = attachment && Array.isArray(attachment.representations)
+      ? attachment.representations : []
+    for (var i = 0; i < representations.length; i++)
+      if (String(representations[i].id || "") === "image") hasScreenshot = true
+    if (!attachment || !hasScreenshot) {
+      voiceEngaged = true
+      voiceNotice = "The selected context did not include a screenshot"
+      return
+    }
+    OmaPilot.OmaPilotStore.setContextRepresentation(attachment.id, "image")
+    preserveCapturedContextOnFreshReset = true
+    Qt.callLater(function() {
+      var outcome = root.voiceToggle()
+      if (outcome !== "preempting")
+        root.preserveCapturedContextOnFreshReset = false
+    })
+  }
 
   function resetFreshVoiceChat() {
     freshChatResetInProgress = true
-    OmaPilot.OmaPilotStore.newChat()
+    OmaPilot.OmaPilotStore.resetChat(preserveCapturedContextOnFreshReset)
+    preserveCapturedContextOnFreshReset = false
     freshChatResetInProgress = false
   }
 
@@ -405,6 +454,7 @@ Item {
     id: capture
     shell: root.shell
     manifest: root.manifest
+    onSelectionCancelled: root.capturedVoicePending = false
   }
 
   // Host contract: `shell.summon(id, payload)` calls open() and `shell.hide(id)`

--- a/ContextCaptureOverlay.qml
+++ b/ContextCaptureOverlay.qml
@@ -12,6 +12,7 @@ Item {
   property var shell: null
   property var manifest: null
   property bool opened: false
+  signal selectionCancelled()
   property string requestId: ""
   property var target: ({})
   readonly property var targetScreen: {
@@ -50,6 +51,7 @@ Item {
     opened = false
     resetGesture()
     if (cancelId !== "") OmaPilot.OmaPilotStore.cancelContextCapture(cancelId)
+    if (cancelId !== "") selectionCancelled()
     if (cancelId !== "") requestId = ""
   }
 

--- a/README.md
+++ b/README.md
@@ -112,8 +112,9 @@ omarchy plugin remove io.github.spencerbull.omapilot
 ## Global hotkeys
 
 OmaPilot exposes compositor-safe IPC actions for a contextual voice session,
-forced-fresh typed or voice conversations, and handing the current chat to
-Herdr. Choose **Settings → Desktop → Install global hotkeys** to add these
+an explicit screen-capture-then-talk flow, forced-fresh typed or voice
+conversations, and handing the current chat to Herdr. Choose **Settings →
+Desktop → Install global hotkeys** to add these
 bindings to `~/.config/hypr/bindings.lua`, where their descriptions appear in
 **Learn → Keybindings**:
 
@@ -121,6 +122,10 @@ bindings to `~/.config/hypr/bindings.lua`, where their descriptions appear in
 -- Start fresh when the ambient flow is closed; continue while it is visible.
 o.bind("SUPER + A", "Talk to OmaPilot",
   "omarchy-shell -q io.github.spencerbull.omapilot voiceToggle")
+
+-- Capture a window or region, then start dictation automatically.
+o.bind("SUPER + ALT + A", "Capture screen and talk to OmaPilot",
+  "omarchy-shell -q io.github.spencerbull.omapilot captureVoice")
 
 -- Force a fresh voice chat, even while the ambient flow is still active.
 hl.unbind("SUPER + SHIFT + A")
@@ -140,10 +145,14 @@ o.bind("SUPER + ALT + H", "Continue OmaPilot chat in Herdr",
 curtain have closed. While that flow remains active, pressing it again finishes
 live dictation or begins a follow-up in the same conversation. The answer timer,
 explicit dismissal, and cancellation close the voice session; they do not erase
-its saved history. `Super+Shift+A` remains the force-new escape hatch, while
-`Super+Alt+X` cancels and closes the active voice flow. New typed chat opens the
-panel with an empty composer. Continue in Herdr does nothing until the current
-conversation has a saved chat ID.
+its saved history. `Super+Alt+A` opens the context crosshair; selecting a window
+or region attaches its screenshot and starts dictation, and the next `Super+A`
+sends the transcript and screenshot in one turn. Escape cancels before capture
+and does not start the microphone. `Super+Shift+A` remains the force-new escape
+hatch, while `Super+Alt+X` cancels and closes the active voice flow. New typed
+chat opens the panel with an empty composer. Continue in Herdr does nothing until
+the current conversation has a saved chat ID. Screenshot questions require a
+model that accepts image input.
 
 The managed block is written only after that explicit action and becomes normal
 user-owned Hyprland configuration. Existing user-defined collisions are left

--- a/components/OmaPilotStore.qml
+++ b/components/OmaPilotStore.qml
@@ -142,6 +142,7 @@ Scope {
   signal ipcVoiceStopRequested()
   signal ipcVoiceToggleRequested()
   signal ipcNewVoiceChatRequested()
+  signal ipcCaptureVoiceRequested()
   signal ipcVoiceCancelRequested()
   signal ipcAmbientDismissRequested()
   signal contextOverlayRequested(string payload)
@@ -479,9 +480,9 @@ Scope {
       pendingPermission = queued.length > 0 ? queued[0] : null
   }
 
-  function resetChat() {
+  function resetChat(preserveContextAttachments) {
     newChatPending = false
-    clearContextAttachments()
+    if (preserveContextAttachments !== true) clearContextAttachments()
     currentId = ""
     currentChatId = ""
     submittedResumeChatId = ""
@@ -1138,6 +1139,7 @@ Scope {
     function voiceStop(): string { root.ipcVoiceStopRequested(); return "ok" }
     function voiceToggle(): string { root.ipcVoiceToggleRequested(); return "ok" }
     function newVoiceChat(): string { root.ipcNewVoiceChatRequested(); return "ok" }
+    function captureVoice(): string { root.ipcCaptureVoiceRequested(); return "ok" }
     function voiceCancel(): string { root.ipcVoiceCancelRequested(); return "ok" }
     function dismiss(): string { root.ipcAmbientDismissRequested(); return "ok" }
     function status(): string { return "store=" + root.state }

--- a/scripts/install-hotkeys.sh
+++ b/scripts/install-hotkeys.sh
@@ -149,6 +149,7 @@ has_user_binding() {
 
 chords=(
   "SUPER + A"
+  "SUPER + ALT + A"
   "SUPER + SHIFT + A"
   "SUPER + ALT + X"
   "SUPER + ALT + N"
@@ -156,6 +157,7 @@ chords=(
 )
 descriptions=(
   "Talk to OmaPilot"
+  "Capture screen and talk to OmaPilot"
   "New OmaPilot voice chat"
   "Cancel OmaPilot voice mode"
   "New OmaPilot chat"
@@ -163,6 +165,7 @@ descriptions=(
 )
 commands=(
   "omarchy-shell -q io.github.spencerbull.omapilot voiceToggle"
+  "omarchy-shell -q io.github.spencerbull.omapilot captureVoice"
   "omarchy-shell -q io.github.spencerbull.omapilot newVoiceChat"
   "omarchy-shell -q io.github.spencerbull.omapilot voiceCancel"
   "omarchy-shell -q io.github.spencerbull.omapilot newChat"

--- a/tests/ambient-session-lifecycle-probe.qml
+++ b/tests/ambient-session-lifecycle-probe.qml
@@ -50,6 +50,12 @@ ShellRoot {
         root.fail("completed speech did not select the two-second dismissal")
       ambient.answerSpoken = false
 
+      OmaPilot.OmaPilotStore.contextAttachments = [{
+        id: "captured-image",
+        representations: [{ id: "image" }],
+        selectedRepresentationIds: ["image"]
+      }]
+      ambient.preserveCapturedContextOnFreshReset = true
       ambient.resetFreshVoiceChat()
 
       if (!ambient.voiceEngaged)
@@ -60,6 +66,8 @@ ShellRoot {
         root.fail("fresh reset did not return the store to composing")
       if (OmaPilot.OmaPilotStore.currentChatId !== "")
         root.fail("fresh reset retained the completed chat continuation")
+      if (OmaPilot.OmaPilotStore.contextAttachments.length !== 1)
+        root.fail("capture-to-voice fresh reset discarded the selected screenshot")
 
       if (!root.failed) console.log("OMAPILOT_AMBIENT_SESSION_LIFECYCLE_PROBE_OK")
       Qt.quit()

--- a/tests/check-ui-contract.sh
+++ b/tests/check-ui-contract.sh
@@ -278,6 +278,12 @@ grep -Fq 'if (!OmaPilot.OmaPilotStore.voiceEnabled)' "$repo_dir/Ambient.qml"
 grep -Fq 'function newVoiceChat() {' "$repo_dir/Ambient.qml"
 grep -Fq 'function onIpcNewVoiceChatRequested() { root.newVoiceChat() }' \
   "$repo_dir/Ambient.qml"
+grep -Fq 'function onIpcCaptureVoiceRequested() { root.captureVoice() }' \
+  "$repo_dir/Ambient.qml"
+grep -Fq 'function captureVoice(): string { root.ipcCaptureVoiceRequested(); return "ok" }' \
+  "$repo_dir/components/OmaPilotStore.qml"
+grep -Fq 'function onContextAttachmentAdded() { root.startCapturedVoice() }' \
+  "$repo_dir/Ambient.qml"
 grep -Fq 'property bool voiceSessionActive: false' "$repo_dir/Ambient.qml"
 grep -Fq 'SessionLifecycle.voiceActivationMode(' "$repo_dir/Ambient.qml"
 grep -Fq 'voiceSessionActive = false' "$repo_dir/Ambient.qml"
@@ -303,6 +309,7 @@ grep -Fq 'String(event.chatId || "") !== pendingHerdrChatId' \
   "$repo_dir/components/OmaPilotStore.qml"
 grep -Fq 'SUPER + SHIFT + A' "$repo_dir/README.md"
 grep -Fq 'io.github.spencerbull.omapilot newVoiceChat' "$repo_dir/README.md"
+grep -Fq 'io.github.spencerbull.omapilot captureVoice' "$repo_dir/README.md"
 grep -Fq 'SUPER + ALT + N' "$repo_dir/README.md"
 grep -Fq 'io.github.spencerbull.omapilot continueInHerdr' "$repo_dir/README.md"
 if grep -Fq 'text: "Voice indicator"' "$repo_dir/components/SettingsView.qml"; then

--- a/tests/test-hotkey-installer.sh
+++ b/tests/test-hotkey-installer.sh
@@ -53,6 +53,8 @@ grep -Fq -- "o.bind('SUPER + ALT + N', 'My existing new chat'" "$bindings"
 assert_absent 'o.bind("SUPER + ALT + N", "New OmaPilot chat"' "$bindings"
 grep -Fq -- 'hl.unbind("SUPER + SHIFT + A")' "$bindings"
 grep -Fq -- 'io.github.spencerbull.omapilot newVoiceChat' "$bindings"
+grep -Fq -- 'hl.unbind("SUPER + ALT + A")' "$bindings"
+grep -Fq -- 'io.github.spencerbull.omapilot captureVoice' "$bindings"
 grep -Fq -- 'hl.unbind("SUPER + ALT + X")' "$bindings"
 grep -Fq -- 'io.github.spencerbull.omapilot voiceCancel' "$bindings"
 grep -Fq -- 'io.github.spencerbull.omapilot continueInHerdr' "$bindings"
@@ -77,6 +79,7 @@ cp -- "$bindings" "$clean_bindings"
 
 cat >>"$bindings" <<'LUA'
 o.bind("SUPER + SHIFT + A", "My existing voice chat", "my-voice-chat")
+o.bind("SUPER + ALT + A", "My existing capture voice", "my-capture-voice")
 o.bind("SUPER + ALT + X", "My existing voice cancel", "my-voice-cancel")
 o.bind("SUPER + ALT + H", "My existing handoff", "my-handoff")
 LUA
@@ -105,6 +108,8 @@ legacy_checksum=$(sha256sum "$bindings")
 test "$(grep -Fc -- '-- BEGIN OmaPilot managed hotkeys' "$bindings")" -eq 1
 grep -Fq -- 'hl.unbind("SUPER + ALT + X")' "$bindings"
 grep -Fq -- 'io.github.spencerbull.omapilot voiceCancel' "$bindings"
+grep -Fq -- 'hl.unbind("SUPER + ALT + A")' "$bindings"
+grep -Fq -- 'io.github.spencerbull.omapilot captureVoice' "$bindings"
 test "$(sha256sum "$bindings")" != "$legacy_checksum"
 upgraded_checksum=$(sha256sum "$bindings")
 "$installed_installer"


### PR DESCRIPTION
## Summary

- add a captureVoice IPC action that opens the existing context crosshair and starts dictation after a window or region is selected
- keep the selected screenshot attached across a fresh voice-session reset so the transcript and image are submitted in one turn
- cancel cleanly before microphone activation when the context picker is dismissed
- install Super+Alt+A as a collision-safe default without changing the existing Super+A or Super+Shift+A voice gestures
- document the flow and note that screenshot questions require an image-capable model

## Validation

- live Omarchy Quattro verification: capture a region, dictate a question, and submit the screenshot plus transcript in one turn
- ./tests/test-hotkey-installer.sh
- ./tests/check-ui-contract.sh
- ./scripts/validate.sh
- 25 test files passed, 245 tests passed, and 9 live-provider tests skipped
- generated runtime and browser-companion artifacts remained unchanged

The full validator reported ShellCheck and qmllint unavailable in the local environment; the repository hotkey tests and live Quickshell QML contract suite passed.