### PR TITLE
Fix panel close freeze on read-only centerHoverRevealSuppressed

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -147,8 +147,8 @@ Panel {
   }
 
   function setCenterHoverRevealSuppressed(value) {
-    if (root.bar && "centerHoverRevealSuppressed" in root.bar)
-      root.bar.centerHoverRevealSuppressed = value
+    if (root.bar && typeof root.bar.setCenterHoverRevealSuppressed === "function")
+      root.bar.setCenterHoverRevealSuppressed(value)
   }
 
   function selectProvider(provider) {

--- a/tests/check-ui-contract.sh
+++ b/tests/check-ui-contract.sh
@@ -353,6 +353,11 @@ awk '
   inside && /root\.controller\.hide\(\)/ { if (!cleared) exit 1; found = 1; exit }
   END { if (!found) exit 1 }
 ' "$repo_dir/Panel.qml"
+grep -Fq 'typeof root.bar.setCenterHoverRevealSuppressed === "function"' "$repo_dir/Panel.qml"
+if grep -Fq 'root.bar.centerHoverRevealSuppressed =' "$repo_dir/Panel.qml"; then
+  printf 'Do not assign PluginBarApi.centerHoverRevealSuppressed; it is read-only\n' >&2
+  exit 1
+fi
 grep -Fq 'backend.submit(draftText)' \
   "$repo_dir/components/Composer.qml"
 grep -Fq 'var autoApprove = configuredDangerousAutoApprove' \


### PR DESCRIPTION
## Problem

On Omarchy Quattro, third-party bar widgets do not receive the host `Bar` object. They receive `PluginBarApi`, where `centerHoverRevealSuppressed` is **read-only** and the write path is `setCenterHoverRevealSuppressed()`.

OmaPilot still did:

```qml
if (root.bar && "centerHoverRevealSuppressed" in root.bar)
  root.bar.centerHoverRevealSuppressed = value
```

`"x" in bar` is true on the facade, so the assign runs and throws:

```
TypeError: Cannot assign to read-only property "centerHoverRevealSuppressed"
```

That TypeError is a QML engine error, not a JS exception, so `try/catch` does not catch it. `close()` aborted **before** `controller.hide()`.

OmaPilot’s panel is an Omarchy `KeyboardPanel`: fullscreen layer-shell with an exclusive keyboard prime. Click-outside and Escape both call `owner.close()`, which is this same `close()`. After the throw, the overlay stays mapped, grabs input, and the session looks frozen.

Reproduced on Omarchy 4 / Hyprland: open the panel, then close via IPC, click-outside, or Escape. Journal shows the TypeError at `Panel.qml` on every close; `hyprctl -j layers` keeps `omarchy-keyboard-panel` and `omarchy-keyboard-panel-dismiss`.

## Fix

Call the setter, matching first-party Omarchy panels (`omarchy.clock`, `omarchy.weather`):

```qml
function setCenterHoverRevealSuppressed(value) {
  if (root.bar && typeof root.bar.setCenterHoverRevealSuppressed === "function")
    root.bar.setCenterHoverRevealSuppressed(value)
}
```

No property assign. First-party panels still have an `"in"` + assign fallback because the real `Bar` property is writable; that fallback is what blows up on `PluginBarApi`.

## Test

`tests/check-ui-contract.sh` now requires the setter call and fails if `Panel.qml` assigns `root.bar.centerHoverRevealSuppressed`.

`bash tests/check-ui-contract.sh` passed locally (qmltestrunner suites green).

On a live Omarchy session after this change: open → `omarchy-keyboard-panel` maps → close → layers gone.