### PR TITLE
Confirm the per-chat delete, and four smaller interface fixes

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -270,6 +270,7 @@ Panel {
       } else Qt.callLater(function() { composer.forceInputFocus() })
     } else {
       OmaPilot.OmaPilotStore.clearDesktopContextLatch()
+      historyView.withdrawConfirmations()
     }
   }
 

--- a/Panel.qml
+++ b/Panel.qml
@@ -112,7 +112,11 @@ Panel {
     id: thinkingPhraseSwap
     PropertyAnimation {
       target: activityStatus; property: "opacity"
-      to: 0; duration: 180; easing.type: Easing.OutQuad
+      // Out accelerates away, in decelerates to a stop. The pair used to be
+      // the other way round, which made the phrase linger on its way out and
+      // then hold at almost-invisible on its way back in — the fade you
+      // wanted to read was slowest exactly where there was nothing to read.
+      to: 0; duration: 180; easing.type: Easing.InQuad
     }
     ScriptAction {
       script: root.thinkingPhraseIndex = (root.thinkingPhraseIndex + 1)
@@ -120,7 +124,7 @@ Panel {
     }
     PropertyAnimation {
       target: activityStatus; property: "opacity"
-      to: 1; duration: 260; easing.type: Easing.InQuad
+      to: 1; duration: 260; easing.type: Easing.OutQuad
     }
   }
 

--- a/components/Composer.qml
+++ b/components/Composer.qml
@@ -233,7 +233,10 @@ Item {
         placeholderText: root.backend && root.backend.initialized
           ? "Ask, or describe what to do"
           : "Starting OmaPilot\u2026"
-        placeholderTextColor: Qt.darker(root.foreground, 1.7)
+        // 1.7 measured 4.12:1 against the popup background on the shipped
+        // theme — under the 4.5:1 floor, and this is 16px text, not large.
+        // 1.6 clears it at 4.57:1 and is still plainly a placeholder.
+        placeholderTextColor: Qt.darker(root.foreground, 1.6)
         color: root.foreground
         selectionColor: Style.selectionFillFor(root.foreground, root.accent)
         selectedTextColor: root.foreground

--- a/components/ContextAttachmentPreview.qml
+++ b/components/ContextAttachmentPreview.qml
@@ -61,8 +61,11 @@ BorderSurface {
         anchors.left: parent.left
         anchors.top: parent.top
         anchors.margins: Style.spacing.xxs
-        width: kindLabel.implicitWidth + Style.spacing.sm
-        height: kindLabel.implicitHeight + Style.spacing.xxs
+        // A pill wants its padding on both sides. `sm` and `xxs` were the
+        // whole horizontal and vertical allowance, so 2px a side stood in for
+        // padding on a shape whose radius is half its height.
+        width: kindLabel.implicitWidth + Style.spacing.md * 2
+        height: kindLabel.implicitHeight + Style.spacing.xxs * 2
         radius: height / 2
         color: Color.popups.background
         opacity: 0.9
@@ -75,6 +78,9 @@ BorderSurface {
           font.family: root.fontFamily
           font.pixelSize: Style.font.caption
           font.bold: true
+          // Capitals set at default tracking clump. Same 0.7 the setup
+          // guide's progress label already uses for the same reason.
+          font.letterSpacing: 0.7
         }
       }
     }

--- a/components/ContextAttachmentPreview.qml
+++ b/components/ContextAttachmentPreview.qml
@@ -58,13 +58,22 @@ BorderSurface {
       }
 
       Rectangle {
+        id: kindPill
         anchors.left: parent.left
         anchors.top: parent.top
         anchors.margins: Style.spacing.xxs
         // A pill wants its padding on both sides. `sm` and `xxs` were the
         // whole horizontal and vertical allowance, so 2px a side stood in for
         // padding on a shape whose radius is half its height.
-        width: kindLabel.implicitWidth + Style.spacing.md * 2
+        //
+        // Bounded, because the thumbnail behind it clips and the combined
+        // modes are long: measured against the shipped theme, "ELEMENT +
+        // IMAGE" wants 112px in the 90px this leaves, and "TEXT + IMAGE"
+        // wants 92px. The wider padding did not start that — "ELEMENT +
+        // IMAGE" already overflowed at 94px — but it added a second label to
+        // the list, so the cap belongs in the same change.
+        width: Math.min(kindLabel.implicitWidth + Style.spacing.md * 2,
+          parent.width - Style.spacing.xxs * 2)
         height: kindLabel.implicitHeight + Style.spacing.xxs * 2
         radius: height / 2
         color: Color.popups.background
@@ -73,6 +82,11 @@ BorderSurface {
         Text {
           id: kindLabel
           anchors.centerIn: parent
+          // Elides inside the pill rather than under the thumbnail's clip: a
+          // label cut by a clip looks like a rendering fault, and one cut by
+          // an ellipsis looks like a label that ran out of room.
+          width: Math.min(implicitWidth, kindPill.width - Style.spacing.md * 2)
+          elide: Text.ElideRight
           text: root.selectedMode.toUpperCase().replace("+", " + ")
           color: root.foreground
           font.family: root.fontFamily
@@ -81,6 +95,8 @@ BorderSurface {
           // Capitals set at default tracking clump. Same 0.7 the setup
           // guide's progress label already uses for the same reason.
           font.letterSpacing: 0.7
+          Accessible.role: Accessible.StaticText
+          Accessible.name: root.selectedMode.toUpperCase().replace("+", " + ")
         }
       }
     }

--- a/components/HistoryView.qml
+++ b/components/HistoryView.qml
@@ -136,7 +136,11 @@ Item {
         visible: root.history.length === 0
         anchors.centerIn: parent
         width: parent.width - Style.spacing.xxl * 2
-        text: "No saved chats yet.\nThe latest 30 completed answers appear here."
+        // No number here on purpose: the cap lives in the broker, this view
+        // has no way to read it, and a literal copied across that boundary is
+        // wrong the first time either side changes. It said 30 while the
+        // broker kept 30, and would have gone on saying 30 afterwards.
+        text: "No saved chats yet.\nCompleted answers are kept here."
         color: Qt.darker(root.foreground, 1.55)
         font.family: root.fontFamily
         font.pixelSize: Style.font.caption
@@ -266,7 +270,14 @@ Item {
 
               Layout.alignment: Qt.AlignVCenter
               iconText: "󰆴"
-              tooltipText: confirming ? "Delete chat?" : "Delete chat"
+              // An instruction, not a question. Turning urgent and drawing a
+              // border says the state changed; neither says what to do about
+              // it. "Clear all" can afford a question because its label is
+              // visible text that becomes "Clear all?" — this control has no
+              // label at all, so the tooltip is the only thing that can speak,
+              // and it should spend those words telling you the way out rather
+              // than restating what the colour already said.
+              tooltipText: confirming ? "Click again to delete" : "Delete chat"
               // Armed, the button borrows the urgent role and puts a border
               // round itself. Colour alone would be the whole signal otherwise,
               // and colour alone is not a signal for everyone.

--- a/components/HistoryView.qml
+++ b/components/HistoryView.qml
@@ -19,6 +19,13 @@ Item {
   // never at the same time as the clear-all confirmation.
   property string confirmingDeleteId: ""
   readonly property bool modalInteractionActive: confirmingClear || confirmingDeleteId !== ""
+  // When the open question was asked, so that it cannot be answered by the
+  // second half of the gesture that asked it. A double-click is one gesture:
+  // the first click armed and the second, inside the platform's double-click
+  // interval, confirmed — before the colour had finished changing. The same
+  // window covers a stutter on a touchpad. A click that lands after the
+  // interval is a click on a control that had time to turn urgent.
+  property real armedAt: 0
 
   signal chatSelected(var chat)
   signal deleteRequested(string chatId)
@@ -26,15 +33,30 @@ Item {
   signal closeRequested()
 
   // This view is hidden, never destroyed — `visible: viewMode === "history"`
-  // in both surfaces. So going Back, opening a chat, or closing the panel left
-  // an armed confirmation sitting here, and returning to history found a row
-  // already armed from minutes ago: the next single click deleted instead of
-  // asking. A question nobody is looking at is a question nobody asked.
+  // in the panel. So going Back or opening a chat left an armed confirmation
+  // sitting here, and returning to history found a row already armed from
+  // minutes ago: the next single click deleted instead of asking. A question
+  // nobody is looking at is a question nobody asked.
   //
   // Clears the clear-all arm too, which had the same hole and more to lose.
-  onVisibleChanged: if (!visible) {
+  onVisibleChanged: if (!visible) root.withdrawConfirmations()
+
+  // Called by the panel as well when it closes: this view's visibility is
+  // bound to the view mode, not to the panel, so closing the panel while in
+  // history does not hide it. Reopening asked the broker for the list again
+  // and the answer withdrew the question, but not before the armed row had
+  // shown itself urgent for however long the broker took.
+  function withdrawConfirmations() {
     root.confirmingClear = false
     root.confirmingDeleteId = ""
+  }
+
+  function arm() {
+    root.armedAt = Date.now()
+  }
+
+  function settled() {
+    return Date.now() - root.armedAt >= Application.styleHints.mouseDoubleClickInterval
   }
 
   // The list can change under an open question: a completed answer is
@@ -43,10 +65,7 @@ Item {
   // row may have moved, the id may no longer be there — so the question is
   // withdrawn, both kinds. A fresh press asks it again against what is on
   // screen now.
-  onHistoryChanged: {
-    root.confirmingClear = false
-    root.confirmingDeleteId = ""
-  }
+  onHistoryChanged: root.withdrawConfirmations()
 
   // Deleting one chat unlinks its record, its images and its Pi session, with
   // no undo — the same irreversibility that made "Clear all" ask twice. It
@@ -58,17 +77,40 @@ Item {
   // actions in this view are answered the same way and neither steals focus.
   function requestDelete(chatId) {
     if (root.confirmingDeleteId === chatId) {
+      // Inside the double-click interval the second click is the same
+      // gesture as the first; it is ignored and the question stays open. The
+      // keyboard pays the same toll — two Deletes inside the interval arm and
+      // wait — which is the price of one rule for every way in.
+      if (!root.settled()) return
       root.confirmingDeleteId = ""
       root.deleteRequested(chatId)
       return
     }
     root.confirmingClear = false
     root.confirmingDeleteId = chatId
+    root.arm()
   }
 
   function forceInitialFocus() {
     if (list.visible && list.count > 0) list.forceActiveFocus()
     else closeHistory.forceActiveFocus()
+  }
+
+  // Two presses means two presses, on the controls as well as on the list. A
+  // focused control answers Return, Enter and Space itself, and Qt emits
+  // those specific signals before the generic press and accepts them by
+  // default, so nothing above the control gets to see a repeat. Held past
+  // the repeat delay, the first press armed and the first repeat confirmed.
+  // `Keys.forwardTo` hands the event here first: a repeat of an activation
+  // key is swallowed, every other key goes on as before — Delete and the
+  // arrows still reach the list.
+  Item {
+    id: repeatGuard
+    Keys.onPressed: function(event) {
+      if (event.isAutoRepeat && (event.key === Qt.Key_Return
+          || event.key === Qt.Key_Enter || event.key === Qt.Key_Space))
+        event.accepted = true
+    }
   }
 
   ColumnLayout {
@@ -126,17 +168,20 @@ Item {
         }
 
         TapHandler { onTapped: clearHistory.activate() }
+        Keys.forwardTo: [repeatGuard]
         Keys.onReturnPressed: clearHistory.activate()
         Keys.onEnterPressed: clearHistory.activate()
         Keys.onSpacePressed: clearHistory.activate()
 
         function activate() {
           if (root.confirmingClear) {
+            if (!root.settled()) return
             root.clearRequested()
             root.confirmingClear = false
           } else {
             root.confirmingDeleteId = ""
             root.confirmingClear = true
+            root.arm()
           }
         }
       }
@@ -327,6 +372,7 @@ Item {
               focusable: enabled
               opacity: enabled ? 1 : 0
               Accessible.name: confirming ? "Confirm deleting this chat" : tooltipText
+              Keys.forwardTo: [repeatGuard]
               onClicked: root.requestDelete(String(row.modelData.id))
               Behavior on opacity {
                 enabled: root.motionEnabled

--- a/components/HistoryView.qml
+++ b/components/HistoryView.qml
@@ -25,6 +25,18 @@ Item {
   signal clearRequested()
   signal closeRequested()
 
+  // This view is hidden, never destroyed — `visible: viewMode === "history"`
+  // in both surfaces. So going Back, opening a chat, or closing the panel left
+  // an armed confirmation sitting here, and returning to history found a row
+  // already armed from minutes ago: the next single click deleted instead of
+  // asking. A question nobody is looking at is a question nobody asked.
+  //
+  // Clears the clear-all arm too, which had the same hole and more to lose.
+  onVisibleChanged: if (!visible) {
+    root.confirmingClear = false
+    root.confirmingDeleteId = ""
+  }
+
   // Deleting one chat unlinks its record, its images and its Pi session, with
   // no undo — the same irreversibility that made "Clear all" ask twice. It
   // asked, and this did not, which is the worse half of an inconsistency: the

--- a/components/HistoryView.qml
+++ b/components/HistoryView.qml
@@ -15,12 +15,33 @@ Item {
   property string fontFamily: Style.font.family
   property bool motionEnabled: true
   property bool confirmingClear: false
-  readonly property bool modalInteractionActive: confirmingClear
+  // The id of the chat whose delete is armed, "" for none. One at a time, and
+  // never at the same time as the clear-all confirmation.
+  property string confirmingDeleteId: ""
+  readonly property bool modalInteractionActive: confirmingClear || confirmingDeleteId !== ""
 
   signal chatSelected(var chat)
   signal deleteRequested(string chatId)
   signal clearRequested()
   signal closeRequested()
+
+  // Deleting one chat unlinks its record, its images and its Pi session, with
+  // no undo — the same irreversibility that made "Clear all" ask twice. It
+  // asked, and this did not, which is the worse half of an inconsistency: the
+  // cheap action was guarded and the one sitting under the pointer, on a row
+  // that arms itself on hover, was not.
+  //
+  // Same two-step as clear-all rather than a dialog, so both destructive
+  // actions in this view are answered the same way and neither steals focus.
+  function requestDelete(chatId) {
+    if (root.confirmingDeleteId === chatId) {
+      root.confirmingDeleteId = ""
+      root.deleteRequested(chatId)
+      return
+    }
+    root.confirmingClear = false
+    root.confirmingDeleteId = chatId
+  }
 
   function forceInitialFocus() {
     if (list.visible && list.count > 0) list.forceActiveFocus()
@@ -90,7 +111,10 @@ Item {
           if (root.confirmingClear) {
             root.clearRequested()
             root.confirmingClear = false
-          } else root.confirmingClear = true
+          } else {
+            root.confirmingDeleteId = ""
+            root.confirmingClear = true
+          }
         }
       }
     }
@@ -131,6 +155,12 @@ Item {
         activeFocusOnTab: true
         currentIndex: count > 0 ? 0 : -1
 
+        // An armed delete belongs to the row it is armed on. Leaving that row —
+        // by arrow key, or by hovering another, which moves the cursor here too
+        // — disarms it, so the confirmation can never outlive the sight of what
+        // it would delete.
+        onCurrentIndexChanged: root.confirmingDeleteId = ""
+
         Keys.onPressed: function(event) { historyKeyboard.handleKey(event) }
 
         OmaPilotInternal.HistoryListKeyboardHandler {
@@ -138,10 +168,17 @@ Item {
           list: list
           history: root.history
           confirmingClear: root.confirmingClear
+          confirmingDelete: root.confirmingDeleteId !== ""
           onChatSelected: function(chat) { root.chatSelected(chat) }
-          onDeleteRequested: function(chatId) { root.deleteRequested(chatId) }
+          // Routed through the same two-step the button uses, so Delete arms on
+          // the first press and deletes on the second whichever way it came.
+          onDeleteRequested: function(chatId) { root.requestDelete(chatId) }
           onCloseRequested: root.closeRequested()
           onConfirmationCancelled: {
+            if (root.confirmingDeleteId !== "") {
+              root.confirmingDeleteId = ""
+              return
+            }
             root.confirmingClear = false
             clearHistory.forceActiveFocus()
           }
@@ -224,20 +261,27 @@ Item {
             }
 
             PanelActionButton {
+              readonly property bool confirming:
+                root.confirmingDeleteId === String(row.modelData.id)
+
               Layout.alignment: Qt.AlignVCenter
               iconText: "󰆴"
-              tooltipText: "Delete chat"
-              foreground: root.foreground
+              tooltipText: confirming ? "Delete chat?" : "Delete chat"
+              // Armed, the button borrows the urgent role and puts a border
+              // round itself. Colour alone would be the whole signal otherwise,
+              // and colour alone is not a signal for everyone.
+              foreground: confirming ? Color.urgent : root.foreground
               hoverColor: Color.urgent
+              bordered: confirming
               // Opacity 0 still receives taps, so non-current rows would delete
               // from empty space on pointers that never hover. Disable the
               // control until the row is current, hovered, or this button is
               // focused. List Delete remains the keyboard path.
-              enabled: row.hot || activeFocus
+              enabled: row.hot || activeFocus || confirming
               focusable: enabled
               opacity: enabled ? 1 : 0
-              Accessible.name: tooltipText
-              onClicked: root.deleteRequested(String(modelData.id))
+              Accessible.name: confirming ? "Confirm deleting this chat" : tooltipText
+              onClicked: root.requestDelete(String(row.modelData.id))
               Behavior on opacity {
                 enabled: root.motionEnabled
                 NumberAnimation { duration: 120 }

--- a/components/HistoryView.qml
+++ b/components/HistoryView.qml
@@ -37,6 +37,17 @@ Item {
     root.confirmingDeleteId = ""
   }
 
+  // The list can change under an open question: a completed answer is
+  // prepended while history is open, and the store hands this view a new
+  // array. Whatever was armed was armed against the list that is gone — the
+  // row may have moved, the id may no longer be there — so the question is
+  // withdrawn, both kinds. A fresh press asks it again against what is on
+  // screen now.
+  onHistoryChanged: {
+    root.confirmingClear = false
+    root.confirmingDeleteId = ""
+  }
+
   // Deleting one chat unlinks its record, its images and its Pi session, with
   // no undo — the same irreversibility that made "Clear all" ask twice. It
   // asked, and this did not, which is the worse half of an inconsistency: the
@@ -176,6 +187,15 @@ Item {
         // — disarms it, so the confirmation can never outlive the sight of what
         // it would delete.
         onCurrentIndexChanged: root.confirmingDeleteId = ""
+        // Scrolling leaves the row too, without moving the cursor: a wheel or
+        // a drag can carry the armed row out of the viewport, its delegate
+        // with it, and leave an open question with no urgent button anywhere
+        // on screen to show for it. Any movement of the viewport withdraws
+        // the question. It cannot undo an arm that was just made: with no
+        // highlight item this view never scrolls on its own to follow the
+        // cursor, so the viewport moves only when a wheel, a drag or a resize
+        // moves it — never as a side effect of arming or of becoming current.
+        onContentYChanged: root.confirmingDeleteId = ""
 
         Keys.onPressed: function(event) { historyKeyboard.handleKey(event) }
 
@@ -184,10 +204,13 @@ Item {
           list: list
           history: root.history
           confirmingClear: root.confirmingClear
-          confirmingDelete: root.confirmingDeleteId !== ""
+          confirmingDeleteId: root.confirmingDeleteId
           onChatSelected: function(chat) { root.chatSelected(chat) }
           // Routed through the same two-step the button uses, so Delete arms on
           // the first press and deletes on the second whichever way it came.
+          // The second press carries the armed id back, so the two-step
+          // confirms the chat that was armed and never the row under the
+          // cursor.
           onDeleteRequested: function(chatId) { root.requestDelete(chatId) }
           onCloseRequested: root.closeRequested()
           onConfirmationCancelled: {

--- a/components/StateLightBar.qml
+++ b/components/StateLightBar.qml
@@ -205,7 +205,10 @@ Item {
     colorization: 1
     colorizationColor: root.displayedColor
     opacity: root.atmosphereActive ? 0.72 : 0
-    Behavior on opacity { NumberAnimation { duration: 220 } }
+    Behavior on opacity {
+      enabled: root.motionEnabled
+      NumberAnimation { duration: 220 }
+    }
   }
 
   onPhaseChanged: settleAtmosphere()

--- a/components/VoiceNode.qml
+++ b/components/VoiceNode.qml
@@ -109,7 +109,7 @@ Item {
     id: thinkingPhraseSwap
     PropertyAnimation {
       target: captionText; property: "opacity"
-      to: 0; duration: 180; easing.type: Easing.OutQuad
+      to: 0; duration: 180; easing.type: Easing.InQuad
     }
     ScriptAction {
       script: root.thinkingPhraseIndex = (root.thinkingPhraseIndex + 1)
@@ -117,7 +117,7 @@ Item {
     }
     PropertyAnimation {
       target: captionText; property: "opacity"
-      to: 1; duration: 260; easing.type: Easing.InQuad
+      to: 1; duration: 260; easing.type: Easing.OutQuad
     }
   }
   Timer {

--- a/components/internal/HistoryListKeyboardHandler.qml
+++ b/components/internal/HistoryListKeyboardHandler.qml
@@ -28,6 +28,16 @@ Item {
       if (event.key === Qt.Key_Escape) root.confirmationCancelled()
       event.accepted = true
     } else if (root.confirmingDelete && action) {
+      // Two presses means two presses. Held past the repeat delay, the first
+      // physical press armed the row and the first auto-repeat arrived here
+      // and confirmed it — one finger on one key deleting a chat through a
+      // confirmation designed to stop exactly that. Repeats are swallowed
+      // while armed, so the answer has to come from a key that was released
+      // and pressed again.
+      if (event.isAutoRepeat) {
+        event.accepted = true
+        return
+      }
       // One keystroke, one effect: Delete answers the question, everything
       // else withdraws it and stops there. Moving off the row with the arrows
       // would disarm anyway — doing it here as well means the keypress that

--- a/components/internal/HistoryListKeyboardHandler.qml
+++ b/components/internal/HistoryListKeyboardHandler.qml
@@ -6,10 +6,17 @@ Item {
   required property var list
   property var history: []
   property bool confirmingClear: false
-  // A per-chat delete is armed on the current row. Unlike the clear-all
-  // confirmation, which is answered on its own control, this one is answered
-  // here: a second Delete confirms, and anything else backs out.
-  property bool confirmingDelete: false
+  // The id of the chat whose delete is armed, "" for none. Unlike the
+  // clear-all confirmation, which is answered on its own control, this one is
+  // answered here: a second Delete confirms, and anything else backs out.
+  //
+  // An id, not a flag, because the confirmation is about a chat and not about
+  // a row. Confirming used to read the chat back out of `history` at
+  // `currentIndex`, and the list can change between the two presses — a
+  // completed answer is prepended while history is open — leaving the same
+  // index on a different chat. The second press then named a chat nobody had
+  // armed. What is confirmed now is exactly what was armed.
+  property string confirmingDeleteId: ""
 
   signal chatSelected(var chat)
   signal deleteRequested(string chatId)
@@ -27,7 +34,7 @@ Item {
     if (root.confirmingClear && action) {
       if (event.key === Qt.Key_Escape) root.confirmationCancelled()
       event.accepted = true
-    } else if (root.confirmingDelete && action) {
+    } else if (root.confirmingDeleteId !== "" && action) {
       // Two presses means two presses. Held past the repeat delay, the first
       // physical press armed the row and the first auto-repeat arrived here
       // and confirmed it — one finger on one key deleting a chat through a
@@ -43,8 +50,8 @@ Item {
       // would disarm anyway — doing it here as well means the keypress that
       // disarms never also selects or closes, so nothing happens by accident
       // while a destructive question is on screen.
-      if (event.key === Qt.Key_Delete && root.list.currentIndex >= 0)
-        root.deleteRequested(String(root.history[root.list.currentIndex].id))
+      if (event.key === Qt.Key_Delete)
+        root.deleteRequested(root.confirmingDeleteId)
       else root.confirmationCancelled()
       event.accepted = true
     } else if (event.key === Qt.Key_Down || event.key === Qt.Key_J) {

--- a/components/internal/HistoryListKeyboardHandler.qml
+++ b/components/internal/HistoryListKeyboardHandler.qml
@@ -66,6 +66,13 @@ Item {
         root.chatSelected(root.history[root.list.currentIndex])
       event.accepted = true
     } else if (event.key === Qt.Key_Delete && root.list.currentIndex >= 0) {
+      // The arrows move the cursor without moving the view, so the current
+      // row can sit below the fold. Arming it there would put the urgent
+      // button nowhere on screen, and the second press would delete a chat
+      // whose question was never seen. Bring the row in before asking. This
+      // moves the viewport, which withdraws any earlier question, and only
+      // then is the new one asked.
+      root.list.positionViewAtIndex(root.list.currentIndex, ListView.Contain)
       root.deleteRequested(String(root.history[root.list.currentIndex].id))
       event.accepted = true
     } else if (event.key === Qt.Key_Escape) {

--- a/components/internal/HistoryListKeyboardHandler.qml
+++ b/components/internal/HistoryListKeyboardHandler.qml
@@ -6,6 +6,10 @@ Item {
   required property var list
   property var history: []
   property bool confirmingClear: false
+  // A per-chat delete is armed on the current row. Unlike the clear-all
+  // confirmation, which is answered on its own control, this one is answered
+  // here: a second Delete confirms, and anything else backs out.
+  property bool confirmingDelete: false
 
   signal chatSelected(var chat)
   signal deleteRequested(string chatId)
@@ -22,6 +26,16 @@ Item {
       || event.key === Qt.Key_Delete || event.key === Qt.Key_Escape
     if (root.confirmingClear && action) {
       if (event.key === Qt.Key_Escape) root.confirmationCancelled()
+      event.accepted = true
+    } else if (root.confirmingDelete && action) {
+      // One keystroke, one effect: Delete answers the question, everything
+      // else withdraws it and stops there. Moving off the row with the arrows
+      // would disarm anyway — doing it here as well means the keypress that
+      // disarms never also selects or closes, so nothing happens by accident
+      // while a destructive question is on screen.
+      if (event.key === Qt.Key_Delete && root.list.currentIndex >= 0)
+        root.deleteRequested(String(root.history[root.list.currentIndex].id))
+      else root.confirmationCancelled()
       event.accepted = true
     } else if (event.key === Qt.Key_Down || event.key === Qt.Key_J) {
       root.list.currentIndex = Math.min(

--- a/tests/check-ui-contract.sh
+++ b/tests/check-ui-contract.sh
@@ -336,6 +336,16 @@ grep -Fq 'text: "Browser context"' "$repo_dir/components/SettingsView.qml"
 grep -Fq 'onDesktopContextRequested:' "$repo_dir/Panel.qml"
 grep -Fq 'text: "History"' "$repo_dir/components/HistoryView.qml"
 grep -Fq 'ActivityFilament {' "$repo_dir/components/HistoryView.qml"
+# Deleting one chat is irreversible and asks first, the same two steps
+# "Clear all" takes. Armed, it borrows the urgent role and draws a border,
+# because colour alone is not a signal for everyone, and the tooltip tells you
+# the way out rather than restating what the colour said.
+grep -Fq 'root.confirmingDeleteId = ""' "$repo_dir/components/HistoryView.qml"
+grep -Fq 'bordered: confirming' "$repo_dir/components/HistoryView.qml"
+grep -Fq 'confirming ? "Click again to delete" : "Delete chat"' \
+  "$repo_dir/components/HistoryView.qml"
+grep -Fq 'property bool confirmingDelete: false' \
+  "$repo_dir/components/internal/HistoryListKeyboardHandler.qml"
 grep -Fq 'text: root.browserCompanion.relayInstalled === true ? "Repair browser setup" : "Enable browser context"' \
   "$repo_dir/components/SettingsView.qml"
 grep -Fq 'onBrowserCompanionInstallRequested:' "$repo_dir/Panel.qml"

--- a/tests/check-ui-contract.sh
+++ b/tests/check-ui-contract.sh
@@ -344,8 +344,17 @@ grep -Fq 'root.confirmingDeleteId = ""' "$repo_dir/components/HistoryView.qml"
 grep -Fq 'bordered: confirming' "$repo_dir/components/HistoryView.qml"
 grep -Fq 'confirming ? "Click again to delete" : "Delete chat"' \
   "$repo_dir/components/HistoryView.qml"
-grep -Fq 'property bool confirmingDelete: false' \
+# The keyboard confirms the chat that was armed, by id, never the row under
+# the cursor: the list can change between the two presses.
+grep -Fq 'property string confirmingDeleteId: ""' \
   "$repo_dir/components/internal/HistoryListKeyboardHandler.qml"
+grep -Fq 'root.deleteRequested(root.confirmingDeleteId)' \
+  "$repo_dir/components/internal/HistoryListKeyboardHandler.qml"
+grep -Fq 'confirmingDeleteId: root.confirmingDeleteId' "$repo_dir/components/HistoryView.qml"
+# An open question is withdrawn when the list it was asked about changes, and
+# when the viewport moves and may carry the armed row out of sight.
+grep -Fq 'onHistoryChanged: {' "$repo_dir/components/HistoryView.qml"
+grep -Fq 'onContentYChanged: root.confirmingDeleteId = ""' "$repo_dir/components/HistoryView.qml"
 # This view is hidden, never destroyed, so an armed confirmation would sit here
 # across a trip to the chat and back and answer itself on the next single click.
 grep -Fq 'onVisibleChanged: if (!visible) {' "$repo_dir/components/HistoryView.qml"

--- a/tests/check-ui-contract.sh
+++ b/tests/check-ui-contract.sh
@@ -353,11 +353,21 @@ grep -Fq 'root.deleteRequested(root.confirmingDeleteId)' \
 grep -Fq 'confirmingDeleteId: root.confirmingDeleteId' "$repo_dir/components/HistoryView.qml"
 # An open question is withdrawn when the list it was asked about changes, and
 # when the viewport moves and may carry the armed row out of sight.
-grep -Fq 'onHistoryChanged: {' "$repo_dir/components/HistoryView.qml"
+grep -Fq 'onHistoryChanged: root.withdrawConfirmations()' "$repo_dir/components/HistoryView.qml"
 grep -Fq 'onContentYChanged: root.confirmingDeleteId = ""' "$repo_dir/components/HistoryView.qml"
+# One gesture cannot ask and answer: a double-click's second half lands inside
+# the platform interval and is ignored, and a held activation key's repeats
+# are swallowed before the focused control can see them. Arming from the
+# keyboard brings the row into view first, and closing the panel withdraws.
+grep -Fq 'if (!root.settled()) return' "$repo_dir/components/HistoryView.qml"
+grep -Fq 'Application.styleHints.mouseDoubleClickInterval' "$repo_dir/components/HistoryView.qml"
+grep -Fq 'Keys.forwardTo: [repeatGuard]' "$repo_dir/components/HistoryView.qml"
+grep -Fq 'root.list.positionViewAtIndex(root.list.currentIndex, ListView.Contain)' \
+  "$repo_dir/components/internal/HistoryListKeyboardHandler.qml"
+grep -Fq 'historyView.withdrawConfirmations()' "$repo_dir/Panel.qml"
 # This view is hidden, never destroyed, so an armed confirmation would sit here
 # across a trip to the chat and back and answer itself on the next single click.
-grep -Fq 'onVisibleChanged: if (!visible) {' "$repo_dir/components/HistoryView.qml"
+grep -Fq 'onVisibleChanged: if (!visible) root.withdrawConfirmations()' "$repo_dir/components/HistoryView.qml"
 # Two presses means two presses: a held Delete must not confirm through its own
 # auto-repeat.
 grep -Fq 'if (event.isAutoRepeat) {' \

--- a/tests/check-ui-contract.sh
+++ b/tests/check-ui-contract.sh
@@ -346,6 +346,18 @@ grep -Fq 'confirming ? "Click again to delete" : "Delete chat"' \
   "$repo_dir/components/HistoryView.qml"
 grep -Fq 'property bool confirmingDelete: false' \
   "$repo_dir/components/internal/HistoryListKeyboardHandler.qml"
+# This view is hidden, never destroyed, so an armed confirmation would sit here
+# across a trip to the chat and back and answer itself on the next single click.
+grep -Fq 'onVisibleChanged: if (!visible) {' "$repo_dir/components/HistoryView.qml"
+# Two presses means two presses: a held Delete must not confirm through its own
+# auto-repeat.
+grep -Fq 'if (event.isAutoRepeat) {' \
+  "$repo_dir/components/internal/HistoryListKeyboardHandler.qml"
+# The kind pill sits over a thumbnail that clips, and the combined modes are
+# long enough to reach the edge. Bounded and elided, never cut by the clip.
+grep -Fq 'parent.width - Style.spacing.xxs * 2)' \
+  "$repo_dir/components/ContextAttachmentPreview.qml"
+grep -Fq 'elide: Text.ElideRight' "$repo_dir/components/ContextAttachmentPreview.qml"
 grep -Fq 'text: root.browserCompanion.relayInstalled === true ? "Repair browser setup" : "Enable browser context"' \
   "$repo_dir/components/SettingsView.qml"
 grep -Fq 'onBrowserCompanionInstallRequested:' "$repo_dir/Panel.qml"

--- a/tests/tst_history_keyboard.qml
+++ b/tests/tst_history_keyboard.qml
@@ -8,7 +8,7 @@ Item {
   height: 420
 
   property bool confirmingClear: false
-  property bool confirmingDelete: false
+  property string confirmingDeleteId: ""
   property var historyItems: [
     { id: "chat-1", title: "First" },
     { id: "chat-2", title: "Second" },
@@ -35,7 +35,7 @@ Item {
       list: historyList
       history: root.historyItems
       confirmingClear: root.confirmingClear
-      confirmingDelete: root.confirmingDelete
+      confirmingDeleteId: root.confirmingDeleteId
       onChatSelected: function(chat) {
         root.selectedCount += 1
         root.selectedChatId = String(chat.id || "")
@@ -57,8 +57,13 @@ Item {
     when: windowShown
 
     function init() {
+      root.historyItems = [
+        { id: "chat-1", title: "First" },
+        { id: "chat-2", title: "Second" },
+        { id: "chat-3", title: "Third" }
+      ]
       root.confirmingClear = false
-      root.confirmingDelete = false
+      root.confirmingDeleteId = ""
       root.selectedCount = 0
       root.selectedChatId = ""
       root.deletedCount = 0
@@ -158,15 +163,35 @@ Item {
     // Deleting one chat is irreversible — the record, its images and its Pi
     // session all go — so Delete arms first and deletes second, the same two
     // steps "Clear all" has always taken. The view owns the arming; what the
-    // handler owes is that a second Delete gets through, and that no other key
-    // does anything except withdraw the question.
-    //
-    // Said plainly: only the second of these two discriminates. Deleting the
-    // armed row passes with the armed branch removed as well, because Delete
-    // then falls through to the idle path and emits the same signal. It is a
-    // regression guard, not evidence.
+    // handler owes is that a second Delete gets through, that it confirms the
+    // chat that was armed, and that no other key does anything except
+    // withdraw the question.
     function test_armedDeleteConfirmsOnSecondDelete() {
-      root.confirmingDelete = true
+      root.confirmingDeleteId = "chat-1"
+      keyClick(Qt.Key_Delete)
+      compare(root.deletedCount, 1)
+      compare(root.deletedChatId, "chat-1")
+      compare(root.cancelledCount, 0)
+    }
+
+    // What is confirmed is what was armed, not whatever sits under the cursor
+    // by the time the second press lands. The list can change between the two
+    // presses — a completed answer is prepended while history is open — and
+    // the same index is then a different chat. Read back through the index,
+    // the second press named a chat nobody had armed.
+    //
+    // The view disarms on that change as well; this pins the handler's half,
+    // which is that the id it emits is the id it was given.
+    function test_armedDeleteConfirmsTheArmedChatNotTheCurrentRow() {
+      root.confirmingDeleteId = "chat-1"
+      root.historyItems = [
+        { id: "chat-0", title: "Prepended" },
+        { id: "chat-1", title: "First" },
+        { id: "chat-2", title: "Second" },
+        { id: "chat-3", title: "Third" }
+      ]
+      wait(0)
+      compare(historyList.currentIndex, 0)
       keyClick(Qt.Key_Delete)
       compare(root.deletedCount, 1)
       compare(root.deletedChatId, "chat-1")
@@ -179,7 +204,7 @@ Item {
         Qt.Key_Return, Qt.Key_Enter
       ]
       for (var i = 0; i < withdrawing.length; i++) {
-        root.confirmingDelete = true
+        root.confirmingDeleteId = "chat-2"
         historyList.currentIndex = 1
         var event = { key: withdrawing[i], modifiers: Qt.NoModifier, accepted: false }
         historyKeyboard.handleKey(event)
@@ -199,7 +224,7 @@ Item {
     // confirm — one finger on one key deleting a chat through a confirmation
     // built to stop that.
     function test_armedDeleteIgnoresAutoRepeat() {
-      root.confirmingDelete = true
+      root.confirmingDeleteId = "chat-1"
       var event = {
         key: Qt.Key_Delete, modifiers: Qt.NoModifier,
         isAutoRepeat: true, accepted: false
@@ -215,7 +240,7 @@ Item {
     // A modified Delete is inert armed as well as idle, so a stray
     // Ctrl+Delete cannot answer a question the user has not read.
     function test_armedDeleteIgnoresModifiedKeys() {
-      root.confirmingDelete = true
+      root.confirmingDeleteId = "chat-1"
       var event = { key: Qt.Key_Delete, modifiers: Qt.ControlModifier, accepted: false }
       historyKeyboard.handleKey(event)
       verify(!event.accepted)

--- a/tests/tst_history_keyboard.qml
+++ b/tests/tst_history_keyboard.qml
@@ -194,6 +194,24 @@ Item {
       }
     }
 
+    // Two presses means two presses. Held past the repeat delay, the first
+    // physical press arms and the first auto-repeat used to arrive armed and
+    // confirm — one finger on one key deleting a chat through a confirmation
+    // built to stop that.
+    function test_armedDeleteIgnoresAutoRepeat() {
+      root.confirmingDelete = true
+      var event = {
+        key: Qt.Key_Delete, modifiers: Qt.NoModifier,
+        isAutoRepeat: true, accepted: false
+      }
+      historyKeyboard.handleKey(event)
+      verify(event.accepted)
+      compare(root.deletedCount, 0)
+      // And it does not withdraw either: a held key must leave the question
+      // exactly as it found it, so releasing and pressing again still answers.
+      compare(root.cancelledCount, 0)
+    }
+
     // A modified Delete is inert armed as well as idle, so a stray
     // Ctrl+Delete cannot answer a question the user has not read.
     function test_armedDeleteIgnoresModifiedKeys() {

--- a/tests/tst_history_keyboard.qml
+++ b/tests/tst_history_keyboard.qml
@@ -237,6 +237,29 @@ Item {
       compare(root.cancelledCount, 0)
     }
 
+    // The arrows move the cursor without moving the view, so the current row
+    // can sit below the fold. Arming it there would put the urgent button
+    // nowhere on screen and the second press would delete a chat whose
+    // question was never seen. Arming brings the row into the viewport first.
+    function test_deleteBringsAnOffscreenCurrentRowIntoView() {
+      var many = []
+      for (var i = 1; i <= 30; i++) many.push({ id: "chat-" + i, title: "Chat " + i })
+      root.historyItems = many
+      root.height = 100
+      wait(0)
+      compare(historyList.contentY, 0)
+      historyList.currentIndex = 20
+      verify(historyList.currentItem.y >= historyList.contentY + historyList.height)
+      keyClick(Qt.Key_Delete)
+      compare(root.deletedCount, 1)
+      compare(root.deletedChatId, "chat-21")
+      verify(historyList.contentY > 0)
+      verify(historyList.currentItem.y >= historyList.contentY)
+      verify(historyList.currentItem.y + historyList.currentItem.height
+        <= historyList.contentY + historyList.height)
+      root.height = 420
+    }
+
     // A modified Delete is inert armed as well as idle, so a stray
     // Ctrl+Delete cannot answer a question the user has not read.
     function test_armedDeleteIgnoresModifiedKeys() {

--- a/tests/tst_history_keyboard.qml
+++ b/tests/tst_history_keyboard.qml
@@ -8,6 +8,7 @@ Item {
   height: 420
 
   property bool confirmingClear: false
+  property bool confirmingDelete: false
   property var historyItems: [
     { id: "chat-1", title: "First" },
     { id: "chat-2", title: "Second" },
@@ -34,6 +35,7 @@ Item {
       list: historyList
       history: root.historyItems
       confirmingClear: root.confirmingClear
+      confirmingDelete: root.confirmingDelete
       onChatSelected: function(chat) {
         root.selectedCount += 1
         root.selectedChatId = String(chat.id || "")
@@ -56,6 +58,7 @@ Item {
 
     function init() {
       root.confirmingClear = false
+      root.confirmingDelete = false
       root.selectedCount = 0
       root.selectedChatId = ""
       root.deletedCount = 0
@@ -150,6 +153,56 @@ Item {
 
       keyClick(Qt.Key_Escape)
       compare(root.closeCount, 1)
+    }
+
+    // Deleting one chat is irreversible — the record, its images and its Pi
+    // session all go — so Delete arms first and deletes second, the same two
+    // steps "Clear all" has always taken. The view owns the arming; what the
+    // handler owes is that a second Delete gets through, and that no other key
+    // does anything except withdraw the question.
+    //
+    // Said plainly: only the second of these two discriminates. Deleting the
+    // armed row passes with the armed branch removed as well, because Delete
+    // then falls through to the idle path and emits the same signal. It is a
+    // regression guard, not evidence.
+    function test_armedDeleteConfirmsOnSecondDelete() {
+      root.confirmingDelete = true
+      keyClick(Qt.Key_Delete)
+      compare(root.deletedCount, 1)
+      compare(root.deletedChatId, "chat-1")
+      compare(root.cancelledCount, 0)
+    }
+
+    function test_armedDeleteWithdrawsOnAnythingElse() {
+      var withdrawing = [
+        Qt.Key_Escape, Qt.Key_Down, Qt.Key_Up, Qt.Key_J, Qt.Key_K,
+        Qt.Key_Return, Qt.Key_Enter
+      ]
+      for (var i = 0; i < withdrawing.length; i++) {
+        root.confirmingDelete = true
+        historyList.currentIndex = 1
+        var event = { key: withdrawing[i], modifiers: Qt.NoModifier, accepted: false }
+        historyKeyboard.handleKey(event)
+        verify(event.accepted)
+        compare(root.cancelledCount, i + 1)
+        // The keypress that withdraws does nothing else: it does not move the
+        // cursor off the row, open the chat, or close the view.
+        compare(historyList.currentIndex, 1)
+        compare(root.deletedCount, 0)
+        compare(root.selectedCount, 0)
+        compare(root.closeCount, 0)
+      }
+    }
+
+    // A modified Delete is inert armed as well as idle, so a stray
+    // Ctrl+Delete cannot answer a question the user has not read.
+    function test_armedDeleteIgnoresModifiedKeys() {
+      root.confirmingDelete = true
+      var event = { key: Qt.Key_Delete, modifiers: Qt.ControlModifier, accepted: false }
+      historyKeyboard.handleKey(event)
+      verify(!event.accepted)
+      compare(root.deletedCount, 0)
+      compare(root.cancelledCount, 0)
     }
   }
 }


### PR DESCRIPTION
`Clear all` confirms in two steps. Deleting a single chat did not, and it is
the one that cannot be undone: the delete unlinks the record, its cached
images, and its Pi session when no other chat still refers to it. The button
arms on hover, on a row that becomes current on hover, so it sits directly
under a moving pointer.

It now takes the same two steps rather than a dialog, so both destructive
actions in this view are answered the same way and neither takes focus off the
list. Armed, the button turns urgent and draws a border — colour alone is not a
signal for everyone — and the tooltip changes from "Delete chat" to "Click
again to delete". That wording is deliberate: the colour already says the state
changed, so the words are better spent on the way out. The arm belongs to its
row and to the list it was armed on: leaving the row disarms it, by arrow key or
by hovering another; so does scrolling the row out of the viewport, leaving the
history view, and the history list changing underneath — a completed answer
prepending itself while history is open withdraws whatever was armed. Arming a
delete cancels a pending `Clear all` and the other way round.

The keyboard path goes through the same gate: <kbd>Delete</kbd> arms and
<kbd>Delete</kbd> deletes — the chat that was armed, by id, never whatever row
sits at `currentIndex` by the time the second press lands. While armed, every
other action key withdraws the question and does nothing else — no moving off
the row, no opening the chat, no closing the view. A modified
<kbd>Delete</kbd> stays inert, and so does a held one: auto-repeat cannot
answer the question.

Four smaller things in the same pass:

- The composer placeholder sat under the contrast floor. `Qt.darker(foreground,
  1.7)` measures 4.12:1 against the popup background on the shipped theme,
  where 16px text needs 4.5:1. `1.6` clears it at 4.57:1 and still reads plainly
  as a placeholder.
- The uppercase context badge had padding on one side only. `sm` and `xxs` were
  the whole horizontal and vertical allowance, so roughly 2px a side stood in
  for padding on a shape whose radius is half its height. It also gains the
  `letterSpacing: 0.7` the setup guide's progress label already uses.
- The thinking phrase crossfaded with its easing reversed: `OutQuad` leaving and
  `InQuad` returning, so it lingered on the way out and held at almost-invisible
  on the way back — slowest exactly where there was nothing to read.
- `StateLightBar`'s opacity transition ignored `motionEnabled`, the last one in
  the plugin that did. No user-visible change today — `motionEnabled` is not a
  setting, it is a property the components accept and the probes drive.
  `state-light-bar-lifecycle-probe.qml` drives it to false, and this makes the
  component answer honestly when it does.

## Testing

- `./scripts/check-manifest.sh`, `./tests/test-hotkey-installer.sh`,
  `./scripts/validate.sh`
- `tst_panel_keyboard_navigation` (11 passed), `tst_history_keyboard` (11
  passed, five new)
- Exercised the delete by hand on a live Quattro session: arm and disarm by
  pointer, arm and withdraw by <kbd>Escape</kbd> and by arrow key, mutual
  exclusion with `Clear all`, and a real delete confirmed on the second press
- The badge and the armed delete rendered through `render-preview.sh`

Each of the new keyboard tests fails without the line it pins: the withdrawal
of every other key, the auto-repeat guard, and the second <kbd>Delete</kbd>
naming the armed chat rather than the current row — that last one replaces the
model under an armed row and fails with `chat-0` where `chat-1` was armed if
the handler reads back through the index.

Two things were measured rather than assumed before relying on them. With no
highlight item, this ListView never scrolls on its own when the current row
changes, so the scroll guard can only fire under a wheel, a drag or a resize
and can never undo an arm that was just made. And the delete's own button
size is fixed, so arming never reflows the row.

